### PR TITLE
Correct the docs to the released 0.0.7 surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The result is not merely a documentation site, knowledge base, vector database, 
 > remain designed, not implemented; running them prints an honest notice and
 > exits 2. Inside a scaffolded project, `pnpm dev` and `pnpm build` work today
 > without them. See [`docs/status.md`](docs/status.md) for the exact released
-> version — some of this lands the release after the one you install.
+> version.
 
 ---
 
@@ -526,17 +526,24 @@ provenance — is a future verb; see [`docs/status.md`](docs/status.md).)
 ## Serve to AI Agents
 
 ```bash
-npx @panaversity/ksor serve
+cp .env.example .env   # fill in KSOR_DB_URL, GEMINI_API_KEY, KSOR_AUTH_DISABLED=1
+pnpm serve             # schema → grant → ingest → serve
 ```
 
 The agent projection exposes the governed KSoR through MCP: `search`, `outline`,
 and `read` over stateless Streamable HTTP, with cited passages, snapshot
 generation-pinning, and honest abstention. `serve` reads `./instance.md` and
 runs the MCP server in-process — the climbed rung, so it needs a Postgres store
-(pgvector) and an embedding provider key, ingested with `ksor ingest`. It binds
-loopback with auth off by default; a public bind fails closed unless auth is
-configured. (Landing the release after the one you install — see
-[`docs/status.md`](docs/status.md).)
+(pgvector) and an embedding provider key. It binds loopback with auth off by
+default; a public bind fails closed unless auth is configured.
+
+`pnpm serve` is the only command this rung needs: run it the first time, after
+editing `knowledge/`, or to bring the server back. Every step reports the state
+it found instead of failing, and a rerun on an unchanged record costs nothing —
+ingest compares what it read against the generation already serving and, when
+they match at the same commit, writes no rows at all. The abstention gate stays
+off until you measure a floor with `ksor calibrate` and paste it into
+`instance.md` — never copied from another corpus.
 
 ---
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -6,17 +6,28 @@ updated: 2026-08-20.
 
 ## Published package
 
-`@panaversity/ksor` **0.0.3** on npm (trusted publishing, provenance
-attached). **In the currently published 0.0.3** it ships the working
+`@panaversity/ksor` **0.0.7** on npm (trusted publishing, provenance
+attached). **In the currently published 0.0.7** it ships the working
 `ksor init` described below — including the visibility model and the deploy
-story — plus the CLI contract where `dev`, `build` AND `serve` still report
-"designed but not implemented" and exit `2`; an unknown verb is refused with
-exit `1` and a stable `error: unknown-verb` stderr slug. The package root
-exports `exitCodes`, `verbs`, and `resolveCommand`, and docs ship inside the
-tarball under `docs/`. (The kernel fold-in below makes `serve`/`ingest`/`schema`/
-`calibrate`/`gc` real — that lands in the NEXT release, 0.0.4, not 0.0.3.)
+story — AND the bundled content kernel: `serve`, `ingest`, `schema`, `grant`,
+`calibrate`, and `gc` all run from the one `ksor` binary. Only `dev` and
+`build` still report "designed but not implemented" and exit `2`; an unknown
+verb is refused with exit `1` and a stable `error: unknown-verb` stderr slug.
+The package root exports `exitCodes`, `verbs`, and `resolveCommand`, and docs
+ship inside the tarball under `docs/`.
 
-## Implemented (released in 0.0.3)
+Verified end to end against published 0.0.7 (2026-08-20, fresh `npm install`
+into a bare project, driven by a real MCP client over a live Neon Postgres and
+real Gemini embeddings): install · `schema` · `grant` · first `ingest` builds
+and flips · a **second ingest consumes nothing** ("unchanged — generation N
+already serves this corpus") · `serve` boots from `.env` alone · the server
+reports its real version · three MCP tools · `search` returns cited passages
+carrying their generation · `read` is byte-faithful. Two regressions repaired
+since 0.0.3 are covered by that walk: the version the server reported was inert
+(0.0.4 said `0.0.0`), and the scaffold's refresh script collided with pnpm's
+builtin `up`.
+
+## Implemented (released in 0.0.7)
 
 - **`ksor init`** — the first working verb, implemented red-first against
   the ratified spec (`specs/ksor/init/spec.md`). One command emits a
@@ -161,12 +172,10 @@ tarball under `docs/`. (The kernel fold-in below makes `serve`/`ingest`/`schema`
 
 - `ksor dev` / `build` — still exit `2` with an honest notice; the scaffold's
   own `pnpm dev` / `pnpm build` work today without them.
-  `ksor serve`, `ingest`, `schema`, `grant`, `calibrate`, `gc` ARE implemented — the
-  bundled kernel provides them from the one `ksor` binary. `serve` runs the
-  MCP server in-process (reads `./instance.md`; exits `3` with a remedy when
-  it is missing). Verified via a real `pnpm pack` → `npm install`. Not yet
-  released (pending the changesets release; the existing `@panaversity/ksor`
-  publish setup covers it — no new package to bootstrap).
+  `ksor serve`, `ingest`, `schema`, `grant`, `calibrate`, `gc` ARE implemented
+  and RELEASED in 0.0.7 — the bundled kernel provides them from the one `ksor`
+  binary. `serve` runs the MCP server in-process (reads `./instance.md`; exits
+  `3` with a remedy when it is missing).
 - Build provenance records (`build.lock.json`) — designed with `ksor build`.
 - Governed directives (`:::quiz` etc.) — no grammar ratified yet; shells
   pass them through as readable text (spec, deferred 2026-08-18).


### PR DESCRIPTION
## Problem

`docs/status.md` is the repo's declared *only authority on what is implemented*, and it was frozen at **0.0.3** — three releases stale. It still said `serve`/`ingest`/`schema`/`calibrate`/`gc` "exit 2" and would land "in the NEXT release, 0.0.4". They shipped, and 0.0.7 is on npm.

`README.md` had two matching falsehoods: it told adopters to `npx @panaversity/ksor serve` (the tool is a project dependency now, so the verb lives in their own scripts), and it flagged serve as "landing the release after the one you install".

## Solution

- **status.md** records 0.0.7 and what it contains, plus the end-to-end walk that verified it against the *published* package — fresh `npm install` into a bare project, real MCP client, live Neon Postgres, real Gemini embeddings. It names the two regressions 0.0.7 repaired (the inert reported version, the `pnpm up` collision with pnpm's builtin `update`) so the walk's coverage is auditable, not asserted.
- **README** golden path is now `cp .env.example .env` then `pnpm serve`. Adds the free-rerun behaviour (an unchanged record at the same commit consumes no generation and writes no rows) and keeps the calibrate step deliberate, so the README stops implying the abstention gate is on out of the box — it is off until a floor is measured.

## Behavior

No code changes: root `README.md` and `docs/status.md` only, so no changeset is owed (the gate watches `packages/ksor`). `pnpm guard` (8 rules) and `pnpm check:corpus` pass.

One thing worth recording from the verification walk: an out-of-corpus question against an instance with no `retrieval:` block does **not** abstain, and that is correct — the gate is off and the server says so. My first walk read that as a pass for the wrong reason (the test document was under the 250-char servable threshold, so nothing was returned for *any* query). Both surprises were fixture errors, not product defects; `search` returns cited passages carrying their generation once the document is long enough to be servable.