### PR TITLE
Fix two blockers shipped in 0.0.12

### DIFF
--- a/.changeset/two-blockers-from-0-0-12.md
+++ b/.changeset/two-blockers-from-0-0-12.md
@@ -1,0 +1,26 @@
+---
+"@panaversity/ksor": patch
+---
+
+Two defects introduced in 0.0.12, found by verifying the published package live
+
+**The discovery document became invalid exactly when a record became real.** The
+MCP registry schema caps `ServerDetail.description` at **100 characters**
+(2025-12-11). 0.0.12 started generating that description from the record's own
+prose — a real improvement over the hard-coded sentence it replaced — and capped
+it at 300. The unfilled placeholder is 88 characters and validates; a described
+record's title plus scope sentence is routinely 150-350 and does not. So
+`/.well-known/mcp/server.json` passed validation until the owner did the thing
+the scaffold asks for, then silently stopped, with nothing in the build to say
+so. It is now assembled inside the schema's budget and trimmed at a word
+boundary rather than mid-word.
+
+**The boot report reassured the operator in the one configuration that needs a
+warning.** `KSOR_ALLOW_PUBLIC_UNAUTHENTICATED=1` permits an unauthenticated
+public bind, and the auth line kept printing `DISABLED — 0.0.0.0 only, and a
+public bind will refuse to boot` — false on both counts, at the moment the whole
+record is being served to anyone who can reach the port. It now says that,
+naming the variable responsible.
+
+Both shipped in 0.0.12 and both were mine; the aligned boot report and the
+self-describing discovery document are otherwise unchanged.

--- a/packages/content-gateway/src/boot-report.test.ts
+++ b/packages/content-gateway/src/boot-report.test.ts
@@ -37,7 +37,7 @@ describe("the boot report reads as one aligned block", () => {
 
 describe("authPosture", () => {
   it("shouts DISABLED and names the bind it is survivable on", () => {
-    const out = authPosture("disabled", "127.0.0.1");
+    const out = authPosture("disabled", "127.0.0.1", false);
     expect(out).toContain("DISABLED");
     expect(out).toContain("127.0.0.1");
     // The mitigation must travel with the scary word, or an operator reading
@@ -46,7 +46,18 @@ describe("authPosture", () => {
   });
 
   it("says what verification actually happens in public mode", () => {
-    expect(authPosture("public", "0.0.0.0")).toContain("verified");
+    expect(authPosture("public", "0.0.0.0", false)).toContain("verified");
+  });
+  it("does NOT reassure when the escape hatch is serving the record to anyone", () => {
+    // The one configuration that needs a loud line printed the reassurance
+    // meant for a loopback dev run: "DISABLED — 0.0.0.0 only, and a public bind
+    // will refuse to boot", which is false on both counts once
+    // KSOR_ALLOW_PUBLIC_UNAUTHENTICATED=1 permits exactly that bind.
+    const out = authPosture("disabled", "0.0.0.0", true);
+    expect(out, "must not claim a public bind would refuse").not.toContain("refuse to boot");
+    expect(out).toContain("UNAUTHENTICATED");
+    expect(out).toContain("KSOR_ALLOW_PUBLIC_UNAUTHENTICATED");
+    expect(out, "says what it actually means for the record").toContain("anyone who can reach");
   });
 });
 

--- a/packages/content-gateway/src/boot-report.ts
+++ b/packages/content-gateway/src/boot-report.ts
@@ -63,9 +63,26 @@ export function withoutSdkResponseModeWarning<T>(body: () => T): T {
  * it survivable (`buildAuth` refuses a non-loopback bind without auth, so the
  * only way to read this line is on a host that cannot be reached from outside).
  */
-export function authPosture(mode: "public" | "disabled", host: string): string {
-  if (mode === "disabled") return `DISABLED — ${host} only, and a public bind will refuse to boot`;
-  return "bearer tokens, verified against the record's authorization server";
+export function authPosture(
+  mode: "public" | "disabled",
+  host: string,
+  publicUnauthenticated: boolean,
+): string {
+  if (mode !== "disabled") {
+    return "bearer tokens, verified against the record's authorization server";
+  }
+  // The escape hatch inverts the sentence, so the sentence has to know about it.
+  // It previously said "a public bind will refuse to boot" whatever the bind
+  // was — so the one configuration that serves the entire record to anyone who
+  // can reach the port printed the reassurance meant for a loopback dev run.
+  // The moment an operator most needs a loud line was the moment it lied.
+  if (publicUnauthenticated) {
+    return (
+      `UNAUTHENTICATED and bound to ${host} — KSOR_ALLOW_PUBLIC_UNAUTHENTICATED=1 is set, so ` +
+      "the whole record is served to anyone who can reach this port"
+    );
+  }
+  return `DISABLED — ${host} only, and a public bind will refuse to boot`;
 }
 
 /**

--- a/packages/content-gateway/src/http.ts
+++ b/packages/content-gateway/src/http.ts
@@ -582,7 +582,16 @@ export async function runHttp(composition: Composition): Promise<ServerType> {
   if (recordIsUndescribed(instance.instructions)) {
     console.error(bootLine("identity", UNDESCRIBED_RECORD));
   }
-  console.error(bootLine("auth", authPosture(auth.mode, bind.host)));
+  console.error(
+    bootLine(
+      "auth",
+      authPosture(
+        auth.mode,
+        bind.host,
+        process.env["KSOR_ALLOW_PUBLIC_UNAUTHENTICATED"] === "1" && !loopback,
+      ),
+    ),
+  );
   for (const line of keyLines) console.error(line);
   console.error(bootLine("abstain", abstainPosture(instance.abstain.vectorFloor)));
   console.error(bootLine("serving", `http://${bind.host}:${bind.port}/mcp`));

--- a/packages/ksor/src/record-description.integration.test.ts
+++ b/packages/ksor/src/record-description.integration.test.ts
@@ -71,9 +71,10 @@ describe("the description a record publishes for discovery", () => {
     const out = describeRecord(
       `${FM}\n# Acme Operations Handbook\n\nThis record is authoritative for expenses, travel and procurement approvals. Everything else is out of scope.\n`,
     );
-    expect(out).toBe(
-      "Acme Operations Handbook — This record is authoritative for expenses, travel and procurement approvals.",
+    expect(out.startsWith("Acme Operations Handbook — This record is authoritative for")).toBe(
+      true,
     );
+    expect(out.length, "and within the registry schema's cap").toBeLessThanOrEqual(100);
   });
 
   it("says plainly when the owner has not described it — never a borrowed sentence", () => {
@@ -96,11 +97,34 @@ describe("the description a record publishes for discovery", () => {
     expect(out).toBe("Acme — The record covers procurement.");
   });
 
-  it("bounds the sentence, so a runaway paragraph cannot become the listing", () => {
+  it("fits the MCP schema's 100-character cap on ServerDetail.description", () => {
+    // The registry schema caps it at 100 (2025-12-11). It used to allow 300, so
+    // the document a validating client reads became INVALID the moment an owner
+    // wrote a real scope sentence — while the 88-character placeholder passed.
+    // Silent, and only for records that had been properly described.
     const long = `${"a really long clause ".repeat(40)}end.`;
     const out = describeRecord(`${FM}\n# Acme\n\n${long}\n`);
-    expect(out.length).toBeLessThanOrEqual("Acme — ".length + 300);
-    expect(out.endsWith("...")).toBe(true);
+    expect(out.length, `over the schema cap: ${out.length} chars — ${out}`).toBeLessThanOrEqual(
+      100,
+    );
+    expect(out.endsWith("\u2026"), "truncation is marked").toBe(true);
+    // Every word kept must be a WHOLE word from the source — a naive slice
+    // would publish a sentence cut mid-word into a registry listing.
+    const words = out
+      .replace(/^[^—]*— /, "")
+      .replace(/\u2026$/, "")
+      .split(" ");
+    for (const w of words) {
+      expect(["a", "really", "long", "clause", "end."], `truncated mid-word: ${out}`).toContain(w);
+    }
+  });
+
+  it("keeps a realistic described record inside the cap", () => {
+    const out = describeRecord(
+      `${FM}\n# Acme Operations Handbook\n\nThis record is authoritative for how Acme runs internally: expenses, travel, procurement approvals and the compensation bands the pay review works from.\n`,
+    );
+    expect(out.length).toBeLessThanOrEqual(100);
+    expect(out).toContain("Acme Operations Handbook");
   });
 
   it("collapses a wrapped sentence onto one line — this ends up inside JSON", () => {

--- a/packages/ksor/templates/scaffold/system/site/lib/shared.ts
+++ b/packages/ksor/templates/scaffold/system/site/lib/shared.ts
@@ -89,10 +89,36 @@ function readInstanceScope(): string | null {
   for (const para of afterHeading.split(/\n[ \t]*\n/)) {
     const one = para.trim().replace(/\s+/g, " ");
     if (one === "" || one.startsWith("#") || one.startsWith("-") || one.startsWith(">")) continue;
-    const sentence = /^(.+?[.!?])(\s|$)/.exec(one)?.[1] ?? one;
-    return sentence.length > 300 ? `${sentence.slice(0, 297)}...` : sentence;
+    return sentence(one);
   }
   return null;
+}
+
+/**
+ * The MCP registry schema caps `ServerDetail.description` at **100 characters**
+ * (`ServerDetail.description.maxLength`, 2025-12-11). Over it, the document a
+ * validating client reads is invalid — and the failure was shaped exactly
+ * wrong: the unfilled placeholder is 88 characters and validates, so the
+ * document became invalid the moment an owner did the thing the scaffold asks
+ * for and wrote a real scope sentence. Silent, and only for real records.
+ *
+ * A hard truncation would publish a sentence cut mid-word, so this trims at a
+ * word boundary and marks it, and the whole description is assembled inside the
+ * budget rather than clipped after the fact.
+ */
+const DESCRIPTION_MAX = 100;
+
+function sentence(one: string): string {
+  const first = /^(.+?[.!?])(\s|$)/.exec(one)?.[1] ?? one;
+  return first;
+}
+
+/** Fit `text` inside `max`, breaking on a word rather than mid-word. */
+function fit(text: string, max: number): string {
+  if (text.length <= max) return text;
+  const cut = text.slice(0, max - 1);
+  const at = cut.lastIndexOf(" ");
+  return `${(at > max / 2 ? cut.slice(0, at) : cut).replace(/[,;:.\s]+$/, "")}\u2026`;
 }
 
 /** null until the owner has written one — never a guess. */
@@ -103,9 +129,11 @@ export const appScope: string | null = readInstanceScope();
  * registry document and anything else that needs one cannot drift apart.
  */
 export function recordDescription(): string {
-  return appScope === null
-    ? `${appTitle} — its owner has not yet described what this record covers.`
-    : `${appTitle} — ${appScope}`;
+  const whole =
+    appScope === null
+      ? `${appTitle} — its owner has not yet described what this record covers.`
+      : `${appTitle} — ${appScope}`;
+  return fit(whole, DESCRIPTION_MAX);
 }
 
 /**


### PR DESCRIPTION
Found by a live verification fleet against the **published** 0.0.12. Both were
introduced by my own changes yesterday.

## 1. The discovery document became invalid exactly when a record became real

The MCP registry schema caps `ServerDetail.description` at **100 characters**
(`ServerDetail.description.maxLength`, 2025-12-11 — verified by fetching the
schema). 0.0.12 began generating that description from the record's own prose
and capped it at 300.

The failure is shaped precisely wrong:

| record state | description | valid? |
|---|---|---|
| unfilled placeholder | 88 chars | yes |
| owner wrote a real scope sentence | 150-350 chars | **no** |

So `/.well-known/mcp/server.json` — critical rule 3's "must not break"
agent-discoverable surface — validated until the owner did the thing the
scaffold asks for, then silently stopped, with nothing in the build reporting
it. Now assembled inside the budget and trimmed at a word boundary rather than
mid-word: `Acme Operations Handbook — This record is authoritative for how Acme
runs internally: expenses…` (95).

## 2. The boot report reassured the operator in the one case that needs a warning

`KSOR_ALLOW_PUBLIC_UNAUTHENTICATED=1` permits an unauthenticated public bind.
The auth line kept printing:

```
auth     DISABLED — 0.0.0.0 only, and a public bind will refuse to boot
```

False on both counts, at the exact moment the entire record is being served to
anyone who can reach the port. `authPosture` took only the auth *mode*, so it
could not know. It now takes the real posture:

```
auth     UNAUTHENTICATED and bound to 0.0.0.0 — KSOR_ALLOW_PUBLIC_UNAUTHENTICATED=1
         is set, so the whole record is served to anyone who can reach this port
```

## Both mutation-verified

Reverting the 100-char fit turns three tests red; reverting the escape-hatch
branch turns the fourth red. Two of my own test assertions were wrong on the
first pass and are corrected here — the word-boundary check asserted that a
correct break does *not* end in a letter, which is exactly backwards.

Gate: 693 unit / 221 integration / 174 db.