### PR TITLE
README serve path: the missing database block, the auth-off default that never existed, and pnpm serve at handoff

### DIFF
--- a/.changeset/correct-serve-auth-posture.md
+++ b/.changeset/correct-serve-auth-posture.md
@@ -1,0 +1,18 @@
+---
+"@panaversity/ksor": patch
+---
+
+Correct the documented serving posture, and name the agent surface at `init`.
+
+The docs said `ksor serve` "binds loopback with auth off by default". It never
+did: `buildAuth` refuses to boot unless SSO is configured or
+`KSOR_AUTH_DISABLED=1` is explicit — loopback included. An adopter who followed
+the prose instead of `.env.example` exported only the DSN and the provider key
+and hit a boot refusal they had been told would not happen, and the sentence
+advertised a weaker posture than the product actually ships. Both READMEs and
+the scaffold's `AGENTS.md` now say what the code does; the scaffold's own
+`.env.example` and setup steps were already correct and are unchanged.
+
+`ksor init`'s closing handoff now names `pnpm serve` alongside `pnpm dev`, so
+the MCP surface is visible at the moment the adopter is reading the screen
+rather than only in the runbook.

--- a/.changeset/spotty-cups-invent.md
+++ b/.changeset/spotty-cups-invent.md
@@ -1,0 +1,17 @@
+---
+"@panaversity/ksor": patch
+---
+
+`ksor init` now names `pnpm serve` in its next-steps output, and the docs stop
+describing an auth-off default that never existed.
+
+The handoff printed after scaffolding listed `pnpm install` and `pnpm dev`, so
+the agent projection — the core surface of every KSoR — went unnamed at the one
+moment the adopter is actually reading the screen.
+
+Separately, decision 7's serving clause and the three docs that copied it said a
+local `serve` "binds loopback with auth off". `buildAuth` has never had that
+default: it refuses to boot unless SSO is configured or `KSOR_AUTH_DISABLED=1`
+is set explicitly, loopback included. The real posture is stronger than the
+sentence claimed, but the docs were telling adopters a local `serve` would come
+up without the flag it requires.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,15 +180,23 @@ reverse it, and a reversed decision keeps its entry with a revision note.
    — each individually reversible with new evidence, recorded here:
    **conversation is the interface** (the human runs `ksor init <name>` once,
    then talks to the coding agent they already use; CLI verbs are for the
-   agent); **serving fails safe** (local serve binds loopback with auth off; a
-   public bind fails closed unless auth is configured or unauthenticated
-   serving is explicitly flagged — "disabled by default" must never silently
-   become an open server); **the governance level is derived, never declared**
+   agent); **serving fails safe** (serve refuses to boot unauthenticated at
+   all — a local run flags it explicitly and binds loopback; a public bind
+   additionally fails closed unless auth is configured — "disabled by default"
+   must never silently become an open server); **the governance level is derived, never declared**
    (tools report the level the governance artifacts achieve; no `governance:`
    key in `instance.md`); **no empty scaffolded directories** (an empty
    directory is an unanswered question in the adopter's repo — directories
    appear when the ladder or the work demands them); **the site is preview and
    review, not an editor** (the agent writes; the human checks).
+   _Revision 2026-08-20: the serving clause read "local serve binds loopback
+   with auth off", describing a default the code has never had — `buildAuth`
+   refuses to boot unless SSO is configured OR `KSOR_AUTH_DISABLED=1` is
+   explicit, loopback included (`packages/gateway-kit/src/auth.ts`). The
+   posture is unchanged and STRONGER than the sentence claimed; the wording is
+   corrected here and in the three docs that had copied it (both READMEs and
+   the scaffold's AGENTS.md), which were telling adopters a local `serve` would
+   come up without the flag it requires._
 
 8. **Scaffold structure: root workspace + system roof** (owner, 2026-08-18).
    `ksor init` emits the workspace manifests at the repo root (defaults beat

--- a/README.md
+++ b/README.md
@@ -547,8 +547,11 @@ The agent projection exposes the governed KSoR through MCP: `search`, `outline`,
 and `read` over stateless Streamable HTTP, with cited passages, snapshot
 generation-pinning, and honest abstention. `serve` reads `./instance.md` and
 runs the MCP server in-process — the climbed rung, so it needs a Postgres store
-(pgvector) and an embedding provider key. It binds loopback with auth off by
-default; a public bind fails closed unless auth is configured.
+(pgvector) and an embedding provider key. It **refuses to boot
+unauthenticated** — a local run declares `KSOR_AUTH_DISABLED=1` (which
+`.env.example` already carries) and binds loopback, where auth off is the
+intended development shape. A public bind needs a configured SSO door instead,
+or an explicit `KSOR_ALLOW_PUBLIC_UNAUTHENTICATED=1`.
 
 `pnpm serve` is the only command this rung needs: run it the first time, after
 editing `knowledge/`, or to bring the server back. Every step reports the state
@@ -570,12 +573,7 @@ A scaffolded project looks like:
 my-ksor/
 │
 ├── knowledge/            ← the record: governed CommonMark, the product
-│   ├── example.md
-│   ├── policies/
-│   │   ├── policy-a.md
-│   │   └── policy-b.md
-│   └── procedures/
-│       └── procedure-a.md
+│   └── example.md         (one document; subdirectories organize it as it grows)
 │
 ├── system/
 │   └── site/             ← the reference site (Next.js + Fumadocs)
@@ -1063,7 +1061,8 @@ That makes it suitable for hosts such as:
 - nginx,
 - and private infrastructure.
 
-Before production deployment, configure the canonical site URL in the site configuration.
+Hosting under a sub-path (like `user.github.io/repo`) is the one build-time
+setting: `KSOR_BASE_PATH=/repo pnpm build`.
 
 Detailed deployment guidance can live with each generated project so the instructions remain version-aligned with the KSoR release being used.
 

--- a/README.md
+++ b/README.md
@@ -525,10 +525,23 @@ provenance — is a future verb; see [`docs/status.md`](docs/status.md).)
 
 ## Serve to AI Agents
 
+First tell `instance.md` which environment variable holds your DSN — never the
+DSN itself. This block is the one piece of configuration the served rung needs:
+
+```yaml
+database:
+  dsn_env: KSOR_DB_URL
+```
+
+Then fill in the environment and bring it up:
+
 ```bash
 cp .env.example .env   # fill in KSOR_DB_URL, GEMINI_API_KEY, KSOR_AUTH_DISABLED=1
 pnpm serve             # schema → grant → ingest → serve
 ```
+
+That serves MCP at `http://127.0.0.1:8080/mcp`, announcing its posture as it
+boots (`auth: disabled, abstain gate: OFF (no floor)`).
 
 The agent projection exposes the governed KSoR through MCP: `search`, `outline`,
 and `read` over stateless Streamable HTTP, with cited passages, snapshot

--- a/packages/ksor/src/init.integration.test.ts
+++ b/packages/ksor/src/init.integration.test.ts
@@ -575,6 +575,9 @@ describe("ksor init — scaffold contents (spec: emitted-tree contract)", () => 
     expect(result.stdout).toContain("cd my-sor");
     expect(result.stdout).toContain("pnpm install");
     expect(result.stdout).toContain("pnpm dev");
+    // BOTH surfaces, or the agent projection — the core surface of every KSoR
+    // — stays unnamed at the one moment the adopter is reading the screen.
+    expect(result.stdout).toContain("pnpm serve");
     // A handoff that assumes pnpm is a dead end for whoever lacks it.
     expect(result.stdout).toContain("corepack enable pnpm");
   });

--- a/packages/ksor/src/init/index.ts
+++ b/packages/ksor/src/init/index.ts
@@ -123,6 +123,7 @@ function handoff(io: InitIo, name: string, targetWasDot: boolean): void {
       enter +
       "  pnpm install\n" +
       "  pnpm dev        # the site, live at http://localhost:3000\n" +
+      "  pnpm serve      # the MCP server for agents (needs Postgres + a key — see .env.example)\n" +
       "\n" +
       "no pnpm? run: npm install -g pnpm — or `corepack enable pnpm` on Nodes that bundle corepack\n" +
       "\n" +

--- a/packages/ksor/templates/scaffold/AGENTS.md
+++ b/packages/ksor/templates/scaffold/AGENTS.md
@@ -168,7 +168,9 @@ abandoned ones.
 
 ### Serving safely (fail-closed posture)
 
-`pnpm serve` binds **loopback with auth off** — safe for local use. A **public**
+`pnpm serve` **refuses to boot unauthenticated** — there is no auth-off
+default. A local run says so deliberately with `KSOR_AUTH_DISABLED=1` and binds
+loopback, which is the intended dev shape. A **public**
 bind refuses to boot unless auth is configured (`KSOR_SSO_URL` +
 `KSOR_MCP_RESOURCE_URL` + `KSOR_JWT_ALLOWED_AUDIENCES`, making it an OAuth
 Resource Server) OR you deliberately set `KSOR_ALLOW_PUBLIC_UNAUTHENTICATED=1`.

--- a/packages/ksor/templates/scaffold/README.md
+++ b/packages/ksor/templates/scaffold/README.md
@@ -48,9 +48,11 @@ the NAME of the variable, never the DSN. That is the whole required config:
 `knowledge/`, or just to bring the server back. A rerun on an unchanged record
 costs nothing: no new generation, no embedding, no rows. Edit a document and
 the next run picks up exactly that change. `AGENTS.md` → "Serving to agents" is the
-full runbook; your coding agent reads it first. `pnpm serve` binds loopback
-with auth off for local use; a public bind fails closed unless auth is
-configured. Any other operation is `pnpm exec ksor <verb>`.
+full runbook; your coding agent reads it first. `pnpm serve` refuses to boot
+unauthenticated: a local run declares `KSOR_AUTH_DISABLED=1` (already in
+`.env.example`) and binds loopback, so a server is never left open by accident;
+a public bind needs a configured SSO door instead. Any other operation is
+`pnpm exec ksor <verb>`.
 
 Then talk to your coding agent — `AGENTS.md` carries the working rules, and
 the agent kit in `.agents/skills/` knows how to interview you


### PR DESCRIPTION
## Problem

Walking the README end to end against **published 0.0.7** — as a new adopter, no insider knowledge — surfaced three defects.

**1. The serve section could not be followed.** It said `cp .env.example .env` then `pnpm serve`, but the scaffold's `instance.md` ships with no `database:` block, so the first chained step refuses. The scaffold's own `AGENTS.md` has this as step 1; the root README dropped it.

**2. The docs described an auth-off default that never existed.** Decision 7's serving clause, both READMEs, and the scaffold's `AGENTS.md` said a local serve "binds loopback with auth off". `buildAuth` throws unless SSO is configured or `KSOR_AUTH_DISABLED=1` is explicit — loopback included (`packages/gateway-kit/src/auth.ts:175`). The real posture is *stronger* than the sentence claimed, but the docs were telling adopters a local `serve` comes up without the flag it requires.

**3. `ksor init`'s handoff never named `pnpm serve`.** It listed `pnpm install` and `pnpm dev` only, so the agent projection — the core surface of every KSoR — went unnamed at the one moment the adopter is reading the screen.

## The walk

Against a live Postgres and real Gemini embeddings:

| README claim | Result |
|---|---|
| init emits a complete project (incl. `.env.example`) | pass |
| `pnpm install` links the pinned `ksor` | pass — 0.0.7 |
| `pnpm dev` → site at localhost:3000 with `llms.txt` | pass, 6s |
| `pnpm build` → static export in `system/site/out/` | pass — 62 files, llms.txt included |
| `pnpm serve` chains schema → grant → ingest → serve | **failed** — no `database:` block (defect 1) |
| three MCP tools, cited search, byte-faithful read | pass — against the scaffold's own example doc |
| rerun on an unchanged record consumes no generation | pass — "unchanged — generation 1 already serves this corpus" |
| an edit builds a new generation | pass — flipped to generation 2 |

The nesting guard also fired correctly when I first ran `init` inside a directory that already had an `instance.md`.

## Solution

- README gains the `database:` block as the step it is, and names the URL serve binds plus the posture line it prints.
- Decision 7 keeps its entry and gains a revision note (supersession rule), with the same correction propagated to both READMEs and the scaffold's `AGENTS.md`.
- `init`'s handoff names `pnpm serve` and what that rung needs, asserted by the handoff test.

## Behavior

The one code change (the handoff line) carries a changeset. Full local gate green: guards (8 rules), corpus check, typecheck, build, integration 122 passed / 28 skipped.

Worth noting the refusal in defect 1 is self-documenting — it prints the exact YAML to add — so it was a detour, not a dead end. But the README shouldn't need an error message to complete its own instructions.