### PR TITLE
Ratify the init spec: scaffold structure, single Fumadocs shell, MIT-0 templates

### DIFF
--- a/.changeset/tarball-test-timeout.md
+++ b/.changeset/tarball-test-timeout.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test-only change (tarball test timeout for cold CI runners) — nothing reaches the published artifact; empty changeset satisfies the gate without a changelog entry.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,12 +161,36 @@ reverse it, and a reversed decision keeps its entry with a revision note.
    appear when the ladder or the work demands them); **the site is preview and
    review, not an editor** (the agent writes; the human checks).
 
+8. **Scaffold structure: root workspace + system roof** (owner, 2026-08-18).
+   `ksor init` emits the workspace manifests at the repo root (defaults beat
+   hiding them behind new algorithms), `knowledge/` at root as the record —
+   CommonMark only, framework-free forever — and ALL code under `system/`
+   (site now; gateways/packages as earned; growth inside, never beside). The
+   root set is closed at birth; full lock record and the closed set:
+   `research/scaffold-structure.md` + `specs/ksor/init/spec.md`. Reversed
+   per-clause with evidence, recorded there.
+9. **Site shell: one in core — Next.js + Fumadocs + shadcn** (owner,
+   2026-08-18), replacing Docusaurus natively before v1 traffic. No shell
+   selector at init (one obvious way; a flag forks every skill, test, and
+   recipe). Choice lives in three existing layers: the pinned **surface
+   contract** (render the record, llms.txt, per-page md artifacts, browser
+   smoke, no authored content — the shell is a slot), adopter ownership of
+   `system/site`, and future registry-distributed alternative shells.
+   _Revision note: supersedes the site-shell open question and the
+   primitives proposal §4 stay-Docusaurus lean (proposed, never ratified) —
+   the extensibility ceiling (auth, features), agent-ecosystem alignment,
+   and the verified portability of the predecessor's remark layer decided
+   it._ Reversed if Fumadocs's static export or llms surface regresses
+   before the site slice ships.
+10. **Scaffold templates are MIT-0** (owner, 2026-08-18): init's output
+    lands in the adopter's proprietary repo free of attribution
+    obligations, and init never emits a LICENSE file into a repo whose
+    knowledge is theirs. The grant sentence lives in the scaffolded README.
+
 **Open questions — decide independently when the work arrives:** how retrieval
 and abstention are implemented for `serve` — reimplement in TS or convert the
 predecessor kernel's logic (decision 6 permits either; revision note: this was
-recorded as settled "stays Python" on 2026-08-17, reversed 2026-08-18) — and
-the site shell (Docusaurus vs Fumadocs — evidence in
-`research/primitives-proposal.md` §4, decide before the site slice). PyPI
+recorded as settled "stays Python" on 2026-08-17, reversed 2026-08-18). PyPI
 `ksor` is left unclaimed on purpose (a PyPI pending publisher reserves nothing
 — only an upload claims a name); revisit only if the exposure changes.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -34,7 +34,8 @@ reservation notice and exits `2`. It has no exports and bundles no docs.
 
 ## Designed, not implemented
 
-- `ksor init` / `dev` / `build` / `serve` — the verbs themselves.
+- `ksor init` / `dev` / `build` / `serve` — the verbs themselves
+  (`specs/ksor/init/spec.md` is ratified; implementation is next).
 - The MCP agent surface and the human site surface.
 - Build provenance records (`build.lock.json`) — designed with `ksor build`.
 - The agent-eval harness (contract in AGENTS.md → Testing).

--- a/packages/ksor/src/tarball.integration.test.ts
+++ b/packages/ksor/src/tarball.integration.test.ts
@@ -23,7 +23,8 @@ const REQUIRED_IN_TARBALL = [
 ];
 
 describe("published tarball", () => {
-  it("ships every contract file (run `pnpm build` first)", () => {
+  // npm startup on a cold CI runner can exceed vitest's 5s default.
+  it("ships every contract file (run `pnpm build` first)", { timeout: 30_000 }, () => {
     const result = spawnSync("npm", ["pack", "--dry-run", "--json"], {
       cwd: pkgDir,
       encoding: "utf8",

--- a/research/primitives-proposal.md
+++ b/research/primitives-proposal.md
@@ -105,6 +105,16 @@ JSON on any host; `shadcn build`'s inline-the-content model is exactly
 
 ## 4 · The shell
 
+> **Revision 2026-08-18 (supersession visible):** ratified the OTHER way —
+> AGENTS.md decision 9: Next.js + Fumadocs + shadcn as the single core shell,
+> behind a pinned surface contract, replacing Docusaurus before v1 traffic.
+> This section's stay-Docusaurus recommendation was optimizing cheapest
+> crossing; the owner's extensibility/ecosystem arguments plus one new fact —
+> all 10 predecessor lib packages verified framework-neutral (zero Docusaurus
+> imports), so the "free crossing" was mostly illusion — reversed it. The
+> section's own closing line named Fumadocs the rewrite target; kept below as
+> the evidence trail.
+
 **Moved.** The shell question outgrew a section: the evidence, the argument,
 the unanswered structural question, and the candidate decision texts now live
 in [`research/site-shell.md`](./site-shell.md) — one fact, one file.

--- a/research/primitives-proposal.md
+++ b/research/primitives-proposal.md
@@ -105,41 +105,16 @@ JSON on any host; `shadcn build`'s inline-the-content model is exactly
 
 ## 4 · The shell
 
-**Recommendation: stay on Docusaurus for the crossing; treat the agent
-surface as a tested output contract, not a framework feature; name the
-reversal condition now.** (Needs owner ratification into AGENTS.md → Decisions.)
+**Moved.** The shell question outgrew a section: the evidence, the argument,
+the unanswered structural question, and the candidate decision texts now live
+in [`research/site-shell.md`](./site-shell.md) — one fact, one file.
 
-Verified 2026-08-18 against primary sources:
-
-- Docusaurus (3.10.2) has **no official llms.txt/MCP surface and no accepted
-  roadmap item** — facebook/docusaurus#10899 is 18 months open, unassigned;
-  the v4 milestone is Rspack + MDX v3 only. The laggard clause is true.
-- But ksor's MCP server ships **in the CLI, not the site** — the only
-  site-side delta at stake is llms.txt + markdown-per-page, and mature
-  community plugins deliver both today (@signalwire ~120K downloads/month,
-  rachfop ~92K incl. per-page .md).
-- Fumadocs is the strongest agent-surface fit (first-party llms.txt,
-  per-page .md routes, Accept negotiation, TS-native, official static
-  export; vercel/eve's docs run it; measured growth ~79× over 24 months —
-  the handover's "105×" overstated a clean window, direction confirmed).
-  Starlight: 23× growth confirmed; maintainer-authored llms-txt plugin;
-  `.astro` component model discards the React shell entirely.
-- The 6,644-line forked shell **crosses for free**; moving to either
-  alternative is a rewrite, not a port — the fork's value goes to zero.
-
-So the honest trade is "free inherited shell + unofficial-plugin risk" vs
-"rewrite cost + first-party agent surface." The risk is made loud instead of
-avoided: per the four-defects rule, `ksor build`'s acceptance asserts the
-**shipped bytes** — `llms.txt` exists and lists every published page,
-per-page markdown exists — so a plugin stranded by the Docusaurus v4
-breaking cycle fails CI the day it breaks, never silently. The site surface
-sits behind ksor's own build contract, so a later shell swap changes an
-implementation, not the product promise.
-
-**Reversal condition:** revisit if the pinned llms.txt plugin breaks under
-the v4 cycle without a maintained replacement, or when the shell needs its
-first major rework anyway. If a rewrite is ever on the table, Fumadocs is
-the target (Starlight only if dropping React is acceptable).
+> **Revision note (2026-08-18):** this section recommended **Docusaurus**.
+> That recommendation is preserved in the new file and is now **challenged,
+> not withdrawn**: it did not weigh the fork's carrying cost, the fact that
+> the migration is paid either way and only gets dearer, or decision 4
+> (scaffolds are adopter-owned). Still undecided; it turns on a question only
+> the owner can answer.
 
 ## 5 · The boundary, and its enforcement
 

--- a/research/scaffold-structure.md
+++ b/research/scaffold-structure.md
@@ -44,6 +44,20 @@ browser smoke, contain no authored content — the shell is a slot);
 The predecessor's Docusaurus shell is reference material for porting
 components and tokens, not a shipped option.
 
+_Evidence appended 2026-08-18 — the side-by-side experiment:_ both shells
+were stood up locally over the same three-document corpus. Docusaurus (vsor
+shell): ~10 min, zero source edits — its `VSOR_KNOWLEDGE_DIR` seam is
+genuinely well-engineered. Fumadocs (official starter): ~18 min, four small
+edits — friction was obtaining a coherent starter (its create-CLI cannot run
+non-interactively and git tags lag npm; both moot for ksor, whose template
+ships pre-built and version-pinned) — after which governance frontmatter
+rendered untouched and `llms.txt` listed every page for zero work. The owner
+compared both UIs directly and judged Fumadocs better and more powerful; the
+enterprise lens (SSO/middleware capability for private corpora, first-party
+agent surface, extensibility as a normal Next app, platform velocity)
+concurred. Decision 9 stands validated by research, by eyes, and by
+measurement.
+
 ## Resolutions locked by the hunt (the ones that were live grenades)
 
 - **No symlinks anywhere in scaffold output** — Windows git materializes

--- a/research/scaffold-structure.md
+++ b/research/scaffold-structure.md
@@ -1,0 +1,107 @@
+---
+issue: recorded via the init-spec PR
+status: accepted
+last_updated: 2026-08-18
+---
+
+# The scaffold structure — locked
+
+The design record behind `specs/ksor/init/spec.md`: what `ksor init` emits,
+why, and the unknown-unknowns hunt (5 adversarial agents, 55 findings, 34
+concerns verified fine) that priced the alternatives before the owner locked
+the choice. Where this document and the spec disagree, the spec wins.
+
+## The three candidates, and the choice
+
+1. **Root workspace + system roof** — **chosen.** `package.json`,
+   `pnpm-workspace.yaml`, and the lockfile live at the repo root (the owner's
+   call: manifests at root beat a permanent algorithm for hiding them);
+   `knowledge/` stays at root as the record; ALL code lives under `system/`
+   (site now; gateways/packages as earned — growth happens inside, never
+   beside). Re-enters every toolchain default and agents' training data:
+   `npx ksor`, `pnpm dev`, deploy auto-detection, and bundler root inference
+   all just work.
+2. **Nested workspace** (workspace root inside `system/`) — rejected: a pure
+   document-tree root, priced at six permanent tooling compensations
+   (bundler-root pinning, CLI root-discovery, deploy overrides, agent
+   retraining) for purity at a level where the promise doesn't live — the
+   real purity boundary is `knowledge/`, identical in both layouts.
+3. **Conventional docs-site layout** — rejected: maximal defaults, but the
+   repo reads as a website that contains knowledge instead of a record served
+   by a system, and growth pollutes the root.
+
+## The shell: one in core, choice via contract
+
+Fumadocs (Next.js + shadcn primitives) is the **single reference shell**,
+replacing Docusaurus natively before v1 traffic. No shell selector at init —
+"one obvious way": a flag would fork every skill, directive renderer, test,
+and deploy recipe, and agents sample flags randomly. Choice arrives through
+three layers that already exist: the **surface contract** (any site must
+render `knowledge/`, emit `llms.txt` + per-page `.md` artifacts, pass the
+browser smoke, contain no authored content — the shell is a slot);
+**ownership** (adopters own `system/site` and may swap it); and the
+**registry** (alternative shells distribute as copy-into-repo items later).
+The predecessor's Docusaurus shell is reference material for porting
+components and tokens, not a shipped option.
+
+## Resolutions locked by the hunt (the ones that were live grenades)
+
+- **No symlinks anywhere in scaffold output** — Windows git materializes
+  them as junk text. `CLAUDE.md` is a one-line `@AGENTS.md` file;
+  `.claude/skills/` holds real copies, byte-identity machine-checked;
+  `.gemini/settings.json` points Gemini CLI at AGENTS.md.
+- **`.gitattributes` with `*.md text eol=lf`** (instance.md included) —
+  `autocrlf` would make identical commits hash differently on Windows,
+  poisoning future provenance. Build also normalizes CRLF→LF before hashing.
+- **`knowledge/` is CommonMark `.md` — never `.mdx`.** Components render via
+  directives (`:::quiz`) that degrade to readable text; MDX and `meta.json`
+  are banned from the record (framework grammar breaks the walk-away
+  promise). Sidebar order is a governed frontmatter key the site translates.
+- **Closed frontmatter set** (fail-closed, like instance.md): title,
+  description, status, owner, provenance, effective, superseded,
+  superseded_by, order. Authored `id:`/`name:` remain banned.
+- **Identity rules enforced at the corpus**: Windows-safe filenames, no
+  case-insensitive collisions, no `foo.md` + `foo/index.md` route collisions,
+  no parenthesized directories. **MCP URI scheme locked now** — citations pin
+  it forever: `ksor://<instance-name>/<path>`.
+- **Assets live in `knowledge/` beside their documents**, relative links
+  only; links may never escape the record. `images.unoptimized` in the
+  emitted next.config (static export would otherwise hard-fail on the first
+  screenshot); `turbopack.root`/`outputFileTracingRoot` pinned to the repo
+  root (never inference — parent lockfiles mislead it).
+- **The template ships its lockfile as bytes** — resolving no-network +
+  determinism + the test-tier-installs-the-artifact-tree rule in one move.
+  Scaffolded manifests carry exact pins, a `packageManager` pin,
+  `minimumReleaseAge`, and an empty build-scripts allowlist.
+- **Governance records are governed markdown**: approvals/policies (and
+  later eval gold) are doc types inside `knowledge/`; the governance level is
+  a corpus query. The root never gains a `governance/` or `evals/` directory
+  — the root set is closed at birth, `build.lock.json` (committed, written
+  only by `ksor build`) named as its one later arrival.
+- **The site never contains authored content** — top scaffolded critical
+  rule plus a machine check; the likeliest corruption is an agent "adding a
+  page" inside `system/site`.
+- **Adopter CI is scaffolded** (`.github/workflows/validate.yml`, SHA-pinned)
+  — governed rules that nothing runs are discipline, not governance.
+- **Templates are MIT-0** (owner-ratified 2026-08-18): init's output lands in
+  the adopter's proprietary repo free of attribution obligations, and init
+  never emits a LICENSE file into a repo whose knowledge is theirs.
+- **Verbs re-scoped**: the site works via plain `pnpm dev` with zero ksor
+  runtime (ownership makes it self-sufficient); `ksor dev` survives only as
+  a passthrough; `ksor build` is governance-only (validation, provenance,
+  corpus artifact, the `.md`/llms build artifacts).
+- Init detects ancestor `instance.md` (`error: nested` — refuse) and warns
+  when a parent pnpm workspace glob would swallow the project; `ksor.
+scaffolded` in instance.md stamps the emitting version for the future
+  upgrade-diff story; provenance for binary sources = external location +
+  content hash (a self-contained `sources/` home is deferred, reason
+  recorded).
+
+## Deferred with reasons
+
+Netlify/Vercel deploy recipes (deploy skill later; root workspace restored
+the platform defaults), non-image asset copying (format check rejects until
+`ksor build` owns it), the 5k-doc scale claim (measure with a synthetic
+corpus in the site slice before claiming — never estimate), i18n,
+multi-corpus mounting (second corpus = second project; the URI scheme keeps
+composition clean).

--- a/research/site-shell.md
+++ b/research/site-shell.md
@@ -1,0 +1,187 @@
+---
+issue: AGENTS.md → Decisions, open question "the site shell" (set to the PR URL when this opens)
+status: proposed
+last_updated: 2026-08-18
+---
+
+# The site shell — Docusaurus or Fumadocs
+
+The one open toolchain question left before the site slice. AGENTS.md records
+it as undecided; this file is the evidence and the argument, and it is the
+only home for both. `research/primitives-proposal.md` §4 points here.
+
+> **Revision note (2026-08-18):** primitives-proposal.md §4 recommended
+> **Docusaurus**. That recommendation is preserved below and is now
+> **challenged, not withdrawn** — two arguments it did not weigh push the
+> other way, and one decision (4) was never applied to the question. Nothing
+> is settled until the deciding question at the end is answered by the owner.
+
+## What is actually being chosen
+
+Not "which docs framework." ksor's MCP surface ships in the **CLI**, not the
+site, and `ksor build` will assert the shipped bytes either way. So the site
+shell sits _behind_ ksor's own build contract: whichever wins, the product
+promise is owned by ksor and a later swap changes an implementation, not a
+guarantee.
+
+What is genuinely at stake is narrower and worth naming precisely:
+
+1. Who carries the shell — us or the adopter (see decision 4, below).
+2. Whether the site-side agent surface (`llms.txt`, per-page markdown) is
+   first-party or borrowed.
+3. When the migration cost gets paid, because it gets paid either way.
+
+## Verified evidence
+
+Everything below was checked against primary sources on 2026-08-18. Claims
+inherited from the predecessor's handover are marked as such and were not
+re-used without checking.
+
+### Docusaurus
+
+- **No official agent surface, and none scheduled.** facebook/docusaurus#10899
+  ("add `docusaurus-plugin-llms-txt`") was opened **2025-02-04** and is
+  **open, unassigned, no milestone, labelled feature request**, with no
+  maintainer commitment in either direction. Verified by fetching the issue.
+- The v4 milestone is Rspack + MDX v3 — a major build-layer transition that
+  does not include an agent surface.
+- Community plugins deliver `llms.txt` and per-page markdown today
+  (@signalwire ~120K downloads/month; rachfop ~92K including per-page `.md`).
+  Both are unofficial and unpinned to the v4 cycle.
+- Mature internationalisation — the strongest thing on this side of the
+  ledger that Fumadocs does not clearly match.
+- Meta-backed: the bus factor is real and favours Docusaurus.
+
+### Fumadocs
+
+Each of these is **first-party**, not a plugin. Verified against the Fumadocs
+documentation:
+
+- `llms(source).index()` from `fumadocs-core/source` — the `llms.txt` route.
+- A `.md` route handler with `generateStaticParams()` — per-page markdown,
+  **statically generated**, so it survives static export.
+- `isMarkdownPreferred` / `rewritePath` from `fumadocs-core/negotiation` —
+  Accept-header content negotiation.
+- Official static export via Next.js `output: 'export'`.
+- TypeScript-native React, which is the house stack (decision 1, decision 5).
+- Essentially one maintainer. This is the honest counterweight to everything
+  above and must not be buried.
+
+### The caveat neither framework's docs make obvious
+
+**Fumadocs' Accept-header negotiation runs in Next.js middleware, and
+middleware does not exist under `output: 'export'`.**
+
+So a fully static ksor site gets `llms.txt` and per-page `.md` — both
+statically generated, both fine — but **not** content negotiation. Serving
+`text/markdown` from the canonical URL requires a Node host at deploy time,
+not a static bucket.
+
+This interacts with decision 1, which makes Node a prerequisite for the
+adopter's **build**. Negotiation would make a runtime a prerequisite for the
+adopter's **serve**. That is a new constraint on adopters and must be chosen
+deliberately, not discovered during implementation. It applies whichever
+shell wins — Docusaurus offers no negotiation at all.
+
+## The argument as it stands
+
+### For Docusaurus (the §4 recommendation, preserved)
+
+The predecessor's 6,644-line forked shell **crosses for free** — and, since
+decision 6 (2026-08-18) granted conversion of the predecessor's work, it
+crosses licence-clear as well. Moving to either alternative is a rewrite, not
+a port; the fork's value goes to zero the moment we leave. The plugin risk is
+made loud rather than avoided: `ksor build`'s acceptance asserts that
+`llms.txt` exists and lists every published page and that per-page markdown
+exists, so a plugin stranded by the v4 cycle fails CI the day it breaks,
+never silently.
+
+### Against it — three arguments §4 did not weigh
+
+**1. "Free" is acquisition cost, not carrying cost.** A 6,644-line fork of a
+framework mid-major-transition is the expensive kind of free. AGENTS.md is
+explicit: never carry a mechanism across without asking what it was for.
+That question has not been asked of this fork.
+
+**2. The migration gets paid either way, and the price only rises.** The CI
+mitigation is good, but a loud failure during the v4 cycle still means
+migrating — the same rewrite, later, under time pressure, with adopters on
+it. Today the site is zero lines and the adopter count is zero. This decision
+will never be cheaper than it is now.
+
+**3. Decision 4 was never applied to this question.** Scaffolds are
+copy-into-repo; the adopter owns what `ksor init` emits. If any of the forked
+shell reaches an adopter's repository, we have handed a non-technical
+knowledge owner a Docusaurus fork to maintain — the opposite of "out of the
+box the owner touches knowledge only." **This is the unanswered structural
+question:** is the shell adopter-owned or framework-owned? If framework-owned,
+decision 4 is being reversed for the largest file set in the product, and
+that reversal must be recorded per-file with its reason.
+
+### And one point of substance for the agent surface
+
+ksor's differentiator is that agents find and read the corpus. The human
+surface can sit on anything. Putting the agent-facing half on two unofficial
+plugins, pinned against a framework whose official issue for that exact
+feature has been unassigned for eighteen months, builds the differentiator on
+someone else's neglected backlog.
+
+## The option not on the list
+
+**No framework — `ksor build` emits its own static site.** Recorded so nobody
+re-derives it: rejected. It means rebuilding search, i18n, theming, and MDX,
+none of which is the differentiator, to avoid a dependency that is swappable
+by design.
+
+## The deciding question — for the owner
+
+**Is multilingual content a near-term requirement, or a someday?**
+
+- **Near-term** (Urdu or any second language in the first adopter corpora):
+  Docusaurus's internationalisation maturity plausibly outweighs every
+  argument above, and the §4 recommendation stands as written.
+- **Someday:** Fumadocs, on the reasoning above.
+
+A second question falls out of the caveat and can be answered independently:
+**must the served site do Accept-header negotiation?** If yes, adopters need
+a Node runtime at serve time and only Fumadocs can do it. If no, static
+export is sufficient and both shells stay in play.
+
+## Candidate decision texts
+
+To be pasted into AGENTS.md → Decisions once the owner answers. One of these,
+not both.
+
+> **Decision 8 — Fumadocs is the site shell.** The agent-facing half of the
+> site (`llms.txt`, per-page markdown, Accept negotiation) is first-party
+> there, and on Docusaurus it is an unassigned eighteen-month-old feature
+> request served by unofficial plugins. The predecessor's forked shell is
+> acquisition-cheap and carrying-expensive, and the migration cost away from
+> Docusaurus only rises with adopters. Reversed if Fumadocs' maintenance
+> stalls without a fork-worthy community, or if multilingual i18n becomes a
+> near-term requirement it cannot meet.
+
+> **Decision 8 — Docusaurus is the site shell.** The predecessor's forked
+> shell crosses working and licence-clear under decision 6; the site-side
+> agent surface is delivered by pinned community plugins whose output is
+> asserted by `ksor build`'s shipped-bytes acceptance, so a break fails CI
+> rather than shipping silently; and its internationalisation is required
+> near-term. Reversed if the pinned `llms.txt` plugin breaks under the v4
+> cycle without a maintained replacement, or when the shell needs its first
+> major rework anyway — in which case Fumadocs is the target.
+
+## Acceptance, whichever wins
+
+Written now so the choice cannot quietly weaken the product guarantee. These
+are `ksor build` acceptance criteria, not framework features:
+
+- `llms.txt` exists in the build output and lists **every** published page —
+  asserted against the built bytes, not against config.
+- Every published page has a machine-readable markdown counterpart at a
+  stable, path-derived address (product principle 3: identity derives from
+  the file path).
+- The site build and the MCP surface read the **same** corpus build — one
+  source, two surfaces, never two truths.
+- A drift test fails if a page exists on one surface and not the other.
+- If negotiation is adopted: an integration test asserts that a request with
+  `Accept: text/markdown` returns markdown from the canonical URL.

--- a/specs/ksor/init/spec.md
+++ b/specs/ksor/init/spec.md
@@ -1,0 +1,93 @@
+---
+status: ratified
+date: 2026-08-18
+claim: the five-minute promise — one human command yields a governed corpus, its agent kit, and a working site; everything after init is the agent's job
+evidence: research/scaffold-structure.md · research/primitives-proposal.md §1 · research/handover-vsor-to-ksor.md
+---
+
+# ksor init
+
+The only verb a human types (decision 7). Ratified from the design
+conversation of 2026-08-18; the predecessor's init spec served as the
+clause-by-clause checklist — every clause crossed, was rewritten for the new
+shape, or was dropped with the reason recorded in
+`research/scaffold-structure.md`. Where this spec and the code disagree, the
+code wins and this page is corrected in the same commit.
+
+## Observable contract
+
+**Invocation.** `ksor init <name>` with `<name>` matching
+`^[a-z0-9][a-z0-9-]{0,62}$`; `ksor init .` scaffolds into an empty-enough
+current directory (the company-monorepo path); bare `ksor init` prints one
+instructional screen and exits `0` — an unattended agent must never scaffold
+into an unknown cwd by accident.
+
+**Refusals** exit `1`, first stderr line a stable slug: `error: bad-name`,
+`error: exists`, `error: blocked` (target dir has unrelated content),
+`error: nested` (an ancestor directory contains `instance.md`);
+`error: unsupported-platform` exits `3`. A parent pnpm workspace whose globs
+would swallow the project produces a warning, not a refusal.
+
+**Negative contract.** No network I/O. Never runs a package manager (the
+handoff text carries `pnpm install && pnpm dev`). Deterministic: the same
+ksor version and name produce byte-identical trees — enforced by shipping
+every emitted byte (the lockfile included) as template content in the ksor
+package. Atomic: staged in a sibling `.ksor-init-<random>/` then renamed
+(`init .`: ordered writes with rollback); a failed init leaves the
+filesystem as found; stale stage dirs are reported, never deleted. Runs
+`git init` unless already inside a repository; never stages or commits. No
+symlinks anywhere in the output.
+
+**The emitted tree** (the closed root set — frozen at birth; its one named
+later arrival is `build.lock.json`, committed, written only by `ksor build`):
+
+| Path                                                      | Contract                                                                                                                                                                                                           |
+| --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `package.json` · `pnpm-workspace.yaml` · `pnpm-lock.yaml` | workspace at root; scripts proxy so `pnpm dev` works at root; exact pins + `packageManager`; `ksor` as devDependency; `minimumReleaseAge`; empty build-scripts allowlist                                           |
+| `AGENTS.md`                                               | the project constitution: the two worlds, command conventions, record-purity rules; critical rule 1 = the site never contains authored content                                                                     |
+| `CLAUDE.md`                                               | one line, `@AGENTS.md` — a file, never a symlink; must never grow content                                                                                                                                          |
+| `README.md`                                               | one page: record vs system, and the grant sentence (templates are MIT-0 — decision 10; no LICENSE file is ever emitted)                                                                                            |
+| `instance.md`                                             | format 1 frontmatter: `format`, `name`, `ksor.requires`, `ksor.scaffolded` (the upgrade stamp); `site.url` reserved. Body = prose identity (the future MCP system prompt). Unknown top-level keys are named errors |
+| `knowledge/example.md`                                    | one real governed document — never an empty directory                                                                                                                                                              |
+| `system/site/`                                            | the reference shell: Next.js + Fumadocs + shadcn. next.config pins `turbopack.root`/`outputFileTracingRoot` to the repo root and sets `images.unoptimized`; a `basePath` knob is documented                        |
+| `.agents/skills/`                                         | intake-interview · add-sources · format-checker; `.claude/skills/` = real copies, byte-identity checked by the format-checker; `.gemini/settings.json` points Gemini at AGENTS.md                                  |
+| `.github/workflows/validate.yml`                          | adopter-owned CI running the format checks; SHA-pinned actions                                                                                                                                                     |
+| `.gitattributes`                                          | `*.md text eol=lf` (instance.md included) — checkout bytes are provenance bytes                                                                                                                                    |
+| `.gitignore`                                              | `.ksor/`, `node_modules/`, `system/site/.next/`, `system/site/out/`, `*.tsbuildinfo`, `.env*`, `.DS_Store`                                                                                                         |
+
+**Record purity** (enforced by the scaffolded format-checker, later by
+`ksor build`): `knowledge/` holds CommonMark `.md` and assets only — no
+`.mdx`, no `meta.json`, no framework files; components are directives
+(`:::quiz`) that degrade to readable text; the closed frontmatter set is
+title, description, status, owner, provenance, effective, superseded,
+superseded_by, order; filenames are Windows-safe with no case-insensitive or
+`foo.md`/`foo/index.md` collisions and no parenthesized directories; asset
+links never escape `knowledge/`. Identity: a doc's path is its route and its
+future MCP URI — `ksor://<instance-name>/<path>`.
+
+**The surface contract** (the shell is a slot — decision 9): the site renders
+`knowledge/`, serves `llms.txt`, exposes per-page markdown (build artifacts
+once `ksor build` exists; dev-mode rewrite as sugar), passes the browser
+smoke, and contains no authored content. Any shell satisfying this contract
+is valid; core ships exactly one.
+
+## Acceptance
+
+Red-first, on a clean machine: (1) run init twice with the same name into
+temp dirs — trees are byte-identical and match the shipped templates
+(diffed, never counted); (2) every refusal fires with its slug and correct
+exit code; (3) the scaffolded project's own validate workflow logic passes
+against the fresh scaffold; (4) `pnpm install && pnpm dev` serves the
+example document — page renders in a real browser, both themes, zero
+console errors, zero external requests; (5) editing `knowledge/example.md`
+hot-reloads; (6) the agent eval: an agent given only the scaffolded project
+completes the intake interview into `instance.md` and lands one governed
+document that passes the format rules (CI-gated once the harness exists;
+manual rubric until then).
+
+## Out of scope
+
+`build`/`serve` (own specs); the upgrade-diff mechanism (the
+`ksor.scaffolded` stamp reserves its merge base); deploy recipes; binary
+source storage (provenance = external location + content hash, recorded);
+i18n; multi-corpus composition (second corpus = second project).

--- a/specs/ksor/init/spec.md
+++ b/specs/ksor/init/spec.md
@@ -58,18 +58,34 @@ later arrival is `build.lock.json`, committed, written only by `ksor build`):
 **Record purity** (enforced by the scaffolded format-checker, later by
 `ksor build`): `knowledge/` holds CommonMark `.md` and assets only — no
 `.mdx`, no `meta.json`, no framework files; components are directives
-(`:::quiz`) that degrade to readable text; the closed frontmatter set is
-title, description, status, owner, provenance, effective, superseded,
-superseded_by, order; filenames are Windows-safe with no case-insensitive or
+(`:::quiz`) that degrade to readable text; the frontmatter key set is closed
+(title, description, status, owner, provenance, effective, superseded,
+superseded_by, order) but requiredness follows the governance ladder —
+**level 0 requires only `title` + `status`**; owner and provenance are
+encouraged keys at level 0 and become required from level 1 up (the level is
+derived, never declared — demanding level 4 of a level-0 project is a bug); filenames are Windows-safe with no case-insensitive or
 `foo.md`/`foo/index.md` collisions and no parenthesized directories; asset
 links never escape `knowledge/`. Identity: a doc's path is its route and its
 future MCP URI — `ksor://<instance-name>/<path>`.
 
-**The surface contract** (the shell is a slot — decision 9): the site renders
-`knowledge/`, serves `llms.txt`, exposes per-page markdown (build artifacts
-once `ksor build` exists; dev-mode rewrite as sugar), passes the browser
-smoke, and contains no authored content. Any shell satisfying this contract
-is valid; core ships exactly one.
+**The surface contract — the shell swap seam** (decision 9). The ONLY
+coupling between ksor (and the root scripts) and the site is this contract;
+swapping shells must require no change outside `system/site/`:
+
+1. the site is the workspace package at `system/site/` exposing `dev`
+   (hot-reload preview of `knowledge/`) and `build` (static output at
+   `system/site/out/`) scripts;
+2. it renders every published document in `knowledge/`, including the
+   governed directives (`:::quiz` etc.), and renders nothing authored inside
+   itself;
+3. it serves `llms.txt`, and per-page markdown once `ksor build` emits the
+   artifacts (dev-mode sugar allowed);
+4. it passes the browser smoke (below).
+
+Fumadocs is the reference implementation core ships; a Docusaurus shell, a
+bare Next.js app, or any registry-distributed alternative that satisfies
+1–4 is equally conformant — this is how "today Fumadocs, tomorrow anything"
+is designed in rather than promised.
 
 ## Acceptance
 
@@ -83,7 +99,42 @@ console errors, zero external requests; (5) editing `knowledge/example.md`
 hot-reloads; (6) the agent eval: an agent given only the scaffolded project
 completes the intake interview into `instance.md` and lands one governed
 document that passes the format rules (CI-gated once the harness exists;
-manual rubric until then).
+manual rubric until then). Acceptance (1)–(3) also run on `windows-latest` —
+the Windows-safety rules are tested, never asserted.
+
+## Live verification — the agent walks
+
+Automated acceptance proves clauses; these walks prove the product. Each
+runs on a fresh environment (never certify a cached one), each surprise is
+recorded as a `found live:` note beside the code, and implementation is not
+done until all six pass:
+
+1. **Cold-adopter walk, stopwatched** — pack the tarball, fresh temp dir,
+   follow only what the handoff text prints; open the served page **in real
+   Chrome** (driven by the agent, in addition to the Playwright smoke):
+   example doc renders, search works, both themes, zero console errors,
+   zero external requests, under five minutes end to end.
+2. **SME walk** — live-edit a doc (watch the reload), add a new doc (nav
+   updates), add a relatively-linked image (renders); then delete `system/`
+   entirely and confirm the record remains a readable document tree — the
+   walk-away promise performed, not asserted.
+3. **Agent cold-start walk** — a fresh zero-context agent session in the
+   scaffold, given only a realistic request ("add a policy about X"; "help
+   me set up this knowledge base"): it must find AGENTS.md, land content in
+   `knowledge/` (never the site), use the frontmatter, run the checker,
+   and complete the intake interview — judged against a written rubric.
+4. **Refusal walk** — trigger every error path and then obey each printed
+   remedy verbatim; a remedy that doesn't fix the situation is a lying
+   error.
+5. **Hostile-environment walks** — init inside a real parent monorepo
+   (warning fires, project still works), stray home-dir lockfile, Ctrl-C
+   mid-run (filesystem as found; stale stage reported), Windows CI logs
+   read, not glanced at.
+6. **Deploy walk** — a scaffold pushed to a throwaway repo and put on a
+   real host plus a locally-served static export (basePath case): verify
+   the shipped bytes — llms.txt reachable, page rendering at the deployed
+   URL. The predecessor's four costliest defects were all found on deployed
+   artifacts; ours get found here first.
 
 ## Out of scope
 

--- a/specs/ksor/init/spec.md
+++ b/specs/ksor/init/spec.md
@@ -84,8 +84,15 @@ swapping shells must require no change outside `system/site/`:
 
 Fumadocs is the reference implementation core ships; a Docusaurus shell, a
 bare Next.js app, or any registry-distributed alternative that satisfies
-1–4 is equally conformant — this is how "today Fumadocs, tomorrow anything"
-is designed in rather than promised.
+1–4 is equally conformant. **The contract proves itself with two
+implementations** (owner, 2026-08-18): alongside the shipped Fumadocs
+reference, a conformance-minimal Docusaurus fixture lives under
+`workbench/` — never feature parity, built from the predecessor's portable
+layer — and one shell-agnostic conformance suite runs clauses 1–4 against
+both in CI. Two implementations keep the seam honest the way two compilers
+keep a language spec honest; the measured comparison (effort, LOC, surface
+quality) is recorded as evidence under decision 9, and the suite is the
+bar any future registry shell must pass.
 
 ## Acceptance
 


### PR DESCRIPTION
The design conversation, made durable: decisions 8–10 in AGENTS.md, the scaffold-structure lock record (5-agent unknown-unknowns hunt: 55 findings, every structure-breaking one resolved), and the ratified `specs/ksor/init/spec.md` — grammar, refusal slugs, negative contract, the closed root set, record-purity rules, the surface contract, and red-first acceptance.

Repo docs/spec only — changeset-exempt. Guard green (rule 8 validates the new spec's frontmatter).

Next PR: init implementation, red tests first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)