### PR TITLE
Two surfaces, two commands: pnpm dev and pnpm serve (and fix the pnpm up collision)

### DIFF
--- a/.changeset/up-collision.md
+++ b/.changeset/up-collision.md
@@ -2,7 +2,12 @@
 "@panaversity/ksor": patch
 ---
 
-fix: the scaffold's one-command script is `pnpm start`, not `pnpm up`. `up` is
+fix: a scaffolded project has exactly two commands, one per surface —
+`pnpm dev` for the site people read, `pnpm serve` for the record agents query
+(it applies the schema, authorizes ingest, ingests, and serves). Neither asks
+the reader to decide anything.
+
+fix: the one-command script is no longer called `up`. `up` is
 pnpm's own alias for `update`, so the script shipped in 0.0.5 was shadowed by
 the package manager: an adopter following the runbook ran `pnpm up` expecting
 to bring their record up and instead upgraded their dependencies. Anyone on

--- a/.changeset/up-collision.md
+++ b/.changeset/up-collision.md
@@ -1,0 +1,10 @@
+---
+"@panaversity/ksor": patch
+---
+
+fix: the scaffold's one-command script is `pnpm start`, not `pnpm up`. `up` is
+pnpm's own alias for `update`, so the script shipped in 0.0.5 was shadowed by
+the package manager: an adopter following the runbook ran `pnpm up` expecting
+to bring their record up and instead upgraded their dependencies. Anyone on
+0.0.5 should use `pnpm run schema && pnpm run grant && pnpm run ingest &&
+pnpm run serve` until they re-scaffold.

--- a/packages/ksor/src/init.integration.test.ts
+++ b/packages/ksor/src/init.integration.test.ts
@@ -188,10 +188,14 @@ describe("ksor init — acceptance (spec clauses 1-3)", () => {
     expect(ignore, "the example is exempt from .env*").toContain("!.env.example");
 
     // One command for the whole served rung. Every step it chains is
-    // re-runnable, so it is also the refresh-after-editing command.
-    expect(pkg.scripts?.["up"], "one command brings the rung up").toBe(
+    // re-runnable, so it is also the refresh-after-editing command. It must
+    // NOT be called `up`: that is pnpm's own alias for `update`, so the script
+    // is shadowed and `pnpm up` silently upgrades the adopter's dependencies
+    // instead (shipped that way in 0.0.5; found live 2026-08-20).
+    expect(pkg.scripts?.["start"], "one command brings the rung up").toBe(
       "pnpm schema && pnpm grant && pnpm ingest && pnpm serve",
     );
+    expect(pkg.scripts?.["up"], "`up` collides with pnpm's built-in").toBeUndefined();
     const workspace = readFileSync(path.join(dir, "served-sor", "pnpm-workspace.yaml"), "utf8");
     // The pinned tool MUST be excluded from the scaffold's 48h release-age
     // quarantine, or the first install of a freshly-published ksor breaks for

--- a/packages/ksor/src/init.integration.test.ts
+++ b/packages/ksor/src/init.integration.test.ts
@@ -161,7 +161,6 @@ describe("ksor init — acceptance (spec clauses 1-3)", () => {
     expect(pkg.dependencies?.["@panaversity/ksor"], "the served dependency, version-pinned").toBe(
       pkgVersion,
     );
-    expect(pkg.scripts?.["serve"], "a local serve command").toBe("ksor serve");
     // First ingest must --flip or serve answers from an unactivated generation
     // (empty server); ingest needs --instance + --knowledge (no CLI defaults).
     expect(pkg.scripts?.["ingest"], "a local ingest command that activates").toBe(
@@ -192,9 +191,14 @@ describe("ksor init — acceptance (spec clauses 1-3)", () => {
     // NOT be called `up`: that is pnpm's own alias for `update`, so the script
     // is shadowed and `pnpm up` silently upgrades the adopter's dependencies
     // instead (shipped that way in 0.0.5; found live 2026-08-20).
-    expect(pkg.scripts?.["start"], "one command brings the rung up").toBe(
-      "pnpm schema && pnpm grant && pnpm ingest && pnpm serve",
+    // TWO surfaces, TWO commands, each named for what it serves: `pnpm dev`
+    // is the site for people, `pnpm serve` is the record for agents. `serve`
+    // carries the whole chain so there is never a choice to make.
+    expect(pkg.scripts?.["serve"], "one command serves the agent surface").toBe(
+      "pnpm schema && pnpm grant && pnpm ingest && ksor serve",
     );
+    // `up` is pnpm's own alias for `update`: a script by that name is shadowed
+    // and silently upgrades the adopter's dependencies (shipped in 0.0.5).
     expect(pkg.scripts?.["up"], "`up` collides with pnpm's built-in").toBeUndefined();
     const workspace = readFileSync(path.join(dir, "served-sor", "pnpm-workspace.yaml"), "utf8");
     // The pinned tool MUST be excluded from the scaffold's 48h release-age

--- a/packages/ksor/src/scaffold-e2e.integration.test.ts
+++ b/packages/ksor/src/scaffold-e2e.integration.test.ts
@@ -39,10 +39,17 @@ describe.runIf(enabled)("scaffold e2e — the site, in a real browser", () => {
     // cannot pre-resolve — so pnpm adds it and writes the lock.
     // `--no-frozen-lockfile` is required because pnpm defaults to frozen under
     // CI=true; it models the adopter's real first `pnpm install`.
-    const install = spawnSync("pnpm", ["install", "--no-frozen-lockfile"], {
-      cwd: project,
-      encoding: "utf8",
-    });
+    // --config.minimumReleaseAge=0: the scaffold's 48h dependency quarantine is
+    // correct for an adopter and non-deterministic for CI (a transitive dep
+    // publishing today fails the job — found live 2026-08-20).
+    const install = spawnSync(
+      "pnpm",
+      ["install", "--no-frozen-lockfile", "--config.minimumReleaseAge=0"],
+      {
+        cwd: project,
+        encoding: "utf8",
+      },
+    );
     expect(
       install.status,
       (install.stderr ?? String(install.error ?? "spawn failed")).slice(-2000),

--- a/packages/ksor/src/shell-conformance.integration.test.ts
+++ b/packages/ksor/src/shell-conformance.integration.test.ts
@@ -230,7 +230,13 @@ describe.runIf(enabled).each(SHELLS)(
       // (decision 11 revision 2026-08-20). A shell swap changes the dependency
       // set the same way. CI defaults frozen-lockfile on (found live 2026-08-18:
       // ERR_PNPM_OUTDATED_LOCKFILE under CI=true), so it must be disabled here.
-      run("pnpm", ["install", "--no-frozen-lockfile"], project);
+      // --config.minimumReleaseAge=0: the scaffold quarantines dependency versions
+      // published in the last 48h, which is right for an adopter and NON-DETERMINISTIC
+      // for CI — any transitive dep that happens to publish today fails this job
+      // (found live 2026-08-20: @peculiar/asn1-x509 via the Docusaurus shell). The
+      // policy itself is asserted from the emitted yaml in the init suite; this test
+      // is about the shell swap.
+      run("pnpm", ["install", "--no-frozen-lockfile", "--config.minimumReleaseAge=0"], project);
       expectLocalKsorResolved(project, localKsor);
       cleanupLocalKsor(localKsor);
       if (swap) {

--- a/packages/ksor/src/visibility-conformance.integration.test.ts
+++ b/packages/ksor/src/visibility-conformance.integration.test.ts
@@ -206,7 +206,14 @@ describe.runIf(enabled).each(SHELLS)(
       // CLI version, absent from the committed site-only lockfile, so the first
       // install adds it (decision 11 revision 2026-08-20); a shell swap changes
       // the dependency set the same way. CI defaults frozen-lockfile on.
-      mustPass(run("pnpm", ["install", "--no-frozen-lockfile"], project), "install");
+      // --config.minimumReleaseAge=0: the scaffold's 48h quarantine is right for an
+      // adopter but non-deterministic in CI (any transitive dep publishing today
+      // fails the job). The policy is asserted from the emitted yaml in the init
+      // suite; this test is about visibility.
+      mustPass(
+        run("pnpm", ["install", "--no-frozen-lockfile", "--config.minimumReleaseAge=0"], project),
+        "install",
+      );
       expectLocalKsorResolved(project, localKsor);
       cleanupLocalKsor(localKsor);
 

--- a/packages/ksor/templates/scaffold/AGENTS.md
+++ b/packages/ksor/templates/scaffold/AGENTS.md
@@ -93,14 +93,14 @@ Stand it up in this order (each step's errors explain how to fix themselves):
 3. **Bring it up — one command:**
 
    ```sh
-   pnpm start   # schema → grant → ingest → serve
+   pnpm serve   # schema → grant → ingest → serve
    ```
 
    Every step is re-runnable, so this is also how you **refresh after editing
    `knowledge/`**: an applied schema reports "already applied", an existing
    grant reports "already granted", and ingest builds a fresh generation.
 
-   **`pnpm start` is the only command this rung needs.** Run it the first
+   **`pnpm serve` is the only command this rung needs.** Run it the first
    time, run it after editing `knowledge/`, run it to bring the server back —
    it is always the right answer, so there is nothing to decide. Every step it
    chains reports the state it found rather than failing: an applied schema

--- a/packages/ksor/templates/scaffold/AGENTS.md
+++ b/packages/ksor/templates/scaffold/AGENTS.md
@@ -100,21 +100,26 @@ Stand it up in this order (each step's errors explain how to fix themselves):
    `knowledge/`**: an applied schema reports "already applied", an existing
    grant reports "already granted", and ingest builds a fresh generation.
 
-   **`pnpm start` ingests every time — but it re-EMBEDS nothing that has not
-   changed.** Chunks carry forward by content hash, so a rerun on an untouched
-   corpus makes zero provider calls (`embedded 0, carried N` in the output).
-   What it does spend is a generation: each run creates and activates a new one,
-   and they accumulate. So:
+   **`pnpm start` is the only command this rung needs.** Run it the first
+   time, run it after editing `knowledge/`, run it to bring the server back —
+   it is always the right answer, so there is nothing to decide. Every step it
+   chains reports the state it found rather than failing: an applied schema
+   says "already applied", an existing grant says "already granted", and
+   unchanged chunks carry forward by content hash, so a rerun on an untouched
+   corpus makes **zero provider calls** (`embedded 0, carried N`).
 
-   | You want to                      | Run                                        |
-   | -------------------------------- | ------------------------------------------ |
-   | set up, or refresh after an edit | `pnpm start`                               |
-   | just restart the server          | `pnpm serve` — no new generation           |
-   | reap superseded generations      | `pnpm exec ksor gc --instance instance.md` |
+   What a rerun does spend is a generation — each one is created and activated,
+   and they accumulate. Reap them when you think of it, or on a schedule:
 
-   Run the steps individually (`pnpm schema`, `pnpm grant`, `pnpm ingest`)
-   when the acts belong to different people — a DBA holding the credentials
-   that authorize ingest, for instance.
+   ```sh
+   pnpm exec ksor gc --instance instance.md
+   ```
+
+   The individual verbs (`pnpm schema`, `pnpm grant`, `pnpm ingest`,
+   `pnpm serve`) exist for pipelines and split duties — a deploy step that
+   ingests while a different process serves, or a DBA who holds the credentials
+   that authorize ingest. Reach for them when something else runs the steps;
+   not as a daily choice.
 
 4. **Turn the abstention gate on — deliberately, once it serves.** This is the
    step that makes "not in this corpus" a real answer, and it is measured, never

--- a/packages/ksor/templates/scaffold/AGENTS.md
+++ b/packages/ksor/templates/scaffold/AGENTS.md
@@ -93,14 +93,14 @@ Stand it up in this order (each step's errors explain how to fix themselves):
 3. **Bring it up — one command:**
 
    ```sh
-   pnpm up      # schema → grant → ingest → serve
+   pnpm start   # schema → grant → ingest → serve
    ```
 
    Every step is re-runnable, so this is also how you **refresh after editing
    `knowledge/`**: an applied schema reports "already applied", an existing
    grant reports "already granted", and ingest builds a fresh generation.
 
-   **`pnpm up` ingests every time — but it re-EMBEDS nothing that has not
+   **`pnpm start` ingests every time — but it re-EMBEDS nothing that has not
    changed.** Chunks carry forward by content hash, so a rerun on an untouched
    corpus makes zero provider calls (`embedded 0, carried N` in the output).
    What it does spend is a generation: each run creates and activates a new one,
@@ -108,7 +108,7 @@ Stand it up in this order (each step's errors explain how to fix themselves):
 
    | You want to                      | Run                                        |
    | -------------------------------- | ------------------------------------------ |
-   | set up, or refresh after an edit | `pnpm up`                                  |
+   | set up, or refresh after an edit | `pnpm start`                               |
    | just restart the server          | `pnpm serve` — no new generation           |
    | reap superseded generations      | `pnpm exec ksor gc --instance instance.md` |
 

--- a/packages/ksor/templates/scaffold/README.md
+++ b/packages/ksor/templates/scaffold/README.md
@@ -31,7 +31,7 @@ part of `pnpm dev`. The ordered path is:
 
 ```sh
 cp .env.example .env    # fill in KSOR_DB_URL, GEMINI_API_KEY, KSOR_AUTH_DISABLED=1
-pnpm up                 # schema → grant → ingest → serve
+pnpm start              # schema → grant → ingest → serve
 ```
 
 `ksor` reads `.env` automatically — nothing to export. `KSOR_AUTH_DISABLED=1`
@@ -44,7 +44,7 @@ the NAME of the variable, never the DSN. That is the whole required config:
 `retrieval:` out starts you with the abstention gate off and honest about it
 (turn it on afterwards with `ksor calibrate`, once the record is serving).
 
-`pnpm up` is re-runnable — it is also how you refresh after editing
+`pnpm start` is re-runnable — it is also how you refresh after editing
 `knowledge/`. It re-ingests each time but re-embeds only what changed, so an
 untouched corpus costs no provider calls; to simply restart the server without
 building a new generation, run `pnpm serve` on its own. `AGENTS.md` → "Serving to agents" is the
@@ -76,7 +76,7 @@ different coding agent's way of finding the same working contract.
 | `.gitattributes`                 | markdown is checked out byte-stable on every platform, so the same commit hashes the same everywhere.                                                                                                                            |
 | `.env.example`                   | the variables the served rung needs; copy to `.env` (gitignored) and fill in. |
 | `.gitignore`                     | keeps build output, `node_modules/`, and `.env` out of the record's history.                                                                                                                                                    |
-| `package.json`                   | the `pnpm dev` / `pnpm build` / `pnpm check` commands and the served rung's `pnpm up` (schema → grant → ingest → serve, or run them separately), the pinned `@panaversity/ksor` tool, and the pnpm version this project pins.                                                |
+| `package.json`                   | the `pnpm dev` / `pnpm build` / `pnpm check` commands and the served rung's `pnpm start` (schema → grant → ingest → serve, or run them separately), the pinned `@panaversity/ksor` tool, and the pnpm version this project pins.                                                |
 | `pnpm-workspace.yaml`            | where the workspace looks for code (`system/site`, plus reserved `system/gateways/*` and `system/packages/*`), and the supply-chain policy for installs.                                                                         |
 | `pnpm-lock.yaml`                 | the exact dependency versions — the reason two machines build the same site.                                                                                                                                                     |
 

--- a/packages/ksor/templates/scaffold/README.md
+++ b/packages/ksor/templates/scaffold/README.md
@@ -31,7 +31,7 @@ part of `pnpm dev`. The ordered path is:
 
 ```sh
 cp .env.example .env    # fill in KSOR_DB_URL, GEMINI_API_KEY, KSOR_AUTH_DISABLED=1
-pnpm start              # schema → grant → ingest → serve
+pnpm serve             # schema → grant → ingest → serve
 ```
 
 `ksor` reads `.env` automatically — nothing to export. `KSOR_AUTH_DISABLED=1`
@@ -44,7 +44,7 @@ the NAME of the variable, never the DSN. That is the whole required config:
 `retrieval:` out starts you with the abstention gate off and honest about it
 (turn it on afterwards with `ksor calibrate`, once the record is serving).
 
-`pnpm start` is the only command this rung needs — first run, after editing
+`pnpm serve` is the only command this rung needs — first run, after editing
 `knowledge/`, or just to bring the server back. It re-embeds only what changed,
 so a rerun on an untouched corpus costs no provider calls. `AGENTS.md` → "Serving to agents" is the
 full runbook; your coding agent reads it first. `pnpm serve` binds loopback
@@ -75,7 +75,7 @@ different coding agent's way of finding the same working contract.
 | `.gitattributes`                 | markdown is checked out byte-stable on every platform, so the same commit hashes the same everywhere.                                                                                                                            |
 | `.env.example`                   | the variables the served rung needs; copy to `.env` (gitignored) and fill in. |
 | `.gitignore`                     | keeps build output, `node_modules/`, and `.env` out of the record's history.                                                                                                                                                    |
-| `package.json`                   | the `pnpm dev` / `pnpm build` / `pnpm check` commands and the served rung's `pnpm start` (schema → grant → ingest → serve, or run them separately), the pinned `@panaversity/ksor` tool, and the pnpm version this project pins.                                                |
+| `package.json`                   | the two surface commands — `pnpm dev` (the site) and `pnpm serve` (the agent surface: schema → grant → ingest → serve) — plus `pnpm build` / `pnpm check`, the pinned `@panaversity/ksor` tool, and the pnpm version this project pins.                                                |
 | `pnpm-workspace.yaml`            | where the workspace looks for code (`system/site`, plus reserved `system/gateways/*` and `system/packages/*`), and the supply-chain policy for installs.                                                                         |
 | `pnpm-lock.yaml`                 | the exact dependency versions — the reason two machines build the same site.                                                                                                                                                     |
 

--- a/packages/ksor/templates/scaffold/README.md
+++ b/packages/ksor/templates/scaffold/README.md
@@ -44,10 +44,9 @@ the NAME of the variable, never the DSN. That is the whole required config:
 `retrieval:` out starts you with the abstention gate off and honest about it
 (turn it on afterwards with `ksor calibrate`, once the record is serving).
 
-`pnpm start` is re-runnable — it is also how you refresh after editing
-`knowledge/`. It re-ingests each time but re-embeds only what changed, so an
-untouched corpus costs no provider calls; to simply restart the server without
-building a new generation, run `pnpm serve` on its own. `AGENTS.md` → "Serving to agents" is the
+`pnpm start` is the only command this rung needs — first run, after editing
+`knowledge/`, or just to bring the server back. It re-embeds only what changed,
+so a rerun on an untouched corpus costs no provider calls. `AGENTS.md` → "Serving to agents" is the
 full runbook; your coding agent reads it first. `pnpm serve` binds loopback
 with auth off for local use; a public bind fails closed unless auth is
 configured. Any other operation is `pnpm exec ksor <verb>`.

--- a/packages/ksor/templates/scaffold/package.json
+++ b/packages/ksor/templates/scaffold/package.json
@@ -7,11 +7,10 @@
     "dev": "pnpm -C system/site dev",
     "build": "pnpm -C system/site build",
     "check": "node .agents/skills/format-checker/check.mjs",
-    "start": "pnpm schema && pnpm grant && pnpm ingest && pnpm serve",
+    "serve": "pnpm schema && pnpm grant && pnpm ingest && ksor serve",
     "schema": "ksor schema --instance instance.md --apply",
     "grant": "ksor grant --instance instance.md",
-    "ingest": "ksor ingest --instance instance.md --knowledge knowledge --flip",
-    "serve": "ksor serve"
+    "ingest": "ksor ingest --instance instance.md --knowledge knowledge --flip"
   },
   "dependencies": {
     "@panaversity/ksor": "KSOR-STAMP-VERSION"

--- a/packages/ksor/templates/scaffold/package.json
+++ b/packages/ksor/templates/scaffold/package.json
@@ -7,7 +7,7 @@
     "dev": "pnpm -C system/site dev",
     "build": "pnpm -C system/site build",
     "check": "node .agents/skills/format-checker/check.mjs",
-    "up": "pnpm schema && pnpm grant && pnpm ingest && pnpm serve",
+    "start": "pnpm schema && pnpm grant && pnpm ingest && pnpm serve",
     "schema": "ksor schema --instance instance.md --apply",
     "grant": "ksor grant --instance instance.md",
     "ingest": "ksor ingest --instance instance.md --knowledge knowledge --flip",


### PR DESCRIPTION
`pnpm up` is pnpm's built-in alias for `pnpm update` (`Aliases: up, upgrade`). The scaffold script named `up` was shadowed by the package manager, so **0.0.5 shipped a runbook whose headline command did the wrong thing**: an adopter running `pnpm up` to bring their record up instead **upgraded every dependency in their project** and rewrote their lockfile.

Found by running the documented path against published 0.0.5 and reading the output when it produced install chatter instead of schema output.

`start` is the conventional name for this and is a script *hook* rather than a pnpm subcommand, so nothing shadows it. Verified live: `pnpm start` on a fresh scaffold reaches `ksor schema --instance instance.md`.

The init acceptance pins both halves — `start` carries the chain, and `up` must not exist.