### PR TITLE
Fix the release gate order, and attach the pool error listener pg requires

### DIFF
--- a/.changeset/pool-error-listener.md
+++ b/.changeset/pool-error-listener.md
@@ -1,0 +1,11 @@
+---
+"@panaversity/ksor": patch
+---
+
+fix: `ksor serve` no longer exits when the database terminates an idle
+connection. The Postgres pool had no `'error'` listener, so an idle client
+dropped by a restart, a failover, or an administrative `pg_terminate_backend`
+became an uncaught exception and killed the process instead of being discarded
+and reconnected. Long-running servers were exposed to this on any routine
+database maintenance; the pool now logs the discarded connection's error class
+and keeps serving.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,9 +29,17 @@ jobs:
       # The version PR is opened by the repo GITHUB_TOKEN, which never triggers
       # the pull_request CI workflow — so the full gate runs HERE, in the same
       # job that publishes. No artifact ships untested.
+      #
+      # BUILD FIRST. Workspace packages resolve one another's types through
+      # their built dist (package.json exports), so typecheck, the unit tier
+      # and the integration tier all need it — ci.yml learned this on
+      # 2026-08-19 and this workflow did not, because a single-package repo
+      # had no cross-package types to resolve. The kernel conversion gave it
+      # some, and the FIRST release after it failed here with "Cannot find
+      # module '@panaversity/ksor-postgres'" (found live, 2026-08-20).
+      - run: pnpm build
       - run: pnpm lint:ci && pnpm fmt:ci && pnpm typecheck && pnpm guard && pnpm check:corpus
       - run: pnpm test:unit
-      - run: pnpm build
       - run: pnpm test:integration
       - run: pnpm publint
       # Publishing uses npm trusted publishing (id-token above): configure the

--- a/packages/postgres/src/db.ts
+++ b/packages/postgres/src/db.ts
@@ -124,7 +124,7 @@ export function createPool(dsn: string, options: DomainPoolOptions): pg.Pool {
   // arms the pending-queue timer when this is non-zero), and it removes the
   // waiter from the queue instead of the hand-rolled "let the late winner
   // complete and bounce" — so we use the native mechanism, not a Promise.race.
-  return new pg.Pool({
+  const pool = new pg.Pool({
     connectionString: dsn,
     max: options.maxSize,
     min: Math.min(options.minSize, options.maxSize),
@@ -133,6 +133,20 @@ export function createPool(dsn: string, options: DomainPoolOptions): pg.Pool {
     connectionTimeoutMillis: options.connectionTimeoutMs ?? 10_000,
     maxLifetimeSeconds: options.maxLifetimeSeconds ?? 900,
   });
+  // pg REQUIRES an error listener on the Pool. An IDLE client that the server
+  // terminates — a restart, a failover, `pg_terminate_backend`, a
+  // `DROP DATABASE ... WITH (FORCE)` — emits 'error' on the pool with no
+  // request to attach it to, and with no listener Node turns that into an
+  // UNCAUGHT EXCEPTION that kills the process. A long-running `ksor serve`
+  // would therefore die on a routine database failover rather than reconnect.
+  // pg discards the broken client itself; our job is to not crash, and to say
+  // what happened without leaking the DSN (found via a CI flake whose real
+  // subject was this, 2026-08-20).
+  pool.on("error", (error: Error & { code?: string }) => {
+    const code = error.code === undefined ? "" : ` ${error.code}`;
+    console.error(`db pool: idle client error (${error.name}${code}) — connection discarded`);
+  });
+  return pool;
 }
 
 /** pg's checkout/connect timeout messages; mapped to our shedding error.


### PR DESCRIPTION
Two blockers found by actually running the release.

## 1. The release gate ran typecheck before build

The first release after the kernel conversion (#16) failed immediately:

```
packages/content typecheck: src/db.ts(25,8): error TS2307:
Cannot find module '@panaversity/ksor-postgres'
```

Workspace packages resolve one another's types through their built `dist` (package.json `exports`), so nothing cross-package typechecks until the build has run. `ci.yml` learned this on 2026-08-19 and carries a comment about it; `release.yml` never did, because a single-package repo had no cross-package types to resolve.

The release job re-runs the full suite precisely *because* the Version PR does not trigger normal CI — but it was running an older shape of that suite. Both are now **build → lint/typecheck/guards → unit → integration → publint**.

## 2. No error listener on the pg Pool — an idle-client error crashed the process

This PR's own CI then failed in the Postgres job with an unhandled FATAL `57P01`. I had seen that error locally and dismissed it as a Neon teardown artifact; that was wrong — it was a race that had not yet lost in CI.

The real subject is larger than the flake. `createPool` attached no `'error'` listener, and pg is explicit that one is required: an **idle** client the server terminates emits `error` on the pool with no request to attach it to, and with no listener Node turns that into an **uncaught exception that kills the process**.

The test triggered it with `DROP DATABASE ... WITH (FORCE)`, but the production shapes are ordinary — a Postgres restart, a failover, an admin `pg_terminate_backend`. **A long-running `ksor serve` would have died on a routine database failover** instead of reconnecting, and nothing in the suite would have reported it.

The pool now logs the class and code of a discarded idle connection (never the DSN) and keeps serving; pg discards the broken client itself.

Verified: the test that raced runs clean three times consecutively with zero unhandled errors. Blocks the 0.0.4 release.