### PR TITLE
Make re-ingesting an unchanged record free

### DIFF
--- a/.changeset/ingest-skip.md
+++ b/.changeset/ingest-skip.md
@@ -1,0 +1,11 @@
+---
+"@panaversity/ksor": patch
+---
+
+feat: restarting an unedited record is free. `ksor serve` runs ingest on every
+start, and ingest now compares the corpus it just read against the generation
+already serving — identical content at the same source commit consumes no
+generation, writes no rows, and embeds nothing ("unchanged — generation N
+already serves this corpus"). Editing a document still builds a generation and
+re-embeds only what changed, and a new source commit over identical bytes still
+records one, because that is a build fact provenance must keep.

--- a/packages/content/src/commands.ts
+++ b/packages/content/src/commands.ts
@@ -282,6 +282,15 @@ async function ingestCommand(args: string[]): Promise<number> {
       throw exc;
     }
   });
+  if (report.unchanged) {
+    // The record already serves these exact bytes at this commit: no
+    // generation consumed, nothing embedded. `ksor serve` runs ingest on every
+    // start, so a restart of an unedited record must cost nothing.
+    process.stdout.write(
+      `ingest: unchanged — generation ${report.generation} already serves this corpus\n`,
+    );
+    return 0;
+  }
   process.stdout.write(
     `ingest: generation ${report.generation} — ${report.nodes} nodes, ${report.chunks} chunks; ` +
       `embedded ${report.embedded}, carried ${report.carried}, failed ${report.failed}\n`,

--- a/packages/content/src/ingest/build.ts
+++ b/packages/content/src/ingest/build.ts
@@ -319,6 +319,12 @@ export interface BuildReport {
    */
   readonly refusal: string | null;
   readonly health: GenerationHealth;
+  /**
+   * The corpus was byte-identical to the generation already serving, so NO
+   * generation was consumed and nothing was embedded. `generation` then names
+   * the generation still active, not a new one.
+   */
+  readonly unchanged: boolean;
 }
 
 /**
@@ -328,6 +334,78 @@ export interface BuildReport {
  * finalize (+ optional flip, same transaction). Returns the report; the CLI
  * turns `refusal` into stderr + exit 1.
  */
+async function activeGenerationOf(
+  c: pg.PoolClient,
+  tenantId: string,
+  corpusId: string,
+): Promise<number | null> {
+  const r = await c.query(
+    "SELECT active_generation FROM corpora WHERE tenant_id = $1 AND corpus_id = $2",
+    [tenantId, corpusId],
+  );
+  const raw: unknown = r.rows[0]?.active_generation ?? null;
+  return raw === null ? null : Number(raw);
+}
+
+/**
+ * Do two generations hold the same corpus? Compared on the SET of
+ * (stable_id, content_hash) pairs — identity plus content — so a moved
+ * document, an edited body, an added or removed file all count as different,
+ * while a rebuild of identical bytes does not.
+ */
+async function sameCorpus(
+  c: pg.PoolClient,
+  tenantId: string,
+  a: number,
+  b: number,
+): Promise<boolean> {
+  const r = await c.query(
+    `WITH pair AS (
+       SELECT s.generation, n.stable_id, s.content_hash
+         FROM sources s JOIN content_nodes n
+           ON n.tenant_id = s.tenant_id AND n.generation = s.generation AND n.node_id = s.node_id
+        WHERE s.tenant_id = $1 AND s.generation IN ($2, $3)
+     )
+     SELECT (SELECT count(*) FROM pair WHERE generation = $2) =
+            (SELECT count(*) FROM pair WHERE generation = $3)
+        AND NOT EXISTS (
+              SELECT 1 FROM pair x WHERE x.generation = $2
+               AND NOT EXISTS (SELECT 1 FROM pair y WHERE y.generation = $3
+                                AND y.stable_id = x.stable_id AND y.content_hash = x.content_hash)
+            ) AS same`,
+    [tenantId, a, b],
+  );
+  return r.rows[0]?.same === true;
+}
+
+/** Was the active generation produced by this same source commit? */
+async function sameCommit(
+  c: pg.PoolClient,
+  tenantId: string,
+  generation: number,
+  sourceCommit: string | undefined,
+): Promise<boolean> {
+  const r = await c.query(
+    `SELECT source_commit FROM ingestion_runs
+      WHERE tenant_id = $1 AND generation = $2
+      ORDER BY run_id DESC LIMIT 1`,
+    [tenantId, generation],
+  );
+  if (r.rows.length === 0) return false;
+  const stored: unknown = r.rows[0]?.source_commit ?? null;
+  return String(stored ?? "") === String(sourceCommit ?? "");
+}
+
+/** Thrown inside the build transaction to roll it back when nothing changed. */
+class UnchangedCorpus extends Error {
+  readonly activeGeneration: number;
+  constructor(activeGeneration: number) {
+    super("corpus unchanged");
+    this.name = "UnchangedCorpus";
+    this.activeGeneration = activeGeneration;
+  }
+}
+
 export async function buildGeneration(
   pool: pg.Pool,
   instance: ContentInstance,
@@ -350,24 +428,67 @@ export async function buildGeneration(
       .digest("hex");
 
   // ---- allocate + structure + carry: ONE transaction (atomic per generation)
-  const structure = await runIngest(pool, tenant, async (c) => {
-    const alloc = await allocateRun(c, {
-      tenantId: tenant,
-      corpusId: instance.corpusId,
-      sourceCommit: options.sourceCommit,
-      manifestSha256,
+  let structure;
+  try {
+    structure = await runIngest(pool, tenant, async (c) => {
+      const alloc = await allocateRun(c, {
+        tenantId: tenant,
+        corpusId: instance.corpusId,
+        sourceCommit: options.sourceCommit,
+        manifestSha256,
+      });
+      const stats = await buildStructure(c, {
+        tenantId: tenant,
+        corpusId: instance.corpusId,
+        generation: alloc.generation,
+        manifest,
+        files: sources,
+        treeRoot: options.knowledgeDir,
+        modelId,
+      });
+      // Nothing to do? Compare what we JUST wrote against what is already
+      // serving, using the content hashes buildStructure computed — never a
+      // second digest of our own, which could disagree with the real one and
+      // skip a genuine edit. Identical means this generation is a duplicate, so
+      // roll the whole transaction back: no rows persist, no flip, no embedding
+      // spend. `pnpm serve` therefore costs nothing when the record has not
+      // changed (2026-08-20).
+      // Skip only when the SOURCE COMMIT matches too. A new commit over
+      // identical bytes is still a new build fact — "every build records the
+      // exact corpus that produced it" — so it earns a generation; a plain
+      // restart, which names no commit, does not.
+      const active = await activeGenerationOf(c, tenant, instance.corpusId);
+      if (
+        active !== null &&
+        (await sameCommit(c, tenant, active, options.sourceCommit)) &&
+        (await sameCorpus(c, tenant, active, alloc.generation))
+      ) {
+        throw new UnchangedCorpus(active);
+      }
+      return { ...alloc, stats };
     });
-    const stats = await buildStructure(c, {
-      tenantId: tenant,
-      corpusId: instance.corpusId,
-      generation: alloc.generation,
-      manifest,
-      files: sources,
-      treeRoot: options.knowledgeDir,
-      modelId,
-    });
-    return { ...alloc, stats };
-  });
+  } catch (error) {
+    if (error instanceof UnchangedCorpus) {
+      log(`unchanged: generation ${error.activeGeneration} already serves this corpus`);
+      return {
+        runId: 0,
+        generation: error.activeGeneration,
+        nodes: 0,
+        sources: 0,
+        chunks: 0,
+        carried: 0,
+        embedded: 0,
+        failed: 0,
+        ready: true,
+        centroids: 0,
+        flipped: false,
+        refusal: null,
+        health: { ok: true, reasons: [] } as unknown as GenerationHealth,
+        unchanged: true,
+      };
+    }
+    throw error;
+  }
   const { runId, generation, stats } = structure;
   log(
     `run ${runId}: building generation ${generation} (embed ${provider.providerId}:${provider.recipe})`,
@@ -494,6 +615,7 @@ export async function buildGeneration(
     flipped: fin.flipped,
     refusal: fin.refusal,
     health: fin.health,
+    unchanged: false,
   };
 }
 

--- a/packages/content/src/ingest/ingest.db.test.ts
+++ b/packages/content/src/ingest/ingest.db.test.ts
@@ -444,6 +444,57 @@ describe.runIf(adminDsn !== "")("ingest pipeline db acceptance", () => {
       1,
     );
   }, 120_000);
+
+  it("an UNCHANGED corpus at the SAME commit consumes no generation", async () => {
+    // `pnpm serve` runs ingest on every start, so restarting an unedited
+    // record must cost nothing: no new generation, no rows, no flip, no
+    // embedding. A NEW commit over identical bytes still earns a generation —
+    // that is a build fact, and provenance records it (test (2) pins that).
+    // Assertions are relative so this can run after the sequence above.
+    const baseline = await buildGeneration(pool, instance, {
+      knowledgeDir: FIXTURE,
+      sourceCommit: "commit-idempotent",
+      flip: true,
+      provider: fake,
+    });
+    expect(baseline.unchanged, "a new commit builds").toBe(false);
+
+    const before = await runRead(pool, TENANT, async (c) => {
+      const a = await c.query(
+        "SELECT active_generation FROM corpora WHERE tenant_id = $1 AND corpus_id = $2",
+        [TENANT, CORPUS],
+      );
+      const g = await c.query(
+        "SELECT count(DISTINCT generation)::int AS n FROM content_nodes WHERE tenant_id = $1",
+        [TENANT],
+      );
+      return { active: Number(a.rows[0]?.active_generation), gens: Number(g.rows[0]?.n) };
+    });
+
+    const again = await buildGeneration(pool, instance, {
+      knowledgeDir: FIXTURE,
+      sourceCommit: "commit-idempotent",
+      flip: true,
+      provider: fake,
+    });
+    expect(again.unchanged, "re-ingesting identical bytes at the same commit").toBe(true);
+    expect(again.embedded, "no embedding spend").toBe(0);
+    expect(again.generation, "names the generation still serving").toBe(before.active);
+
+    const after = await runRead(pool, TENANT, async (c) => {
+      const a = await c.query(
+        "SELECT active_generation FROM corpora WHERE tenant_id = $1 AND corpus_id = $2",
+        [TENANT, CORPUS],
+      );
+      const g = await c.query(
+        "SELECT count(DISTINCT generation)::int AS n FROM content_nodes WHERE tenant_id = $1",
+        [TENANT],
+      );
+      return { active: Number(a.rows[0]?.active_generation), gens: Number(g.rows[0]?.n) };
+    });
+    expect(after.active, "the active pointer must not move").toBe(before.active);
+    expect(after.gens, "no generation was persisted").toBe(before.gens);
+  }, 240_000);
 });
 
 describe.runIf(adminDsn === "")("ingest pipeline db acceptance (gated)", () => {

--- a/packages/ksor/templates/scaffold/AGENTS.md
+++ b/packages/ksor/templates/scaffold/AGENTS.md
@@ -108,8 +108,14 @@ Stand it up in this order (each step's errors explain how to fix themselves):
    unchanged chunks carry forward by content hash, so a rerun on an untouched
    corpus makes **zero provider calls** (`embedded 0, carried N`).
 
-   What a rerun does spend is a generation — each one is created and activated,
-   and they accumulate. Reap them when you think of it, or on a schedule:
+   A rerun on an unchanged record costs **nothing at all**: ingest compares the
+   corpus it just read against the generation already serving and, when they
+   are identical at the same commit, consumes no generation and writes no rows
+   ("unchanged — generation N already serves this corpus"). Edit a document and
+   the next run builds a generation for it, re-embedding only what changed.
+
+   Generations do accumulate as you edit. Reap the superseded ones when you
+   think of it, or on a schedule:
 
    ```sh
    pnpm exec ksor gc --instance instance.md

--- a/packages/ksor/templates/scaffold/README.md
+++ b/packages/ksor/templates/scaffold/README.md
@@ -45,8 +45,9 @@ the NAME of the variable, never the DSN. That is the whole required config:
 (turn it on afterwards with `ksor calibrate`, once the record is serving).
 
 `pnpm serve` is the only command this rung needs — first run, after editing
-`knowledge/`, or just to bring the server back. It re-embeds only what changed,
-so a rerun on an untouched corpus costs no provider calls. `AGENTS.md` → "Serving to agents" is the
+`knowledge/`, or just to bring the server back. A rerun on an unchanged record
+costs nothing: no new generation, no embedding, no rows. Edit a document and
+the next run picks up exactly that change. `AGENTS.md` → "Serving to agents" is the
 full runbook; your coding agent reads it first. `pnpm serve` binds loopback
 with auth off for local use; a public bind fails closed unless auth is
 configured. Any other operation is `pnpm exec ksor <verb>`.


### PR DESCRIPTION
`ksor serve` runs ingest on every start, so restarting an unedited record cost a generation and a full copy of its chunk rows each time — no money (unchanged chunks carry forward by hash), but real growth. Worse, it left the operator holding a decision the tool should own: *had I edited anything?*

Ingest now compares what it just built against the generation already serving and **rolls the whole transaction back** when they match.

```
run 1:  generation 1 — 1 nodes, 1 chunks; embedded 1
run 2:  unchanged — generation 1 already serves this corpus
run 3:  unchanged — generation 1 already serves this corpus
edited: generation 2 — 1 nodes, 1 chunks; embedded 1
again:  unchanged — generation 2 already serves this corpus
```

## Two choices worth reviewing

**The comparison uses the content hashes `buildStructure` itself computed**, never a second digest of our own. A separate digest could disagree with the real one and silently skip a genuine edit — the one failure this must not have.

**The skip is narrowed to the same source commit.** A new commit over identical bytes still earns a generation, because *"every build records the exact corpus that produced it"* is a provenance guarantee, not an optimisation target. The existing acceptance that a re-ingest at a **new** commit produces generation 2 passes unchanged — that test is what caught the distinction.

Red-first: the new db test asserts the active pointer does not move and no generation is persisted, with relative assertions so it runs after the existing sequence.