### PR TITLE
The audience-binding guard checks each call, not a total

### DIFF
--- a/.changeset/sharpen-the-audience-binding-guard.md
+++ b/.changeset/sharpen-the-audience-binding-guard.md
@@ -1,0 +1,10 @@
+---
+---
+
+Test-only: no shipped behaviour changed, so this deliberately carries no version
+bump. `audience-binding.integration.test.ts` asserted its guarantee by counting
+`runRead(` against `audienceScope(ctx)` and comparing totals, which cannot tell
+pairing from arithmetic — two bindings on one call and none on another satisfies
+it exactly (verified: counts stay 6 === 6 while one serving read is unscoped).
+Each call is now inspected inside its own window, bounded by the next call rather
+than by a fixed span, and a failure names the line.

--- a/packages/content/src/lib/audience-binding.integration.test.ts
+++ b/packages/content/src/lib/audience-binding.integration.test.ts
@@ -5,13 +5,28 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 /**
- * Every serving path in service.ts must bind the caller's audience scope.
+ * Every serving path in service.ts must bind the caller's audience scope — a
+ * SHAPE check, deliberately, and not the guarantee itself.
  *
  * `runRead` binds the whole-record scope by default, which keeps library and
  * test callers working — and means a SERVING path that forgets to narrow would
  * silently serve every tier. The SQL backstop cannot catch that, because the
- * default IS bound. So the binding is asserted here, on the source, where the
- * omission would happen.
+ * default IS bound. So the presence of a binding on every call is asserted here,
+ * on the source, where the omission would happen — and this file runs without a
+ * database, so a newly added unscoped read fails fast and locally.
+ *
+ * What it is NOT: the behavioural guarantee. That lives in
+ * `governance-chain.db.test.ts`, which ingests real markdown, serves it through
+ * these same functions at two tiers, and asserts what each tier can and cannot
+ * see. Replacing `audienceScope`'s body with the whole-record sentinel — the
+ * exact fail-open decision 15 exists to end — turns five of its tests red
+ * (re-verified 2026-08-21). Read that file for the promise; read this one for
+ * the shape.
+ *
+ * The distinction is the point. Asserting a payload by grepping source is how a
+ * defect once came to be PINNED by a test (the 503 that named the database
+ * host, refusal-body.test.ts). Source assertions may pin structure; behaviour
+ * needs the real thing.
  */
 const SERVICE = readFileSync(
   path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "service.ts"),
@@ -19,16 +34,30 @@ const SERVICE = readFileSync(
 );
 
 describe("every serving read narrows to the caller's audience", () => {
-  it("binds audienceScope on each runRead in the serving paths", () => {
-    // Each `runRead(` in service.ts is a path that returns record content.
-    const calls = SERVICE.split("runRead(").length - 1;
-    const scoped = SERVICE.split("audienceScope(ctx)").length - 1;
-    expect(calls, "service.ts still has serving reads").toBeGreaterThan(0);
+  it("binds audienceScope on EACH runRead — per call, not by counting", () => {
+    // Counting `runRead(` against `audienceScope(ctx)` and comparing totals was
+    // the old check, and totals cannot tell pairing from arithmetic: two
+    // bindings on one call and none on another satisfies it exactly. Each call
+    // is now inspected on its own.
+    const calls = [...SERVICE.matchAll(/runRead\(/g)].map((m) => m.index ?? 0);
+    expect(calls.length, "service.ts still has serving reads").toBeGreaterThan(0);
+
+    // Each call's window ends where the NEXT one begins — never a fixed span. A
+    // generous fixed window is exactly the bug this test is replacing: two of
+    // these calls sit thirteen lines apart, so a 900-character window let the
+    // second one's binding vouch for the first one's absence.
+    const unscoped = calls
+      .map((at, i) => ({
+        at,
+        line: SERVICE.slice(0, at).split("\n").length,
+        window: SERVICE.slice(at, calls[i + 1] ?? SERVICE.length),
+      }))
+      .filter(({ window }) => !window.includes("audienceScope(ctx)"));
+
     expect(
-      scoped,
-      `${calls} runRead call(s) in service.ts but only ${scoped} bind audienceScope(ctx) — ` +
-        "an unscoped serving read returns the whole record",
-    ).toBe(calls);
+      unscoped.map((u) => `service.ts:${u.line}`),
+      "an unscoped serving read returns the WHOLE record, whatever tier the caller is",
+    ).toEqual([]);
   });
 
   it("keeps the sentinel out of service.ts — the door narrows, it never widens", () => {


### PR DESCRIPTION
The review's PR 3 rested on this guarantee being untested. **It isn't** — I
re-ran the mutation before writing anything.

Replacing `audienceScope`'s body with the whole-record sentinel — the door
handing itself every tier on every serving path, the exact fail-open decision 15
exists to end — turns **five tests red** in `governance-chain.db.test.ts`:

```
LINK 2 — a PUBLIC door cannot search, read or outline the internal document
the outline's positions do not leak that a hidden sibling exists
an UNIDENTIFIED caller gets the least-privileged tier, not the whole record
a PUBLIC document under an INTERNAL parent is reachable, not merely citable
the tiers DIFFER — an assertion satisfied by both would prove nothing
```

That hole was found in round 8 and closed in round 8. All three serving
functions (`search`, `readDocument`, `outlineDocuments`) bind on all six reads,
and all three are covered behaviourally. So the proposed per-function work is
already done, and this PR does not do it.

## What was real

The source-counting test is a poor instrument that reads like the guard:

```ts
const calls  = SERVICE.split("runRead(").length - 1;
const scoped = SERVICE.split("audienceScope(ctx)").length - 1;
expect(scoped).toBe(calls);
```

Totals cannot tell pairing from arithmetic. Proved by mutation: move one call's
binding into another call's window and the counts stay **6 === 6** — green —
while a serving read is genuinely unscoped.

Each call is now inspected inside its own window, and a failure names the line
(`service.ts:612`). The window is bounded by the *next* call rather than a fixed
span — my first attempt used 900 characters, which two calls thirteen lines
apart would have defeated, letting one binding vouch for its neighbour's absence.

The file's docstring now says what it is and is not: the shape lives here, the
promise lives in `governance-chain.db.test.ts`. That distinction is the one this
week's 503 leak taught — a payload asserted by grepping source is how a defect
came to be pinned by a test.

**Empty changeset on purpose**: nothing shipped changed.

Gate: 692 unit / 220 integration / 174 db.