### PR TITLE
Exempt version PRs from the changeset gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,14 @@ jobs:
 
   changesets:
     name: Changeset present
-    if: github.event_name == 'pull_request'
+    # Version PRs CONSUME changesets — that is their whole job — so the gate
+    # exempts them (found live: the 0.0.2 version PR failed its own release
+    # mechanism's check, 2026-08-18). changeset-release/* is the changesets
+    # action's branch; release-* is the manual rescue's.
+    if: >-
+      github.event_name == 'pull_request' &&
+      !startsWith(github.head_ref, 'changeset-release/') &&
+      !startsWith(github.head_ref, 'release-')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
The 0.0.2 version PR (#8) failed the "Changeset present" check while every real check was green — a version PR consumes changesets, that's its whole job, so the gate red-Xes the release mechanism itself forever. The exemption covers `changeset-release/*` (the changesets action's branch) and `release-*` (the manual rescue's, used while the org PR-permission toggle stays off).

Workflow-only change; nothing under `packages/ksor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)