### PR TITLE
Refuse without naming the database

### DIFF
--- a/.changeset/refuse-without-naming-the-database.md
+++ b/.changeset/refuse-without-naming-the-database.md
@@ -1,0 +1,37 @@
+---
+"@panaversity/ksor": patch
+---
+
+A 503 refusal no longer puts the database host and user on the wire
+
+When the deferred boot checks fail, `/mcp` refuses with the thrown error's
+message in full under `data.detail`. For the three authored failures that is the
+point — a too-old schema, a governance violation and a text-search mismatch each
+carry a multi-line remedy the operator has to act on. But the catch treated every
+error alike, and `pg` writes the host, its resolved address, the port and the
+database user into its connection and authentication failures. Those went out
+verbatim to any caller who could reach the door.
+
+What may leave is now decided in one place and by TYPE, not by inspecting
+message text: a class we wrote is a class whose words we control. A driver error
+is refused with its class named and its text withheld, and the caller is told
+which kind of failure it is — infrastructure, not their request.
+
+The full text still reaches the operator, deliberately: the refusal says the
+reason is in the server's logs, and the deferred-boot line recorded only the
+error's NAME, so before this the real message existed nowhere. That is also why
+the boot checks are not sanitised at their source — reducing a driver error to a
+class name early would destroy the one copy anyone can act on.
+
+**The test that covered this was holding it in place.** It asserted that
+`http.ts` contains the literal string `data: { detail: message }` — so the leak
+was pinned by an assertion with reasoning attached. Grepping source is the right
+instrument for "does this check run before dispatch", because position is a
+property of source, and the wrong one for "what does the response contain".
+Response contents are now asserted against real bodies, including a `pg`-shaped
+connection failure whose host, address, port and user must all be absent.
+
+Verified live: a gateway pointed at an unreachable database answers
+`the content store is unavailable (Error)` with no host, port, user or database
+name anywhere in the body, while the server log carries
+`connect ECONNREFUSED 127.0.0.1:59999` in full.

--- a/packages/content-gateway/src/deferred-boot.integration.test.ts
+++ b/packages/content-gateway/src/deferred-boot.integration.test.ts
@@ -44,10 +44,21 @@ describe("deferred boot checks gate the door, not just the probe", () => {
     ).toBeLessThan(handler.indexOf("mcpHandler.fetch"));
   });
 
-  it("refuses with 503 and names the reason, rather than a bare error", () => {
-    expect(HTTP).toContain("this record cannot be served:");
-    expect(HTTP, "a refusal an operator can act on carries the full remedy").toContain(
-      "data: { detail: message }",
+  it("builds the refusal body through the one function that decides what may leave", () => {
+    // Deliberately NOT an assertion about the body's contents. This file greps
+    // source, which is the right instrument for "does the check sit before
+    // dispatch" — position is a property of source — and the wrong one for
+    // "what does the response contain".
+    //
+    // It was used for both, and that is how the leak survived: the old
+    // assertion required the literal string `data: { detail: message }` in
+    // http.ts, so a test with reasoning attached PINNED a driver error's host,
+    // address, port and database user onto the wire. What goes in the body is
+    // now asserted against real bodies in refusal-body.test.ts; all this may
+    // legitimately check is that the handler routes through it.
+    expect(HTTP, "the 503 body must not be assembled inline again").toContain("refusalBody(error)");
+    expect(HTTP, "and the full text must still reach the operator's logs").toContain(
+      "refusing requests — boot checks failing",
     );
   });
 

--- a/packages/content-gateway/src/http.ts
+++ b/packages/content-gateway/src/http.ts
@@ -44,6 +44,7 @@ import {
   UNDESCRIBED_RECORD,
   withoutSdkResponseModeWarning,
 } from "./boot-report.js";
+import { refusalBody } from "./refusal-body.js";
 import { buildServer, recordIsUndescribed } from "./server.js";
 import type { Composition } from "./compose.js";
 
@@ -387,19 +388,27 @@ export async function runHttp(composition: Composition): Promise<ServerType> {
       try {
         await verifyBoot();
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        return new Response(
-          JSON.stringify({
-            jsonrpc: "2.0",
-            error: {
-              code: -32001,
-              message: `this record cannot be served: ${message.split("\n")[0]}`,
-              data: { detail: message },
-            },
-            id: null,
-          }),
-          { status: 503, headers: { "content-type": "application/json" } },
+        // LOG in full, ANSWER in the minimum. Which messages may go on the wire
+        // is decided in one place and by type — see refusal-body.ts. It used to
+        // be decided here by not deciding: the thrown error's message went out
+        // whoever threw it, so a `pg` connection failure put the database host,
+        // its resolved address, the port and the database user into an API
+        // response.
+        //
+        // The logging half is not decoration. The refusal tells the operator the
+        // reason is in the server's logs, and the deferred-boot line records
+        // only the error's NAME — so without this the full text existed nowhere
+        // and the refusal would be pointing at an empty page. This is also why
+        // the boot checks are NOT sanitised at their source: reducing a driver
+        // error to its class name before it reaches here would destroy the one
+        // copy an operator can act on.
+        console.error(
+          `refusing requests — boot checks failing: ${error instanceof Error ? (error.stack ?? error.message) : String(error)}`,
         );
+        return new Response(JSON.stringify(refusalBody(error)), {
+          status: 503,
+          headers: { "content-type": "application/json" },
+        });
       }
     }
     const response = await mcpHandler.fetch(request, authInfo === undefined ? {} : { authInfo });

--- a/packages/content-gateway/src/refusal-body.test.ts
+++ b/packages/content-gateway/src/refusal-body.test.ts
@@ -1,0 +1,96 @@
+/**
+ * What a 503 refusal is allowed to put on the wire.
+ *
+ * The deferred-boot refusal returns the thrown error's message in full, under
+ * `data.detail`. For the three AUTHORED failures that is the point — a schema
+ * that is too old, a governance violation, or a text-search mismatch each carry
+ * a multi-line remedy an operator has to act on, and truncating it to one line
+ * would be the "errors are documentation" principle broken at the moment it
+ * matters most.
+ *
+ * A DRIVER error is a different thing on the same channel. `pg` writes the host,
+ * the port, the resolved address and the database user into its connection and
+ * authentication failures, and `storedTextSearchConfig` queried the pool with no
+ * catch at all, so those went out verbatim.
+ *
+ * The test that covered this asserted the leak: it grepped `http.ts` for the
+ * literal string `data: { detail: message }`. That is a legitimate way to pin
+ * where a check SITS — position is a property of source — and the wrong way to
+ * pin what a response CONTAINS. So the defect was held in place by an assertion
+ * with reasoning attached. Payloads need a real response; this file builds one.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { GovernanceGateError, SchemaVersionError } from "@panaversity/ksor-content";
+
+import { refusalBody } from "./refusal-body.js";
+
+/** A pg connection failure, in the shape the driver actually produces. */
+const driverError = (): Error =>
+  Object.assign(
+    new Error(
+      'connection to server at "ep-secret-corp-9f2.eu-central-1.aws.neon.tech" (10.4.7.22), ' +
+        'port 5432 failed: FATAL: password authentication failed for user "sor_content_runtime"',
+    ),
+    { code: "28P01" },
+  );
+
+const SECRETS = [
+  "ep-secret-corp-9f2",
+  "neon.tech",
+  "10.4.7.22",
+  "5432",
+  "sor_content_runtime",
+  "password authentication",
+];
+
+describe("an authored refusal carries its whole remedy", () => {
+  it("keeps the multi-line detail — that IS the fix instruction", () => {
+    const authored = new SchemaVersionError(
+      "database schema is 2.1; this build requires >= 2.4.\n" +
+        "Run `ksor schema --instance instance.md --apply` to migrate it forward.",
+    );
+    const body = refusalBody(authored);
+    expect(body.error.message).toContain("this record cannot be served:");
+    expect(body.error.data?.detail, "the operator needs the second line").toContain(
+      "ksor schema --instance instance.md --apply",
+    );
+    expect(body.error.data?.detail).toBe(authored.message);
+  });
+
+  it("does the same for a governance refusal", () => {
+    const body = refusalBody(new GovernanceGateError("a document declares visibility:\nfix: …"));
+    expect(body.error.data?.detail).toContain("fix:");
+  });
+});
+
+describe("a driver error is refused WITHOUT its detail", () => {
+  it("puts no host, address, port or database user on the wire", () => {
+    const serialized = JSON.stringify(refusalBody(driverError()));
+    for (const secret of SECRETS) {
+      expect(serialized, `leaked ${secret} into a 503 body:\n${serialized}`).not.toContain(secret);
+    }
+  });
+
+  it("still refuses, and still says the record cannot be served", () => {
+    const body = refusalBody(driverError());
+    expect(body.error.message).toContain("this record cannot be served");
+    expect(body.error.code).toBe(-32001);
+  });
+
+  it("says the class of failure and where to look, instead of nothing", () => {
+    // Honest absence, never silent weakness: the caller learns this is an
+    // infrastructure fault rather than their request, and the operator is sent
+    // to the place the real message IS written.
+    const body = refusalBody(driverError());
+    expect(body.error.message.toLowerCase()).toMatch(/unavailable|store/);
+    expect(body.error.data?.detail, "no detail at all beats a leaked one").toBeUndefined();
+  });
+
+  it("treats an unknown non-Error throw the same way", () => {
+    const serialized = JSON.stringify(refusalBody("postgres://user:hunter2@db.internal/x"));
+    expect(serialized).not.toContain("hunter2");
+    expect(serialized).not.toContain("db.internal");
+  });
+});

--- a/packages/content-gateway/src/refusal-body.ts
+++ b/packages/content-gateway/src/refusal-body.ts
@@ -1,0 +1,80 @@
+/**
+ * The body of a deferred-boot refusal, and the one decision inside it: whose
+ * message may go on the wire.
+ *
+ * Three AUTHORED failures carry a remedy written for the operator —
+ * `SchemaVersionError`, `GovernanceGateError`, `TextSearchConfigMismatch`. Their
+ * whole multi-line message is the point; a caller that receives only the first
+ * line has been told a problem exists and not how to end it.
+ *
+ * Everything else reaching this catch is infrastructure — most of it straight
+ * from `pg`, whose connection and authentication failures name the host, the
+ * resolved address, the port and the database user. Those went out verbatim
+ * under `data.detail`, because the catch treated every error alike.
+ *
+ * So the split is by TYPE, not by message inspection: a class we wrote is a
+ * class whose text we control. A driver error is refused with its class named
+ * and its text withheld — the operator finds the real message in the server's
+ * own logs, which is where an infrastructure fault belongs.
+ */
+
+import {
+  GovernanceGateError,
+  SchemaVersionError,
+  TextSearchConfigMismatch,
+} from "@panaversity/ksor-content";
+
+/** The JSON-RPC error envelope a 503 refusal returns. */
+export interface RefusalBody {
+  readonly jsonrpc: "2.0";
+  readonly error: {
+    readonly code: number;
+    readonly message: string;
+    readonly data?: { readonly detail: string };
+  };
+  readonly id: null;
+}
+
+/**
+ * Did WE write this error's text?
+ *
+ * Named classes only. Matching on message prose would put the decision back
+ * inside the strings it is meant to police, and a reworded driver error would
+ * quietly re-open the leak.
+ */
+function isAuthored(error: unknown): error is Error {
+  return (
+    error instanceof SchemaVersionError ||
+    error instanceof GovernanceGateError ||
+    error instanceof TextSearchConfigMismatch
+  );
+}
+
+export function refusalBody(error: unknown): RefusalBody {
+  if (isAuthored(error)) {
+    return {
+      jsonrpc: "2.0",
+      error: {
+        code: -32001,
+        message: `this record cannot be served: ${error.message.split("\n")[0] ?? ""}`,
+        data: { detail: error.message },
+      },
+      id: null,
+    };
+  }
+  // The class name is safe and useful — it distinguishes "your request was
+  // fine, our store is not" from a refusal the caller could act on — and it is
+  // the same reduction `ContentStoreError` already applies on the serving path.
+  const kind = error instanceof Error ? error.name : "Error";
+  return {
+    jsonrpc: "2.0",
+    error: {
+      code: -32001,
+      message:
+        `this record cannot be served: the content store is unavailable (${kind}). ` +
+        "The reason is in this server's logs; it is withheld here because a driver " +
+        "error names the database host and user.",
+    },
+    id: null,
+  };
+}


### PR DESCRIPTION
From the review's A1/B6. Verified, with one departure from the prescription and a
note on severity.

## The leak

`handleMcp`'s deferred-boot catch put the thrown error's message on the wire in
full (`data.detail`). `pg` writes the host, resolved address, port and database
user into connection and authentication failures, and `storedTextSearchConfig`
queries the pool with no catch at all, so those went out verbatim.

**Severity, stated honestly:** this is after bearer verification in public mode,
and `/ready` maps the same promise to a boolean and leaks nothing. So it is
disclosure of internal topology to an *authenticated* caller, not to the
internet. Real, worth fixing now, not an emergency.

## The review's best point, which is not the leak

The test at `deferred-boot.integration.test.ts:47-52` asserted that `http.ts`
contains the literal `data: { detail: message }`. The defect was **held in place
by an assertion with reasoning attached**. That file makes eight assertions and
every one greps source — legitimate for "does the check sit before dispatch",
because position is a property of source, and wrong for "what does the response
contain".

So the rule this lands: **source-string assertions may pin structure; payloads
need a real response.** Response contents move to `refusal-body.test.ts`, which
builds real bodies from a `pg`-shaped failure and asserts host, address, port and
user are all absent. The old file keeps only the routing check.

## Where I departed from the proposed fix

The review suggested routing `assertSchemaCompatible` and
`storedTextSearchConfig` through the sanitised path. I did not, and the reason is
the refusal's own promise: it tells the operator the reason is in the logs, and
the deferred-boot line records only the error's **name** — so the full text
existed nowhere. Sanitising at the source would have destroyed the one copy
anyone can act on and made the refusal point at an empty page.

**Log in full, answer in the minimum**, decided once at the boundary where the
wire is. One decision point rather than two competing ones.

## Live

A gateway pointed at an unreachable database:

- body: `this record cannot be served: the content store is unavailable (Error).
  The reason is in this server's logs; it is withheld here because a driver error
  names the database host and user.` — no host, port, user or database name.
- log: `refusing requests — boot checks failing: Error: connect ECONNREFUSED
  127.0.0.1:59999`

Mutation-verified: restoring the undifferentiated catch turns three tests red.

Gate: 692 unit / 220 integration / 174 db.