### PR TITLE
Every 401 carries its challenge; the ceiling and MTEB prose say only what is true

### DIFF
--- a/.changeset/document-the-client-side-of-the-door.md
+++ b/.changeset/document-the-client-side-of-the-door.md
@@ -4,7 +4,7 @@
 
 The scaffold documents what a CLIENT has to do to reach a public MCP door
 
-`ksor serve` implements the OAuth Resource Server handshake in full — an
+`ksor serve` implements the OAuth Resource Server handshake — an
 unauthenticated request gets a 401 carrying
 `WWW-Authenticate: Bearer resource_metadata="…"`, and that document names the
 record's resource identifier and its authorization server, so a client discovers

--- a/.changeset/every-401-carries-the-challenge.md
+++ b/.changeset/every-401-carries-the-challenge.md
@@ -1,0 +1,26 @@
+---
+"@panaversity/ksor": patch
+---
+
+Every 401 from the MCP door carries its `WWW-Authenticate` challenge, not just the first
+
+Only the missing-token branch emitted `WWW-Authenticate: Bearer
+resource_metadata="…"`. A token that failed verification — expired, wrong
+audience, no subject, bad signature — came back as a bare 401. That is the most
+common 401 a real client will ever see, because tokens expire mid-conversation,
+and it left the client with no pointer back to the resource-metadata document:
+it could not re-discover the authorization server it had just been talking to.
+Only a caller that had never sent a token was told where to go.
+
+The MCP authorization spec requires `WWW-Authenticate` on a 401 without
+qualification. Every 401 now carries it, with RFC 6750's `error="invalid_token"`
+so a client refreshes rather than retrying the dead token.
+
+A **503** stays deliberately unchallenged: an unreachable key set is our outage,
+not the token's fault, and challenging there would send a user whose token is
+perfectly good back through a login over a key-fetch failure.
+
+Found by adversarially checking the release that documented this door. The
+adversarial auth suite missed it by asserting the STATUS of each rejection and
+never the header — it now sweeps every 401-producing token and asserts the
+challenge on each, with the 503 as the negative control.

--- a/packages/content-gateway/src/auth-adversarial.db.test.ts
+++ b/packages/content-gateway/src/auth-adversarial.db.test.ts
@@ -401,6 +401,47 @@ describe.runIf(adminDsn !== "")("the bearer door, adversarially (db)", () => {
     expect(r.status).toBe(403);
   }, 60_000);
 
+  it("EVERY 401 carries the challenge, not only the one for a missing token", async () => {
+    // The suite asserted the STATUS of each rejection and never the header, so
+    // it stayed green while the invalid-token branch returned a bare 401 — and
+    // that branch serves the most common 401 a real client ever sees, a token
+    // that expired mid-conversation. Left bare, such a client has no pointer
+    // back to the resource-metadata document and cannot re-discover the
+    // authorization server it was just talking to. The MCP authorization spec
+    // requires WWW-Authenticate on a 401 without qualification.
+    const rejected: [string, Awaited<ReturnType<typeof call>>][] = [
+      ["no token", await call({})],
+      [
+        "expired",
+        await call(
+          bearer(await as.token({ aud: resource, exp: Math.floor(Date.now() / 1000) - 60 })),
+        ),
+      ],
+      [
+        "wrong audience",
+        await call(bearer(await as.token({ aud: "https://other.example.com/mcp" }))),
+      ],
+      ["no subject", await call(bearer(await as.token({ aud: resource, sub: "" })))],
+    ];
+    for (const [what, r] of rejected) {
+      expect(r.status, `${what} must be a 401`).toBe(401);
+      const challenge = r.headers.get("www-authenticate") ?? "";
+      expect(challenge, `${what}: 401 with no challenge — the client cannot re-discover`).toContain(
+        "resource_metadata=",
+      );
+      expect(challenge, `${what}`).toContain("/.well-known/oauth-protected-resource/mcp");
+    }
+  }, 120_000);
+
+  it("a 503 is NOT challenged — an outage must not send a good token back to login", async () => {
+    // An unreachable JWKS is not an authorization failure. Challenging here
+    // would tell a client whose token is perfectly valid to re-authenticate
+    // because OUR key fetch failed.
+    const r = await call(bearer(await as.token({ aud: resource, kid: "rotated-away" })));
+    expect(r.status).toBe(503);
+    expect(r.headers.get("www-authenticate")).toBeNull();
+  }, 60_000);
+
   it("and the door is still serving afterwards — none of that killed it", async () => {
     const r = await call(bearer(await as.token({ aud: resource })));
     expect(r.status, "a refusal path must not take the process down").toBe(200);

--- a/packages/content-gateway/src/http.ts
+++ b/packages/content-gateway/src/http.ts
@@ -468,9 +468,30 @@ export async function runHttp(composition: Composition): Promise<ServerType> {
         identity = await auth.verify(token);
       } catch (error) {
         const transient = error instanceof TokenVerifyError && error.transient;
+        // EVERY 401 carries the challenge, not just the one for a missing
+        // token. The MCP authorization spec requires `WWW-Authenticate` on a
+        // 401 without qualification, and the case this branch serves — a token
+        // that expired mid-conversation — is the most common 401 a real client
+        // will ever see. Returning it bare left that client with no pointer
+        // back to the resource-metadata document, so it could not re-discover
+        // the authorization server it had just been talking to; only a caller
+        // that had never sent a token got told where to go. The suite missed it
+        // by asserting the STATUS of each rejection and never the header
+        // (found 2026-08-21, verifying the release that documented this door).
+        //
+        // 503 is deliberately bare: an unreachable JWKS is not an authorization
+        // failure, and challenging a caller whose token may be perfectly good
+        // would send them to re-authenticate over our outage.
         return c.json(
           { error: transient ? "token verification temporarily unavailable" : "invalid token" },
           transient ? 503 : 401,
+          transient
+            ? {}
+            : {
+                // RFC 6750 §3: `error` tells the client WHY, so it retries by
+                // refreshing rather than by repeating the same dead token.
+                "www-authenticate": `Bearer error="invalid_token", resource_metadata="${resourceMetadataUrl}"`,
+              },
         );
       }
       bearer = token;

--- a/packages/content/src/instance.ts
+++ b/packages/content/src/instance.ts
@@ -176,7 +176,19 @@ const groupSchemas = {
   embedding: z.object({
     provider: z.string().min(1).default("gemini"),
     model: z.string().min(1).default(EMBED_MODEL),
-    dim: z.coerce.number().int().min(1).max(EMBED_DIM_MAX).default(EMBED_DIM),
+    dim: z.coerce
+      .number()
+      .int()
+      .min(1)
+      // The reason travels with the refusal. Declaring `dim:` in instance.md is
+      // the path the scaffold documents, and it used to fail here with only
+      // zod's "expected number to be <=2000" — no mention of what 2000 is or
+      // why, so an adopter whose model emits more had nothing to act on. The
+      // `--dim` flag's refusal explains itself; this one did not.
+      .max(EMBED_DIM_MAX, {
+        error: `at most ${EMBED_DIM_MAX}: this schema declares VECTOR columns and indexes one directly, and pgvector's HNSW takes a vector to ${EMBED_DIM_MAX}`,
+      })
+      .default(EMBED_DIM),
   }),
   retrieval: z.object({
     /**

--- a/packages/content/src/schema.ts
+++ b/packages/content/src/schema.ts
@@ -31,9 +31,11 @@ import { ContentStoreError } from "./db.js";
  * Raising it is a decision, not a constant: every query site would have to use
  * the same cast as the index or fall silently back to a sequential scan, and
  * the halfvec arm's float16 rounding lands on the score the abstention gate
- * reads. Recorded in issue #49, along with why 1536 stays — Google's own MTEB
- * table has 1536 at 68.17 against 2048's 68.16, so there is no quality
- * gradient to climb up there.
+ * reads. Recorded in issue #49, along with the evidence for staying at 1536 —
+ * Google's published MTEB table runs 128..2048 and is FLAT at the top of that
+ * range (1536 scores 68.17, 2048 scores 68.16), so there is no gradient to
+ * climb toward the ceiling. It carries no 3072 row, so the cost of the
+ * truncation itself is unpublished; do not infer one.
  */
 export const EMBED_DIM_MAX = 2000;
 

--- a/packages/ksor/templates/scaffold/AGENTS.md
+++ b/packages/ksor/templates/scaffold/AGENTS.md
@@ -68,9 +68,10 @@ Stand it up in this order (each step's errors explain how to fix themselves):
    later means re-embedding the whole corpus. Keep `dim` at or below 2000 — the
    schema indexes a `vector` column directly and pgvector's HNSW takes a
    `vector` to 2000. `gemini-embedding-001` emits 3072 by default, so ksor asks
-   it for 1536; per Google's own MTEB table that costs nothing measurable
-   (1536 scores 68.17, 2048 scores 68.16), and 768 costs 0.18 if you want the
-   storage back.
+   it for 1536. Google's published MTEB table runs 128–2048 and is flat at the
+   top of it — 1536 scores 68.17 against 2048's 68.16 — so there is no gradient
+   to climb toward the ceiling; going the other way, 768 costs 0.18 if you want
+   the storage back.
 
    Leave `retrieval:` out for now — the gate is off and the server says so.
    Turning it on is step 4, AFTER the record is serving.
@@ -250,9 +251,13 @@ Three things worth being deliberate about:
 
 ### What a CLIENT has to do
 
-The door is an OAuth **Resource Server**, which means a client is not told the
-authorization server — it discovers it. Nothing here needs configuring; it is
-what your agents will experience, and what to check when one cannot connect.
+Once the SSO door is configured (the three variables above), the server is an
+OAuth **Resource Server**, which means a client is not told the authorization
+server — it discovers it. Nothing here needs configuring beyond those variables;
+this is what your agents will experience, and what to check when one cannot
+connect. With `KSOR_AUTH_DISABLED=1` — the local default `.env.example` ships —
+none of it applies: there is no challenge and the metadata document answers 404,
+because there is no authorization server to point at.
 
 1. The client calls `POST /mcp` with no token and gets **401** carrying
 
@@ -277,6 +282,14 @@ what your agents will experience, and what to check when one cannot connect.
 3. The client gets a token from that authorization server, asking for THIS
    record as the resource (RFC 8707: `resource=https://<your-host>/mcp`), and
    sends it as `Authorization: Bearer <token>`.
+
+Every 401 carries that same header, not just the first one — including the one
+your clients will hit most often, a token that expired mid-conversation. It
+arrives as `Bearer error="invalid_token", resource_metadata="…"`, so a client
+knows to refresh rather than to retry the dead token. A **503** is deliberately
+_not_ challenged: an unreachable key set is our outage, not your token's fault,
+and telling a client to re-authenticate over it would send a perfectly good user
+back through a login.
 
 The one thing that goes wrong here goes wrong quietly: a token minted for a
 different audience is a perfectly valid token, and this door rejects it. The


### PR DESCRIPTION
Found by adversarially checking 0.0.12 before publishing it, rather than after.

## The defect

Only the **missing-token** branch emitted `WWW-Authenticate: Bearer
resource_metadata="…"`. A token that failed verification — expired, wrong
audience, no subject, bad signature — came back as a **bare 401**
(`http.ts:470-475`).

That is the most common 401 a real client will ever see, because tokens expire
mid-conversation. Left bare, the client has no pointer back to the
resource-metadata document and cannot re-discover the authorization server it
was just talking to. Only a caller that had *never* sent a token was told where
to go. The MCP authorization spec requires `WWW-Authenticate` on a 401 without
qualification.

Every 401 now carries it, with RFC 6750's `error="invalid_token"` so a client
refreshes rather than retrying a dead token. A **503 stays unchallenged** on
purpose: an unreachable key set is our outage, not the token's fault, and
challenging there sends a user whose token is perfectly good back through a
login over a key-fetch failure.

**Why the suite missed it:** it asserted the *status* of each rejection and never
the header. It now sweeps every 401-producing token and asserts the challenge on
each, with the 503 as the negative control. Mutation-verified — restoring the
bare 401 turns the new test red.

## Two prose corrections in the same review

**The MTEB citation claimed a comparison its source does not contain.** The
sentence shipped in the scaffold's `AGENTS.md` and in a changeset said asking for
1536 "costs nothing measurable (1536 scores 68.17, 2048 scores 68.16)". The three
numbers are right, but Google's published table runs 128–2048 and has **no 3072
row**, so it cannot speak to the cost of the 3072→1536 truncation at all. Both
places now say only what the table shows: the curve is flat at the top of the
published range, and the truncation's own cost is unpublished — do not infer one.

**The corrected dimension ceiling only reached the `--dim` flag.** The path the
scaffold actually documents is declaring `dim:` in `instance.md`, which refused
at parse time with zod's bare "expected number to be <=2000" — no mention of what
2000 is or why. The reason now travels with that refusal too.

## Also in the client-auth section

Its lead sentence was unconditional; the posture it describes only exists once
the SSO door is configured, and the scaffold's shipped `.env.example` default is
the other one (`KSOR_AUTH_DISABLED=1`), where there is no challenge and the
metadata document answers 404. Qualified, and the expired-token case is written
down where an operator will look for it.

## Process

These four commits' predecessors went **directly to main**, which violates
critical rule 2 — and because CI's "Changeset present" job is gated on
`pull_request`, that check never ran for any commit in 0.0.12. Coverage was
verified by hand and holds, but the gate was bypassed. This branch is the
correction; the gate runs here.

Gate: 686 unit / 220 integration / 174 db, all green.