### PR TITLE
An outage is not an abstention; calibrate stops blessing far-domain evidence

### DIFF
--- a/.changeset/an-outage-is-not-an-abstention.md
+++ b/.changeset/an-outage-is-not-an-abstention.md
@@ -1,0 +1,36 @@
+---
+"@panaversity/ksor": patch
+---
+
+A provider outage is never reported as "the record does not cover this"
+
+When the embedding provider is down, the vector arm does not run — so an empty
+result says nothing about coverage. It says we could not look. That distinction
+was fixed once for records with a calibrated floor, and the condition was the
+bug: it left the case out that matters most.
+
+An **uncalibrated** record is the default state of every fresh scaffold. There
+the emptiness came from the keyword arm, which abstains when it returns no rows
+— and it returns nothing for almost every natural-language question, because
+`websearch_to_tsquery` ANDs its terms (measured 12 of 12 on real questions). So
+during any outage an uncalibrated record answered every question with
+`abstained: true`, while the tool description instructs the agent to state that
+as fact and never fall back on its own knowledge.
+
+It reached this release because the existing test asked a question the keyword
+arm could answer, so the degraded path served real hits and looked correct. Ask
+the way a person asks and it did not. That case is now covered.
+
+Found live against the published 0.0.12 with an invalid key — the same state a
+rejected CI key had produced that morning, which is how likely this is.
+
+**`ksor calibrate` also stops blessing a floor on far-domain evidence alone.**
+The built-in out-of-corpus probes are all far-domain — dinner, taxes, boiling an
+egg — and a shipped set cannot be scope-adjacent, because adjacency depends on a
+corpus it has never seen. Far-domain probes score low against anything, so the
+margin comes out inflated. Measured on one record, changing only the probe set:
+built-ins reported "separable, margin 0.072" and recommended a floor; eight
+scope-adjacent near-misses reported "NOT separable, margin -0.030" — and that
+floor then answered six of the eight live, with citations. The tool already knew
+to say "widen the probe set", but said it only on the not-separable branch, which
+is when it is least needed. It now says it whenever the built-ins are used.

--- a/packages/content/src/calibrate/fixtures/math.ts
+++ b/packages/content/src/calibrate/fixtures/math.ts
@@ -1480,6 +1480,7 @@ export const fixture: MathFixture = {
         model: "gemini-embedding-001",
         dim: 1536,
         door: "synthesized",
+        oocSource: "built-in",
       },
       target_precision: 0.95,
       expected: {
@@ -1488,6 +1489,7 @@ export const fixture: MathFixture = {
         model: "gemini-embedding-001",
         dim: 1536,
         door: "synthesized",
+        ooc_source: "built-in",
         in_corpus_queries: 6,
         ooc_probes: 4,
         aurc: 0.0926,
@@ -1592,7 +1594,7 @@ export const fixture: MathFixture = {
         ],
       },
       rendered:
-        "\nmeasured on generation 3 (served), model gemini-embedding-001, door: synthesized\nCAVEAT: synthesized queries are written FROM the passages they are then scored against, so they share vocabulary a reader's question will not. This door measures an UPPER BOUND on separation \u2014 treat the floor below as provisional until it has been checked against questions the corpus did not write (--queries-file), and re-run if real questions score under it.\nAURC = 0.0926  (lower = better separation)\nseparation margin: 0.054 (over 6 in-corpus / 4 out-of-corpus probes)\nzero-FA floor (never refuse a real question): 0.664 -> coverage 0.600, ooc leak 0.000\nALT (0.95-precision): floor = 0.664 -> coverage 0.600\nweakest in-corpus queries (these set the floor):\n  0.664  what pins a citation to a generation\n  0.680  how is the corpus version derived\n  0.690  how are chunks kept overlap-free\n  0.710  how does the abstention gate decide\n  0.730  what does the build lock record\n\nseparable: max OOC 0.610 < min in-corpus 0.664; midpoint has margin both ways\nPaste into instance.md:\n  vector_floor: 0.637   # calibrated 2026-08-21 on generation 3, model gemini-embedding-001/d1536, door: synthesized\n",
+        "\nmeasured on generation 3 (served), model gemini-embedding-001, door: synthesized\nCAVEAT: synthesized queries are written FROM the passages they are then scored against, so they share vocabulary a reader's question will not. This door measures an UPPER BOUND on separation \u2014 treat the floor below as provisional until it has been checked against questions the corpus did not write (--queries-file), and re-run if real questions score under it.\nCAVEAT: the out-of-corpus probes are the BUILT-IN set, which is entirely far-domain \u2014 a shipped set cannot be scope-adjacent, because adjacency depends on a corpus it has never seen. Far-domain probes score low against anything, so this margin is an OVER-estimate and a floor it blesses may still answer near-misses just outside your scope. Re-run with --ooc-file naming questions a reader might plausibly ask that this record does NOT cover, and trust that verdict over this one.\nAURC = 0.0926  (lower = better separation)\nseparation margin: 0.054 (over 6 in-corpus / 4 out-of-corpus probes)\nzero-FA floor (never refuse a real question): 0.664 -> coverage 0.600, ooc leak 0.000\nALT (0.95-precision): floor = 0.664 -> coverage 0.600\nweakest in-corpus queries (these set the floor):\n  0.664  what pins a citation to a generation\n  0.680  how is the corpus version derived\n  0.690  how are chunks kept overlap-free\n  0.710  how does the abstention gate decide\n  0.730  what does the build lock record\n\nseparable: max OOC 0.610 < min in-corpus 0.664; midpoint has margin both ways\nPaste into instance.md:\n  vector_floor: 0.637   # calibrated 2026-08-21 on generation 3, model gemini-embedding-001/d1536, door: synthesized\n",
     },
     {
       name: "queries-file door, generation None, not separable, no alt floor",
@@ -1624,6 +1626,7 @@ export const fixture: MathFixture = {
         model: "some-model@768",
         dim: 768,
         door: "queries-file",
+        oocSource: "built-in",
       },
       target_precision: 0.95,
       expected: {
@@ -1632,6 +1635,7 @@ export const fixture: MathFixture = {
         model: "some-model@768",
         dim: 768,
         door: "queries-file",
+        ooc_source: "built-in",
         in_corpus_queries: 2,
         ooc_probes: 2,
         aurc: 0.2708,
@@ -1691,7 +1695,7 @@ export const fixture: MathFixture = {
         ],
       },
       rendered:
-        "\nmeasured on generation unknown (no generation pinned) (served), model some-model@768, door: queries-file\nCAVEAT: --queries-file floors are measured on human/gold-derived queries \u2014 section-weighted eval targets, NOT per-node passage samples \u2014 so this floor's low tail is a different distribution than the synthesized door's; record 'door: queries-file' beside the number and never compare the two doors' floors as interchangeable.\nAURC = 0.2708  (lower = better separation)\nseparation margin: -0.040 (over 2 in-corpus / 2 out-of-corpus probes)\nzero-FA floor (never refuse a real question): 0.580 -> coverage 0.750, ooc leak 0.333\nALT (0.95-precision): floor = 0.720 -> coverage 0.250\nweakest in-corpus queries (these set the floor):\n  0.580  what is a governed corpus\n  0.720  how does serving fail safe\n\nNOT separable: max OOC 0.620 >= min in-corpus 0.580; zero-FA floor leaks 0.333\nNOT pasting a floor: this measurement did not separate, so any number here would be one that is known to leak.\nPut the record in the fail-closed state and fix the measurement:\n  retrieval:\n    vector_floor: uncalibrated\nThen widen the probe set (scope-adjacent near-misses, not only far-domain questions), add in-corpus questions, and re-run.\n",
+        "\nmeasured on generation unknown (no generation pinned) (served), model some-model@768, door: queries-file\nCAVEAT: --queries-file floors are measured on human/gold-derived queries \u2014 section-weighted eval targets, NOT per-node passage samples \u2014 so this floor's low tail is a different distribution than the synthesized door's; record 'door: queries-file' beside the number and never compare the two doors' floors as interchangeable.\nCAVEAT: the out-of-corpus probes are the BUILT-IN set, which is entirely far-domain \u2014 a shipped set cannot be scope-adjacent, because adjacency depends on a corpus it has never seen. Far-domain probes score low against anything, so this margin is an OVER-estimate and a floor it blesses may still answer near-misses just outside your scope. Re-run with --ooc-file naming questions a reader might plausibly ask that this record does NOT cover, and trust that verdict over this one.\nAURC = 0.2708  (lower = better separation)\nseparation margin: -0.040 (over 2 in-corpus / 2 out-of-corpus probes)\nzero-FA floor (never refuse a real question): 0.580 -> coverage 0.750, ooc leak 0.333\nALT (0.95-precision): floor = 0.720 -> coverage 0.250\nweakest in-corpus queries (these set the floor):\n  0.580  what is a governed corpus\n  0.720  how does serving fail safe\n\nNOT separable: max OOC 0.620 >= min in-corpus 0.580; zero-FA floor leaks 0.333\nNOT pasting a floor: this measurement did not separate, so any number here would be one that is known to leak.\nPut the record in the fail-closed state and fix the measurement:\n  retrieval:\n    vector_floor: uncalibrated\nThen widen the probe set (scope-adjacent near-misses, not only far-domain questions), add in-corpus questions, and re-run.\n",
     },
     {
       name: "pinned candidate generation, low tail truncates at five",
@@ -1748,6 +1752,7 @@ export const fixture: MathFixture = {
         model: "gemini-embedding-001",
         dim: 1536,
         door: "synthesized",
+        oocSource: "built-in",
       },
       target_precision: 1.0,
       expected: {
@@ -1756,6 +1761,7 @@ export const fixture: MathFixture = {
         model: "gemini-embedding-001",
         dim: 1536,
         door: "synthesized",
+        ooc_source: "built-in",
         in_corpus_queries: 7,
         ooc_probes: 2,
         aurc: 0.0262,
@@ -1855,7 +1861,7 @@ export const fixture: MathFixture = {
         ],
       },
       rendered:
-        "\nmeasured on generation 7 (PINNED), model gemini-embedding-001, door: synthesized\nCAVEAT: synthesized queries are written FROM the passages they are then scored against, so they share vocabulary a reader's question will not. This door measures an UPPER BOUND on separation \u2014 treat the floor below as provisional until it has been checked against questions the corpus did not write (--queries-file), and re-run if real questions score under it.\nAURC = 0.0262  (lower = better separation)\nseparation margin: 0.250 (over 7 in-corpus / 2 out-of-corpus probes)\nzero-FA floor (never refuse a real question): 0.600 -> coverage 0.778, ooc leak 0.000\nALT (1.0-precision): floor = 0.600 -> coverage 0.778\nweakest in-corpus queries (these set the floor):\n  0.600  q-weak-1\n  0.600  q-weak-2\n  0.641  q-weak-3\n  0.650  q-weak-4\n  0.660  q-weak-5\n\nseparable: max OOC 0.350 < min in-corpus 0.600; midpoint has margin both ways\nPaste into instance.md:\n  vector_floor: 0.475   # calibrated 2026-08-21 on generation 7, model gemini-embedding-001/d1536, door: synthesized\n",
+        "\nmeasured on generation 7 (PINNED), model gemini-embedding-001, door: synthesized\nCAVEAT: synthesized queries are written FROM the passages they are then scored against, so they share vocabulary a reader's question will not. This door measures an UPPER BOUND on separation \u2014 treat the floor below as provisional until it has been checked against questions the corpus did not write (--queries-file), and re-run if real questions score under it.\nCAVEAT: the out-of-corpus probes are the BUILT-IN set, which is entirely far-domain \u2014 a shipped set cannot be scope-adjacent, because adjacency depends on a corpus it has never seen. Far-domain probes score low against anything, so this margin is an OVER-estimate and a floor it blesses may still answer near-misses just outside your scope. Re-run with --ooc-file naming questions a reader might plausibly ask that this record does NOT cover, and trust that verdict over this one.\nAURC = 0.0262  (lower = better separation)\nseparation margin: 0.250 (over 7 in-corpus / 2 out-of-corpus probes)\nzero-FA floor (never refuse a real question): 0.600 -> coverage 0.778, ooc leak 0.000\nALT (1.0-precision): floor = 0.600 -> coverage 0.778\nweakest in-corpus queries (these set the floor):\n  0.600  q-weak-1\n  0.600  q-weak-2\n  0.641  q-weak-3\n  0.650  q-weak-4\n  0.660  q-weak-5\n\nseparable: max OOC 0.350 < min in-corpus 0.600; midpoint has margin both ways\nPaste into instance.md:\n  vector_floor: 0.475   # calibrated 2026-08-21 on generation 7, model gemini-embedding-001/d1536, door: synthesized\n",
     },
   ],
   format_cases: [

--- a/packages/content/src/calibrate/math.test.ts
+++ b/packages/content/src/calibrate/math.test.ts
@@ -142,6 +142,26 @@ describe("report assembly and the printed recommendation block", () => {
     }
   });
 
+  it("says so whenever the OUT-OF-CORPUS probes came from the binary", () => {
+    // A shipped probe set cannot be scope-adjacent — adjacency depends on a
+    // corpus it has never seen — so a separability verdict resting on it is
+    // measuring the easy half. Measured on one record, changing ONLY the probe
+    // set: built-ins said "separable, margin 0.072" and recommended a floor;
+    // eight scope-adjacent near-misses said "NOT separable, margin -0.030", and
+    // that floor then answered six of the eight live, with citations.
+    const cases = fixture.report_cases.filter((c) => c.expected.ooc_source === "built-in");
+    expect(cases.length, "the fixture covers the built-in probe set").toBeGreaterThan(0);
+    for (const c of cases) {
+      expect(c.rendered, c.name).toContain("BUILT-IN set");
+      expect(c.rendered, "and names the way out").toContain("--ooc-file");
+    }
+    // On BOTH branches — the advice used to appear only after weak probes had
+    // already failed to bless a floor, which is when it is least needed.
+    const separable = cases.filter((c) => c.expected.separable);
+    expect(separable.length, "including a SEPARABLE case").toBeGreaterThan(0);
+    for (const c of separable) expect(c.rendered).toContain("OVER-estimate");
+  });
+
   it("every report states the margin and the number of probes behind it", () => {
     // paste_why names max-OOC and min-in-corpus; the SUBTRACTION is the number
     // that decides, and a margin measured over six probes is not the same claim

--- a/packages/content/src/calibrate/math.ts
+++ b/packages/content/src/calibrate/math.ts
@@ -43,6 +43,13 @@ export interface ReportMeta {
   readonly model: string;
   readonly dim: number;
   readonly door: CalibrationDoor;
+  /**
+   * Where the OUT-OF-CORPUS probes came from. The built-in set can only ever be
+   * far-domain — scope-adjacency is a property of the corpus, and a set shipped
+   * in the binary does not know the corpus — so a separability verdict resting
+   * on it is measuring the easy half of the question.
+   */
+  readonly oocSource: "built-in" | "provided";
 }
 
 /** The report dict of the oracle's `calibrate()`, key for key. */
@@ -73,6 +80,8 @@ export interface CalibrationReport {
    * report so the renderer cannot hand out a number the maths just refused.
    */
   readonly separable: boolean;
+  /** See ReportMeta.oocSource. Carried so the renderer can qualify the verdict. */
+  readonly ooc_source: "built-in" | "provided";
   /** The precision target the ALT floor was measured at — reported, not assumed. */
   readonly target: number;
   /** When the measurement was taken: the invariant says the DATE rides beside the number. */
@@ -281,6 +290,36 @@ export const SYNTHESIZED_CAVEAT: string =
   "separation — treat the floor below as provisional until it has been checked against questions " +
   "the corpus did not write (--queries-file), and re-run if real questions score under it.";
 
+/**
+ * What a separability verdict is worth when the probes came from the binary.
+ *
+ * Every entry in BUILT_IN_OOC is far-domain — dinner, taxes, football, boiling
+ * an egg. Those score low against ANY corpus, so max-OOC comes out artificially
+ * low and the margin is inflated from that end, exactly as synthesized in-corpus
+ * queries inflate it from the other. Measured on one record, changing ONLY the
+ * probe set: built-ins reported "separable, margin 0.072" and recommended a
+ * floor; eight scope-adjacent near-misses on the same corpus and the same
+ * in-corpus questions reported "NOT separable, margin -0.030". The recommended
+ * floor then answered six of those eight near-misses live, with citations
+ * (2026-08-21).
+ *
+ * The tool already knows this — the not-separable branch tells the operator to
+ * "widen the probe set (scope-adjacent near-misses, not only far-domain
+ * questions)". It said so only AFTER weak probes had failed to bless a floor,
+ * which is the one case where the advice is least needed.
+ *
+ * A shipped set cannot be scope-adjacent, because adjacency depends on a corpus
+ * the binary has never seen. So this is stated whenever built-ins are used, on
+ * BOTH branches, rather than pretending a better default exists.
+ */
+export const BUILT_IN_OOC_CAVEAT: string =
+  "CAVEAT: the out-of-corpus probes are the BUILT-IN set, which is entirely far-domain — a " +
+  "shipped set cannot be scope-adjacent, because adjacency depends on a corpus it has never " +
+  "seen. Far-domain probes score low against anything, so this margin is an OVER-estimate and " +
+  "a floor it blesses may still answer near-misses just outside your scope. Re-run with " +
+  "--ooc-file naming questions a reader might plausibly ask that this record does NOT cover, " +
+  "and trust that verdict over this one.";
+
 export const QUERIES_FILE_CAVEAT: string =
   "CAVEAT: --queries-file floors are measured on human/gold-derived queries — section-weighted " +
   "eval targets, NOT per-node passage samples — so this floor's low tail is a different distribution " +
@@ -344,6 +383,7 @@ export function buildReport(
     // so a hair of overlap does not read as a clean zero.
     margin: pythonRound(marginOf(points), 4),
     separable,
+    ooc_source: meta.oocSource,
     target: rec.target,
     // "Never copy a calibrated constant between corpora. Recalibrate; record
     // the measurement and its DATE beside the number" — the date was the half
@@ -377,6 +417,7 @@ export function renderReport(report: CalibrationReport): string {
     `\nmeasured on generation ${gen} (${how}), model ${report.model}, door: ${report.door}`,
   );
   lines.push(report.door === "queries-file" ? QUERIES_FILE_CAVEAT : SYNTHESIZED_CAVEAT);
+  if (report.ooc_source === "built-in") lines.push(BUILT_IN_OOC_CAVEAT);
   lines.push(`AURC = ${pythonFloatRepr(report.aurc)}  (lower = better separation)`);
   // The margin is the number that decides, and it was the one number the block
   // never printed: `paste_why` names both ends, leaving the subtraction to the

--- a/packages/content/src/calibrate/run.ts
+++ b/packages/content/src/calibrate/run.ts
@@ -223,6 +223,7 @@ export async function runCalibration(
     inQueries = normalizeQueries(synthesized);
   }
 
+  const oocSource = options.oocProbes === undefined ? "built-in" : "provided";
   const ooc = normalizeQueries(options.oocProbes ?? BUILT_IN_OOC);
   const detail = [
     ...(await scoreQueries(pool, scope, options.provider, inQueries, true)),
@@ -238,6 +239,7 @@ export async function runCalibration(
       model: options.provider.modelId,
       dim: options.provider.dim,
       door,
+      oocSource,
     },
     options.targetPrecision ?? 0.95,
   );

--- a/packages/content/src/kernel.db.test.ts
+++ b/packages/content/src/kernel.db.test.ts
@@ -304,6 +304,35 @@ describe.runIf(adminDsn !== "")("kernel db acceptance", () => {
       expect(kwServed.hits[0]?.slug).toBe("yak");
     }
 
+    // …and the case that was NOT covered, which is the common one. The test
+    // above picks a query the keyword arm can answer, so the degrade serves
+    // real hits. Ask the way a person actually asks and that arm returns
+    // NOTHING — `websearch_to_tsquery` ANDs its terms, so one word absent from
+    // the corpus empties the result (measured 12/12 on natural questions,
+    // 2026-08-21). The empty result then reached `keywordAbstains`, which
+    // abstains on no rows, and the envelope reported "abstained".
+    //
+    // So during any provider outage an UNCALIBRATED record — the default state
+    // of every fresh scaffold — told every caller it covered nothing, while the
+    // tool description instructs the agent to state that as fact and never fall
+    // back. The vector arm never ran; an empty result says nothing about
+    // coverage. Found live against published 0.0.12 with an invalid key.
+    const noKeywordMatch = await search(uncalibrated, "what does the flurbish protocol require", 5);
+    expect(
+      noKeywordMatch.ok,
+      "an outage with nothing to serve must not be a success envelope",
+    ).toBe(false);
+    if (!noKeywordMatch.ok) {
+      expect(
+        noKeywordMatch.reason,
+        `an outage is not an abstention, calibrated or not: ${JSON.stringify(noKeywordMatch)}`,
+      ).toBe("unavailable");
+      expect(
+        noKeywordMatch.abstained,
+        "and must never claim the record was checked and found wanting",
+      ).toBe(false);
+    }
+
     // The §7 rows exist for every act above (admin read bypasses RLS).
     const rows = await pool.query(
       "SELECT action, count(*)::int AS n FROM retrieval_log GROUP BY action",

--- a/packages/content/src/service.ts
+++ b/packages/content/src/service.ts
@@ -405,13 +405,25 @@ export async function search(ctx: ServiceContext, query: string, k = 10): Promis
 
     // "The record does not cover this" and "I could not look properly" are
     // DIFFERENT answers, and only the first is an abstention. When the embed
-    // provider is down on a calibrated record the floor cannot be evaluated at
-    // all, so withholding is right — but reporting it as an abstention told the
-    // agent the record does not cover a question it does cover, for the whole
-    // outage, and the tool description instructs the agent to state exactly
-    // that and not fall back (round-6 review of #43, reproduced live with a
-    // bogus provider key against a corpus that contains the answer).
-    const unavailable = embedFailed && inst.abstain.vectorFloor !== null;
+    // provider is down the vector arm did not run at all, so an empty result is
+    // not evidence about coverage — it is evidence that we could not look.
+    //
+    // This was first fixed for CALIBRATED records only, on the reasoning that a
+    // declared floor cannot be evaluated without an embedding (round-6 review of
+    // #43). The condition was the bug: an UNCALIBRATED record is the default
+    // state of every fresh scaffold, and there the emptiness comes from
+    // `keywordAbstains`, which abstains whenever the keyword arm returns no
+    // rows — and that arm returns nothing for almost every natural-language
+    // question, because `websearch_to_tsquery` ANDs its terms (measured 12/12
+    // on real questions, 2026-08-21). So during any provider outage an
+    // uncalibrated record told every caller it covered nothing, while the tool
+    // description instructs the agent to state exactly that and never fall back
+    // on its own knowledge. Found live against the published 0.0.12 with an
+    // invalid key — the same state a CI key rejection produced that morning.
+    //
+    // The floor is irrelevant to the question being asked here. What matters is
+    // whether we were able to look.
+    const unavailable = embedFailed;
     const reason = unavailable ? "unavailable" : unpublished ? "unpublished" : "abstained";
     return {
       ok: false,


### PR DESCRIPTION
Two of the three remaining blockers from the live verification fleet. Both are
about the product telling the truth about ITSELF.

## 1. "I could not look" was reported as "the record does not cover this"

When the embedding provider is down the vector arm never runs, so an empty result
is not evidence about coverage. This was fixed once — for records with a
**calibrated floor** — on the reasoning that a declared floor cannot be evaluated
without an embedding. The condition was the bug.

An **uncalibrated** record is the default state of every fresh scaffold. There
the emptiness came from `keywordAbstains`, which abstains on zero rows — and the
keyword arm returns nothing for almost every natural question, because
`websearch_to_tsquery` ANDs its terms (measured **12 of 12** on real questions).

So during any provider outage, an uncalibrated record answered every question:

```json
{"ok":false,"abstained":true,"reason":"abstained","gate":"off","hits":[]}
```

`abstained: true` and `gate: "off"` in the same envelope — claiming an abstention
from a gate it simultaneously declares incapable of abstaining. And the search
tool's own description tells the agent to state that as fact and never fall back
on its own knowledge.

**Why it survived:** the existing test asked `"onboarding checklist"`, which the
keyword arm CAN match — so the degrade served real hits and looked right. Ask the
way a person asks and it did not. That case is covered now, and reverting the fix
turns it red with the bad envelope printed.

This is not exotic: it is exactly the state a rejected CI key produced here this
morning.

## 2. `calibrate` blessed floors on far-domain evidence alone

`BUILT_IN_OOC` is 20 probes — dinner, taxes, football, boiling an egg. A shipped
set **cannot** be scope-adjacent, because adjacency depends on a corpus it has
never seen. Far-domain probes score low against anything, so max-OOC comes out
artificially low and the margin is inflated from that end — exactly as
synthesized in-corpus queries inflate it from the other.

Measured on one record, changing ONLY the probe set:

| probes | verdict | margin | recommendation |
|---|---|---|---|
| built-in (far-domain) | separable | +0.072 | `vector_floor: 0.579` |
| 8 scope-adjacent near-misses | **NOT separable** | **−0.030** | refuses to paste one |

That floor then answered **six of the eight** near-misses live, with citations to
passages that do not contain the answer.

The tool already knew the right advice — *"widen the probe set (scope-adjacent
near-misses, not only far-domain questions)"* — and printed it only on the
not-separable branch, i.e. only once weak probes had already failed to bless a
bad floor. It now says so whenever the built-ins are used, on both branches. No
new default is invented, because a correct default is not possible.

Gate: 694 unit / 221 integration / 176 db.