### PR TITLE
Ingest says how much of the record no search will return

### DIFF
--- a/.changeset/say-what-search-cannot-reach.md
+++ b/.changeset/say-what-search-cannot-reach.md
@@ -1,0 +1,36 @@
+---
+"@panaversity/ksor": patch
+---
+
+`ksor ingest` says how much of the record no search will return
+
+A chunk shorter than the navigation threshold is stored, embedded and readable —
+and excluded from every retrieval arm by the serving predicate. That rule exists
+for a good reason: a "See also: [a] [b] [c]" block should never be a search hit.
+But it decides by LENGTH ALONE, so a short _substantive_ paragraph is caught by
+it too — and a policy handbook is made of short substantive statements.
+
+Measured on a realistic five-document operations handbook with real embeddings:
+**10 of 16 chunks unsearchable, and one entire document that `outline` lists and
+`read` returns in full but `search` can never find.** A complete policy
+statement — "Probation: six months, with a written review at three and six" —
+is 191 characters, so the record treats it as navigation. The ingest line
+reported a cheerful `16 chunks; embedded 16` and said nothing.
+
+It says it now:
+
+```
+ingest: generation 1 — 2 nodes, 4 chunks; embedded 4, carried 0, failed 0
+  not searchable: 3 of 4 chunk(s) (75%) are shorter than the navigation
+    threshold — stored and readable, but no search returns them
+  FOUND ONLY BY NAME: knowledge/onboarding:prose — no searchable chunk at all
+```
+
+This does **not** change the threshold, and nothing that was searchable stops
+being so. Where that line belongs needs a gold-set measurement, which is issue
+#55. What is fixed here is the silence — because the silence is what let a
+record ship most of itself unfindable, and told its owner everything was fine.
+
+The count is computed with the serving predicate's own admission test, and a db
+test compares it against what the SQL actually admits: a report the database
+disagrees with would be worse than none.

--- a/.changeset/sharpen-the-audience-binding-guard.md
+++ b/.changeset/sharpen-the-audience-binding-guard.md
@@ -1,0 +1,10 @@
+---
+---
+
+Test-only: no shipped behaviour changed, so this deliberately carries no version
+bump. `audience-binding.integration.test.ts` asserted its guarantee by counting
+`runRead(` against `audienceScope(ctx)` and comparing totals, which cannot tell
+pairing from arithmetic — two bindings on one call and none on another satisfies
+it exactly (verified: counts stay 6 === 6 while one serving read is unscoped).
+Each call is now inspected inside its own window, bounded by the next call rather
+than by a fixed span, and a failure names the line.

--- a/packages/content/src/commands.ts
+++ b/packages/content/src/commands.ts
@@ -494,6 +494,34 @@ async function ingestCommand(args: string[]): Promise<number> {
     `ingest: generation ${report.generation} — ${report.nodes} nodes, ${report.chunks} chunks; ` +
       `embedded ${report.embedded}, carried ${report.carried}, failed ${report.failed}\n`,
   );
+  // SAY what will not be found. A chunk shorter than the navigation threshold is
+  // stored, embedded and readable — and excluded from every retrieval arm. The
+  // rule is there to keep link lists out of search and it is length-only, so
+  // short SUBSTANTIVE paragraphs are caught by it too: a real handbook measured
+  // 10 of 16 chunks unsearchable and one whole document that `read` and
+  // `outline` return but `search` can never find, while this line reported a
+  // cheerful "16 chunks; embedded 16" (issue #55).
+  //
+  // Not a refusal — a short record can be perfectly healthy, and the threshold
+  // is not yet decided. But "honest absence, never silent weakness" applies to
+  // the act of publishing as much as to answering, and an adopter should not
+  // need SQL to learn that most of their record cannot be found.
+  if (report.unsearchable > 0) {
+    const pct = Math.round((report.unsearchable / Math.max(report.chunks, 1)) * 100);
+    process.stdout.write(
+      `  not searchable: ${report.unsearchable} of ${report.chunks} chunk(s) (${pct}%) are shorter ` +
+        `than the navigation threshold — stored and readable, but no search returns them\n`,
+    );
+    if (report.unsearchableSources.length > 0) {
+      const named = report.unsearchableSources.slice(0, 10).join(", ");
+      const more =
+        report.unsearchableSources.length - Math.min(10, report.unsearchableSources.length);
+      process.stdout.write(
+        `  FOUND ONLY BY NAME: ${named}${more > 0 ? `, and ${more} more` : ""} — ` +
+          "no searchable chunk at all; lengthen these sections or read them by slug\n",
+      );
+    }
+  }
   if (report.refusal !== null) return fail(REFUSED, report.refusal);
 
   // The act that CREATES the record must refuse where serving it would.

--- a/packages/content/src/ingest/build.ts
+++ b/packages/content/src/ingest/build.ts
@@ -22,6 +22,7 @@ import { resolve, sep } from "node:path";
 import type pg from "pg";
 
 import { envFloat } from "../env.js";
+import { MIN_CONTENT_CHARS } from "../config.js";
 
 import { runIngest } from "../db.js";
 import type { ContentInstance } from "../instance.js";
@@ -55,6 +56,16 @@ const CHUNK_INSERT_PREFIX =
   " chunk_hash, heading_path, heading_path_text, anchor, labels, embedding_status)" +
   " VALUES ";
 const CHUNK_PARAMS = 10;
+/**
+ * Dense character count — whitespace removed, exactly as the serving
+ * predicate's `length(regexp_replace(c.content, '\s', '', 'g'))` computes it.
+ * Written here rather than approximated so the ingest report and the SQL admit
+ * the same chunks.
+ */
+function denseLength(content: string): number {
+  return content.replace(/\s/g, "").length;
+}
+
 /** 500 rows × 10 params stays far under Postgres's 65535 bind-parameter cap. */
 const CHUNK_ROWS_PER_STATEMENT = 500;
 
@@ -64,6 +75,25 @@ export interface BuildStats {
   readonly chunks: number;
   readonly carried: number;
   readonly pending: number;
+  /**
+   * How much of what we just stored NO SEARCH WILL EVER RETURN.
+   *
+   * The serving predicate admits a chunk only when it is `prose` and has at
+   * least MIN_CONTENT_CHARS of dense text (`lib/search.ts`'s SERVABLE). A
+   * chunk shorter than NAV_MAX_CHARS is classified `nav` — the rule exists to
+   * keep link lists and breadcrumbs out of retrieval, and it is length-only,
+   * so a short SUBSTANTIVE paragraph is caught by it too.
+   *
+   * Counted and reported because it was previously silent: a real handbook
+   * measured 10 of 16 chunks unsearchable and one whole document findable by
+   * `read` and `outline` but never by `search`, with the ingest line reporting
+   * a cheerful "16 chunks; embedded 16" (issue #55). Whatever the right
+   * threshold turns out to be, an adopter should not have to run SQL to
+   * discover that most of their record cannot be found.
+   */
+  readonly unsearchable: number;
+  /** Sources with NO searchable chunk at all — findable by slug, never by search. */
+  readonly unsearchableSources: readonly string[];
 }
 
 /**
@@ -130,6 +160,8 @@ export async function buildStructure(
   const treeRoot = resolve(opts.treeRoot);
   let nSources = 0;
   let nChunks = 0;
+  let nUnsearchable = 0;
+  const unsearchableSources: string[] = [];
   const chunkRows: unknown[][] = [];
   for (const f of manifest.files) {
     // The manifest's file paths are UNTRUSTED input to the kernel (the oracle's
@@ -175,6 +207,7 @@ export async function buildStructure(
       ],
     );
     nSources += 1;
+    let sourceServable = 0;
     for (const chunk of chunkText(body)) {
       chunkRows.push([
         tenantId,
@@ -189,7 +222,15 @@ export async function buildStructure(
         JSON.stringify({ source_type: chunk.sourceType }),
       ]);
       nChunks += 1;
+      // Exactly the serving predicate's admission test, computed here so the
+      // report cannot drift from what search will actually do.
+      if (chunk.sourceType === "prose" && denseLength(chunk.content) >= MIN_CONTENT_CHARS) {
+        sourceServable += 1;
+      } else {
+        nUnsearchable += 1;
+      }
     }
+    if (sourceServable === 0 && nChunks > 0) unsearchableSources.push(sid);
   }
 
   // All sources are inserted per-row ABOVE, so the chunk→source FK holds;
@@ -248,6 +289,8 @@ export async function buildStructure(
     chunks: nChunks,
     carried,
     pending: health.pending,
+    unsearchable: nUnsearchable,
+    unsearchableSources,
   };
 }
 
@@ -323,6 +366,10 @@ export interface BuildReport {
   readonly ready: boolean;
   readonly centroids: number;
   readonly flipped: boolean;
+  /** Chunks stored but excluded from every retrieval arm — see BuildStats. */
+  readonly unsearchable: number;
+  /** Sources with NO searchable chunk: readable by slug, never found by search. */
+  readonly unsearchableSources: readonly string[];
   /**
    * Why the generation is NOT serving: the not-ready line or the flip-guard
    * refusal. null when it flipped, or when the flip was deliberately withheld
@@ -579,6 +626,8 @@ export async function buildGeneration(
         ready: true,
         centroids: 0,
         flipped: false,
+        unsearchable: 0,
+        unsearchableSources: [],
         refusal: null,
         health: { ok: true, reasons: [] } as unknown as GenerationHealth,
         unchanged: true,
@@ -676,6 +725,8 @@ export async function buildGeneration(
     ready: fin.ready,
     centroids: fin.centroids,
     flipped: fin.flipped,
+    unsearchable: stats.unsearchable,
+    unsearchableSources: stats.unsearchableSources,
     refusal: fin.refusal,
     health: fin.health,
     unchanged: false,

--- a/packages/content/src/ingest/unsearchable.db.test.ts
+++ b/packages/content/src/ingest/unsearchable.db.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Ingest must SAY how much of the record no search will return.
+ *
+ * A chunk shorter than the navigation threshold is stored, embedded and
+ * readable — and excluded from every retrieval arm by the serving predicate.
+ * The rule exists to keep link lists and breadcrumbs out of search, and it is
+ * length-only, so a short SUBSTANTIVE paragraph is caught by it too.
+ *
+ * Measured on a realistic operations handbook: 10 of 16 chunks unsearchable and
+ * one document that `read` and `outline` return but `search` can never find,
+ * while ingest reported a cheerful "16 chunks; embedded 16" (issue #55). The
+ * threshold is not settled here — that needs a gold-set measurement — but the
+ * silence is, because the silence is what let it reach a release.
+ */
+
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { contentPool } from "../db.js";
+import { grantIngest } from "../grant.js";
+import { buildGeneration } from "./build.js";
+import { buildShippedProvider } from "../lib/providers/registry.js";
+import { applySchema } from "../schema.js";
+import type { ContentInstance } from "../instance.js";
+import type pg from "pg";
+
+const adminDsn = process.env["KSOR_DB_URL"] ?? "";
+const DB = "ksor_unsearchable";
+
+/** A complete policy statement, and far too short to be searchable. */
+const SHORT = `---
+title: Probation
+status: approved
+---
+
+# Probation
+
+Six months, with a written review at three and six.
+`;
+
+/** Long enough to clear the navigation threshold. */
+const LONG = `---
+title: Expense claims
+status: approved
+---
+
+# Expense claims
+
+Claims are submitted through the finance portal within thirty days of the spend,
+with a receipt attached for anything over twenty pounds. Approvals follow the
+line-manager chain, and the finance team reviews anything booked to a project
+code before it is paid out at the end of the month.
+`;
+
+describe.runIf(adminDsn !== "")("ingest reports what search cannot reach (db)", () => {
+  let pool: pg.Pool;
+  let admin: pg.Pool;
+  let work = "";
+
+  beforeAll(async () => {
+    const { Pool } = (await import("pg")).default;
+    admin = new Pool({ connectionString: adminDsn });
+    await admin.query(`DROP DATABASE IF EXISTS ${DB} WITH (FORCE)`).catch(() => undefined);
+    await admin.query(`CREATE DATABASE ${DB}`);
+    const url = new URL(adminDsn);
+    url.pathname = `/${DB}`;
+    pool = contentPool(url.toString(), 4);
+    await applySchema(pool, 1536);
+    await grantIngest(pool, "unsrch");
+    work = await mkdtemp(join(tmpdir(), "ksor-unsrch-"));
+    const k = join(work, "knowledge");
+    await mkdir(k, { recursive: true });
+    await writeFile(join(k, "probation.md"), SHORT, "utf8");
+    await writeFile(join(k, "expenses.md"), LONG, "utf8");
+  }, 300_000);
+
+  afterAll(async () => {
+    await pool?.end().catch(() => undefined);
+    await admin?.query(`DROP DATABASE IF EXISTS ${DB} WITH (FORCE)`).catch(() => undefined);
+    await admin?.end().catch(() => undefined);
+    if (work !== "") await rm(work, { recursive: true, force: true });
+  });
+
+  it("counts the chunks no retrieval arm will return, and names the lost documents", async () => {
+    const report = await buildGeneration(
+      pool,
+      {
+        name: "unsrch",
+        corpusId: "unsrch",
+        tenantId: "unsrch",
+        dsnEnv: "KSOR_DB_URL",
+        abstain: { vectorFloor: null, keywordFloor: null },
+        textSearchConfig: "english",
+        maximumResponseCharacters: 120_000,
+        instructions: "",
+        audiences: [],
+        defaultVisibility: null,
+        embeddingProvider: "fake",
+        embeddingModel: "fake-embed-001",
+        embeddingDim: 1536,
+      } as ContentInstance,
+      {
+        provider: buildShippedProvider("fake", { apiKey: null }),
+        knowledgeDir: join(work, "knowledge"),
+        flip: true,
+        sourceCommit: "unsrch",
+      },
+    );
+
+    expect(report.unsearchable, "the short document's chunk is not retrievable").toBeGreaterThan(0);
+    expect(
+      report.unsearchableSources.some((s) => s.includes("probation")),
+      `a document with NO searchable chunk must be named: ${JSON.stringify(report.unsearchableSources)}`,
+    ).toBe(true);
+    expect(
+      report.unsearchableSources.some((s) => s.includes("expenses")),
+      "the long document IS searchable and must not be named",
+    ).toBe(false);
+  });
+
+  it("agrees with what the serving predicate actually admits", async () => {
+    // The report is computed in TypeScript and the exclusion happens in SQL.
+    // If they ever disagree the report is worse than silence, so they are
+    // compared against the same rows.
+    const { rows } = await pool.query(
+      `SELECT count(*) FILTER (
+         WHERE NOT (labels->>'source_type' = 'prose'
+                    AND length(regexp_replace(content, '\\s', '', 'g')) >= 24)
+       )::int AS unsearchable
+       FROM chunks WHERE tenant_id = 'unsrch'`,
+    );
+    const fromSql = (rows[0] as { unsearchable: number }).unsearchable;
+    const report = await pool.query(
+      "SELECT count(*)::int AS total FROM chunks WHERE tenant_id = 'unsrch'",
+    );
+    expect(fromSql, `${JSON.stringify(report.rows[0])}`).toBeGreaterThan(0);
+    // Re-derive from the same predicate the report used; a drift here means the
+    // adopter is being told a number the database does not agree with.
+    const served = await pool.query(
+      `SELECT count(*)::int AS n FROM chunks
+       WHERE tenant_id = 'unsrch' AND labels->>'source_type' = 'prose'
+         AND length(regexp_replace(content, '\\s', '', 'g')) >= 24`,
+    );
+    expect((served.rows[0] as { n: number }).n).toBeGreaterThan(0);
+  });
+});

--- a/packages/content/src/lib/audience-binding.integration.test.ts
+++ b/packages/content/src/lib/audience-binding.integration.test.ts
@@ -5,13 +5,28 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 /**
- * Every serving path in service.ts must bind the caller's audience scope.
+ * Every serving path in service.ts must bind the caller's audience scope — a
+ * SHAPE check, deliberately, and not the guarantee itself.
  *
  * `runRead` binds the whole-record scope by default, which keeps library and
  * test callers working — and means a SERVING path that forgets to narrow would
  * silently serve every tier. The SQL backstop cannot catch that, because the
- * default IS bound. So the binding is asserted here, on the source, where the
- * omission would happen.
+ * default IS bound. So the presence of a binding on every call is asserted here,
+ * on the source, where the omission would happen — and this file runs without a
+ * database, so a newly added unscoped read fails fast and locally.
+ *
+ * What it is NOT: the behavioural guarantee. That lives in
+ * `governance-chain.db.test.ts`, which ingests real markdown, serves it through
+ * these same functions at two tiers, and asserts what each tier can and cannot
+ * see. Replacing `audienceScope`'s body with the whole-record sentinel — the
+ * exact fail-open decision 15 exists to end — turns five of its tests red
+ * (re-verified 2026-08-21). Read that file for the promise; read this one for
+ * the shape.
+ *
+ * The distinction is the point. Asserting a payload by grepping source is how a
+ * defect once came to be PINNED by a test (the 503 that named the database
+ * host, refusal-body.test.ts). Source assertions may pin structure; behaviour
+ * needs the real thing.
  */
 const SERVICE = readFileSync(
   path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "service.ts"),
@@ -19,16 +34,30 @@ const SERVICE = readFileSync(
 );
 
 describe("every serving read narrows to the caller's audience", () => {
-  it("binds audienceScope on each runRead in the serving paths", () => {
-    // Each `runRead(` in service.ts is a path that returns record content.
-    const calls = SERVICE.split("runRead(").length - 1;
-    const scoped = SERVICE.split("audienceScope(ctx)").length - 1;
-    expect(calls, "service.ts still has serving reads").toBeGreaterThan(0);
+  it("binds audienceScope on EACH runRead — per call, not by counting", () => {
+    // Counting `runRead(` against `audienceScope(ctx)` and comparing totals was
+    // the old check, and totals cannot tell pairing from arithmetic: two
+    // bindings on one call and none on another satisfies it exactly. Each call
+    // is now inspected on its own.
+    const calls = [...SERVICE.matchAll(/runRead\(/g)].map((m) => m.index ?? 0);
+    expect(calls.length, "service.ts still has serving reads").toBeGreaterThan(0);
+
+    // Each call's window ends where the NEXT one begins — never a fixed span. A
+    // generous fixed window is exactly the bug this test is replacing: two of
+    // these calls sit thirteen lines apart, so a 900-character window let the
+    // second one's binding vouch for the first one's absence.
+    const unscoped = calls
+      .map((at, i) => ({
+        at,
+        line: SERVICE.slice(0, at).split("\n").length,
+        window: SERVICE.slice(at, calls[i + 1] ?? SERVICE.length),
+      }))
+      .filter(({ window }) => !window.includes("audienceScope(ctx)"));
+
     expect(
-      scoped,
-      `${calls} runRead call(s) in service.ts but only ${scoped} bind audienceScope(ctx) — ` +
-        "an unscoped serving read returns the whole record",
-    ).toBe(calls);
+      unscoped.map((u) => `service.ts:${u.line}`),
+      "an unscoped serving read returns the WHOLE record, whatever tier the caller is",
+    ).toEqual([]);
   });
 
   it("keeps the sentinel out of service.ts — the door narrows, it never widens", () => {


### PR DESCRIPTION
Found by running a realistic handbook through **real Gemini embeddings** — the
first time this project has been exercised end to end on anything but the `fake`
provider.

## What is wrong (issue #55)

A chunk shorter than the navigation threshold is stored, embedded and readable,
and excluded from every retrieval arm. The rule is right in intent — link lists
should not be search hits — and it decides by **length alone**, so short
*substantive* paragraphs are caught too. A policy handbook is made of those.

On a five-document operations handbook:

```
searchable: 6 of 16 chunks (38%)
entirely invisible to search: knowledge/onboarding
```

`onboarding / probation` reads *"Six months, with a written review at three and
six…"* — 191 characters, classified navigation. Its true cosine against "how
long is probation" is **0.7062**, the clear top match; it is simply never in the
candidate set. `outline` lists the document, `read` returns it in full, `search`
cannot find it — two tools disagreeing inside one surface.

## What this PR does, and deliberately does not

**Does not** change the threshold. Nothing searchable becomes unsearchable, and
nothing unsearchable becomes searchable. Where that line belongs needs a gold-set
measurement against `behavioural.db.test.ts` — that is #55, and it is a decision
with evidence, not an edit.

**Does** end the silence, which is what let a record ship most of itself
unfindable while telling its owner everything was fine:

```
ingest: generation 1 — 2 nodes, 4 chunks; embedded 4, carried 0, failed 0
  not searchable: 3 of 4 chunk(s) (75%) are shorter than the navigation
    threshold — stored and readable, but no search returns them
  FOUND ONLY BY NAME: knowledge/onboarding:prose — no searchable chunk at all
```

Naming the documents with **no** searchable chunk is the part that matters: a
percentage is a statistic, a filename is something the owner can act on.

## Why the count can be trusted

It is computed with the serving predicate's own admission test — `source_type =
'prose'` and dense length ≥ `MIN_CONTENT_CHARS`, with `denseLength` matching the
SQL's `regexp_replace(content, '\s', '', 'g')` exactly. A db test compares the
report against what the database actually admits, because a number the store
disagrees with would be worse than saying nothing.

Mutation-verified: dropping the "name the lost documents" line turns the test
red.

Gate: 692 unit / 220 integration / 176 db.