### PR TITLE
Pin the vector arm's plan, and remove a parameter-renumbering hazard

### DIFF
--- a/.changeset/an-outage-is-not-an-abstention.md
+++ b/.changeset/an-outage-is-not-an-abstention.md
@@ -1,0 +1,36 @@
+---
+"@panaversity/ksor": patch
+---
+
+A provider outage is never reported as "the record does not cover this"
+
+When the embedding provider is down, the vector arm does not run — so an empty
+result says nothing about coverage. It says we could not look. That distinction
+was fixed once for records with a calibrated floor, and the condition was the
+bug: it left the case out that matters most.
+
+An **uncalibrated** record is the default state of every fresh scaffold. There
+the emptiness came from the keyword arm, which abstains when it returns no rows
+— and it returns nothing for almost every natural-language question, because
+`websearch_to_tsquery` ANDs its terms (measured 12 of 12 on real questions). So
+during any outage an uncalibrated record answered every question with
+`abstained: true`, while the tool description instructs the agent to state that
+as fact and never fall back on its own knowledge.
+
+It reached this release because the existing test asked a question the keyword
+arm could answer, so the degraded path served real hits and looked correct. Ask
+the way a person asks and it did not. That case is now covered.
+
+Found live against the published 0.0.12 with an invalid key — the same state a
+rejected CI key had produced that morning, which is how likely this is.
+
+**`ksor calibrate` also stops blessing a floor on far-domain evidence alone.**
+The built-in out-of-corpus probes are all far-domain — dinner, taxes, boiling an
+egg — and a shipped set cannot be scope-adjacent, because adjacency depends on a
+corpus it has never seen. Far-domain probes score low against anything, so the
+margin comes out inflated. Measured on one record, changing only the probe set:
+built-ins reported "separable, margin 0.072" and recommended a floor; eight
+scope-adjacent near-misses reported "NOT separable, margin -0.030" — and that
+floor then answered six of the eight live, with citations. The tool already knew
+to say "widen the probe set", but said it only on the not-separable branch, which
+is when it is least needed. It now says it whenever the built-ins are used.

--- a/.changeset/pin-the-index-plan.md
+++ b/.changeset/pin-the-index-plan.md
@@ -1,0 +1,18 @@
+---
+---
+
+Dev-only: no shipped behaviour changes, so this deliberately carries no version
+bump.
+
+A characterization test pins the vector arm's query PLAN, which is currently
+wrong — `idx_chunks_hnsw` is built, maintained and never opened (issue #59). It
+asserts the defect so a fix, or a further regression, arrives as a red test with
+the plan printed. The same defect was announced as fixed once before and
+returned through a different clause because nothing asserted the outcome.
+
+Also removes a latent hazard found while investigating it: the standalone search
+arms derived their WHERE clause with `ARM_WHERE.replaceAll("$5", "$4")`, which
+works only while the predicate contains exactly one placeholder. Adding a second
+one breaks every derived query silently, and the failure surfaces as "content
+store temporarily unavailable" — a message that says nothing about the cause.
+The parameter number is now an argument.

--- a/packages/content/src/calibrate/fixtures/math.ts
+++ b/packages/content/src/calibrate/fixtures/math.ts
@@ -1480,6 +1480,7 @@ export const fixture: MathFixture = {
         model: "gemini-embedding-001",
         dim: 1536,
         door: "synthesized",
+        oocSource: "built-in",
       },
       target_precision: 0.95,
       expected: {
@@ -1488,6 +1489,7 @@ export const fixture: MathFixture = {
         model: "gemini-embedding-001",
         dim: 1536,
         door: "synthesized",
+        ooc_source: "built-in",
         in_corpus_queries: 6,
         ooc_probes: 4,
         aurc: 0.0926,
@@ -1592,7 +1594,7 @@ export const fixture: MathFixture = {
         ],
       },
       rendered:
-        "\nmeasured on generation 3 (served), model gemini-embedding-001, door: synthesized\nCAVEAT: synthesized queries are written FROM the passages they are then scored against, so they share vocabulary a reader's question will not. This door measures an UPPER BOUND on separation \u2014 treat the floor below as provisional until it has been checked against questions the corpus did not write (--queries-file), and re-run if real questions score under it.\nAURC = 0.0926  (lower = better separation)\nseparation margin: 0.054 (over 6 in-corpus / 4 out-of-corpus probes)\nzero-FA floor (never refuse a real question): 0.664 -> coverage 0.600, ooc leak 0.000\nALT (0.95-precision): floor = 0.664 -> coverage 0.600\nweakest in-corpus queries (these set the floor):\n  0.664  what pins a citation to a generation\n  0.680  how is the corpus version derived\n  0.690  how are chunks kept overlap-free\n  0.710  how does the abstention gate decide\n  0.730  what does the build lock record\n\nseparable: max OOC 0.610 < min in-corpus 0.664; midpoint has margin both ways\nPaste into instance.md:\n  vector_floor: 0.637   # calibrated 2026-08-21 on generation 3, model gemini-embedding-001/d1536, door: synthesized\n",
+        "\nmeasured on generation 3 (served), model gemini-embedding-001, door: synthesized\nCAVEAT: synthesized queries are written FROM the passages they are then scored against, so they share vocabulary a reader's question will not. This door measures an UPPER BOUND on separation \u2014 treat the floor below as provisional until it has been checked against questions the corpus did not write (--queries-file), and re-run if real questions score under it.\nCAVEAT: the out-of-corpus probes are the BUILT-IN set, which is entirely far-domain \u2014 a shipped set cannot be scope-adjacent, because adjacency depends on a corpus it has never seen. Far-domain probes score low against anything, so this margin is an OVER-estimate and a floor it blesses may still answer near-misses just outside your scope. Re-run with --ooc-file naming questions a reader might plausibly ask that this record does NOT cover, and trust that verdict over this one.\nAURC = 0.0926  (lower = better separation)\nseparation margin: 0.054 (over 6 in-corpus / 4 out-of-corpus probes)\nzero-FA floor (never refuse a real question): 0.664 -> coverage 0.600, ooc leak 0.000\nALT (0.95-precision): floor = 0.664 -> coverage 0.600\nweakest in-corpus queries (these set the floor):\n  0.664  what pins a citation to a generation\n  0.680  how is the corpus version derived\n  0.690  how are chunks kept overlap-free\n  0.710  how does the abstention gate decide\n  0.730  what does the build lock record\n\nseparable: max OOC 0.610 < min in-corpus 0.664; midpoint has margin both ways\nPaste into instance.md:\n  vector_floor: 0.637   # calibrated 2026-08-21 on generation 3, model gemini-embedding-001/d1536, door: synthesized\n",
     },
     {
       name: "queries-file door, generation None, not separable, no alt floor",
@@ -1624,6 +1626,7 @@ export const fixture: MathFixture = {
         model: "some-model@768",
         dim: 768,
         door: "queries-file",
+        oocSource: "built-in",
       },
       target_precision: 0.95,
       expected: {
@@ -1632,6 +1635,7 @@ export const fixture: MathFixture = {
         model: "some-model@768",
         dim: 768,
         door: "queries-file",
+        ooc_source: "built-in",
         in_corpus_queries: 2,
         ooc_probes: 2,
         aurc: 0.2708,
@@ -1691,7 +1695,7 @@ export const fixture: MathFixture = {
         ],
       },
       rendered:
-        "\nmeasured on generation unknown (no generation pinned) (served), model some-model@768, door: queries-file\nCAVEAT: --queries-file floors are measured on human/gold-derived queries \u2014 section-weighted eval targets, NOT per-node passage samples \u2014 so this floor's low tail is a different distribution than the synthesized door's; record 'door: queries-file' beside the number and never compare the two doors' floors as interchangeable.\nAURC = 0.2708  (lower = better separation)\nseparation margin: -0.040 (over 2 in-corpus / 2 out-of-corpus probes)\nzero-FA floor (never refuse a real question): 0.580 -> coverage 0.750, ooc leak 0.333\nALT (0.95-precision): floor = 0.720 -> coverage 0.250\nweakest in-corpus queries (these set the floor):\n  0.580  what is a governed corpus\n  0.720  how does serving fail safe\n\nNOT separable: max OOC 0.620 >= min in-corpus 0.580; zero-FA floor leaks 0.333\nNOT pasting a floor: this measurement did not separate, so any number here would be one that is known to leak.\nPut the record in the fail-closed state and fix the measurement:\n  retrieval:\n    vector_floor: uncalibrated\nThen widen the probe set (scope-adjacent near-misses, not only far-domain questions), add in-corpus questions, and re-run.\n",
+        "\nmeasured on generation unknown (no generation pinned) (served), model some-model@768, door: queries-file\nCAVEAT: --queries-file floors are measured on human/gold-derived queries \u2014 section-weighted eval targets, NOT per-node passage samples \u2014 so this floor's low tail is a different distribution than the synthesized door's; record 'door: queries-file' beside the number and never compare the two doors' floors as interchangeable.\nCAVEAT: the out-of-corpus probes are the BUILT-IN set, which is entirely far-domain \u2014 a shipped set cannot be scope-adjacent, because adjacency depends on a corpus it has never seen. Far-domain probes score low against anything, so this margin is an OVER-estimate and a floor it blesses may still answer near-misses just outside your scope. Re-run with --ooc-file naming questions a reader might plausibly ask that this record does NOT cover, and trust that verdict over this one.\nAURC = 0.2708  (lower = better separation)\nseparation margin: -0.040 (over 2 in-corpus / 2 out-of-corpus probes)\nzero-FA floor (never refuse a real question): 0.580 -> coverage 0.750, ooc leak 0.333\nALT (0.95-precision): floor = 0.720 -> coverage 0.250\nweakest in-corpus queries (these set the floor):\n  0.580  what is a governed corpus\n  0.720  how does serving fail safe\n\nNOT separable: max OOC 0.620 >= min in-corpus 0.580; zero-FA floor leaks 0.333\nNOT pasting a floor: this measurement did not separate, so any number here would be one that is known to leak.\nPut the record in the fail-closed state and fix the measurement:\n  retrieval:\n    vector_floor: uncalibrated\nThen widen the probe set (scope-adjacent near-misses, not only far-domain questions), add in-corpus questions, and re-run.\n",
     },
     {
       name: "pinned candidate generation, low tail truncates at five",
@@ -1748,6 +1752,7 @@ export const fixture: MathFixture = {
         model: "gemini-embedding-001",
         dim: 1536,
         door: "synthesized",
+        oocSource: "built-in",
       },
       target_precision: 1.0,
       expected: {
@@ -1756,6 +1761,7 @@ export const fixture: MathFixture = {
         model: "gemini-embedding-001",
         dim: 1536,
         door: "synthesized",
+        ooc_source: "built-in",
         in_corpus_queries: 7,
         ooc_probes: 2,
         aurc: 0.0262,
@@ -1855,7 +1861,7 @@ export const fixture: MathFixture = {
         ],
       },
       rendered:
-        "\nmeasured on generation 7 (PINNED), model gemini-embedding-001, door: synthesized\nCAVEAT: synthesized queries are written FROM the passages they are then scored against, so they share vocabulary a reader's question will not. This door measures an UPPER BOUND on separation \u2014 treat the floor below as provisional until it has been checked against questions the corpus did not write (--queries-file), and re-run if real questions score under it.\nAURC = 0.0262  (lower = better separation)\nseparation margin: 0.250 (over 7 in-corpus / 2 out-of-corpus probes)\nzero-FA floor (never refuse a real question): 0.600 -> coverage 0.778, ooc leak 0.000\nALT (1.0-precision): floor = 0.600 -> coverage 0.778\nweakest in-corpus queries (these set the floor):\n  0.600  q-weak-1\n  0.600  q-weak-2\n  0.641  q-weak-3\n  0.650  q-weak-4\n  0.660  q-weak-5\n\nseparable: max OOC 0.350 < min in-corpus 0.600; midpoint has margin both ways\nPaste into instance.md:\n  vector_floor: 0.475   # calibrated 2026-08-21 on generation 7, model gemini-embedding-001/d1536, door: synthesized\n",
+        "\nmeasured on generation 7 (PINNED), model gemini-embedding-001, door: synthesized\nCAVEAT: synthesized queries are written FROM the passages they are then scored against, so they share vocabulary a reader's question will not. This door measures an UPPER BOUND on separation \u2014 treat the floor below as provisional until it has been checked against questions the corpus did not write (--queries-file), and re-run if real questions score under it.\nCAVEAT: the out-of-corpus probes are the BUILT-IN set, which is entirely far-domain \u2014 a shipped set cannot be scope-adjacent, because adjacency depends on a corpus it has never seen. Far-domain probes score low against anything, so this margin is an OVER-estimate and a floor it blesses may still answer near-misses just outside your scope. Re-run with --ooc-file naming questions a reader might plausibly ask that this record does NOT cover, and trust that verdict over this one.\nAURC = 0.0262  (lower = better separation)\nseparation margin: 0.250 (over 7 in-corpus / 2 out-of-corpus probes)\nzero-FA floor (never refuse a real question): 0.600 -> coverage 0.778, ooc leak 0.000\nALT (1.0-precision): floor = 0.600 -> coverage 0.778\nweakest in-corpus queries (these set the floor):\n  0.600  q-weak-1\n  0.600  q-weak-2\n  0.641  q-weak-3\n  0.650  q-weak-4\n  0.660  q-weak-5\n\nseparable: max OOC 0.350 < min in-corpus 0.600; midpoint has margin both ways\nPaste into instance.md:\n  vector_floor: 0.475   # calibrated 2026-08-21 on generation 7, model gemini-embedding-001/d1536, door: synthesized\n",
     },
   ],
   format_cases: [

--- a/packages/content/src/calibrate/math.test.ts
+++ b/packages/content/src/calibrate/math.test.ts
@@ -142,6 +142,26 @@ describe("report assembly and the printed recommendation block", () => {
     }
   });
 
+  it("says so whenever the OUT-OF-CORPUS probes came from the binary", () => {
+    // A shipped probe set cannot be scope-adjacent — adjacency depends on a
+    // corpus it has never seen — so a separability verdict resting on it is
+    // measuring the easy half. Measured on one record, changing ONLY the probe
+    // set: built-ins said "separable, margin 0.072" and recommended a floor;
+    // eight scope-adjacent near-misses said "NOT separable, margin -0.030", and
+    // that floor then answered six of the eight live, with citations.
+    const cases = fixture.report_cases.filter((c) => c.expected.ooc_source === "built-in");
+    expect(cases.length, "the fixture covers the built-in probe set").toBeGreaterThan(0);
+    for (const c of cases) {
+      expect(c.rendered, c.name).toContain("BUILT-IN set");
+      expect(c.rendered, "and names the way out").toContain("--ooc-file");
+    }
+    // On BOTH branches — the advice used to appear only after weak probes had
+    // already failed to bless a floor, which is when it is least needed.
+    const separable = cases.filter((c) => c.expected.separable);
+    expect(separable.length, "including a SEPARABLE case").toBeGreaterThan(0);
+    for (const c of separable) expect(c.rendered).toContain("OVER-estimate");
+  });
+
   it("every report states the margin and the number of probes behind it", () => {
     // paste_why names max-OOC and min-in-corpus; the SUBTRACTION is the number
     // that decides, and a margin measured over six probes is not the same claim

--- a/packages/content/src/calibrate/math.ts
+++ b/packages/content/src/calibrate/math.ts
@@ -43,6 +43,13 @@ export interface ReportMeta {
   readonly model: string;
   readonly dim: number;
   readonly door: CalibrationDoor;
+  /**
+   * Where the OUT-OF-CORPUS probes came from. The built-in set can only ever be
+   * far-domain — scope-adjacency is a property of the corpus, and a set shipped
+   * in the binary does not know the corpus — so a separability verdict resting
+   * on it is measuring the easy half of the question.
+   */
+  readonly oocSource: "built-in" | "provided";
 }
 
 /** The report dict of the oracle's `calibrate()`, key for key. */
@@ -73,6 +80,8 @@ export interface CalibrationReport {
    * report so the renderer cannot hand out a number the maths just refused.
    */
   readonly separable: boolean;
+  /** See ReportMeta.oocSource. Carried so the renderer can qualify the verdict. */
+  readonly ooc_source: "built-in" | "provided";
   /** The precision target the ALT floor was measured at — reported, not assumed. */
   readonly target: number;
   /** When the measurement was taken: the invariant says the DATE rides beside the number. */
@@ -281,6 +290,36 @@ export const SYNTHESIZED_CAVEAT: string =
   "separation — treat the floor below as provisional until it has been checked against questions " +
   "the corpus did not write (--queries-file), and re-run if real questions score under it.";
 
+/**
+ * What a separability verdict is worth when the probes came from the binary.
+ *
+ * Every entry in BUILT_IN_OOC is far-domain — dinner, taxes, football, boiling
+ * an egg. Those score low against ANY corpus, so max-OOC comes out artificially
+ * low and the margin is inflated from that end, exactly as synthesized in-corpus
+ * queries inflate it from the other. Measured on one record, changing ONLY the
+ * probe set: built-ins reported "separable, margin 0.072" and recommended a
+ * floor; eight scope-adjacent near-misses on the same corpus and the same
+ * in-corpus questions reported "NOT separable, margin -0.030". The recommended
+ * floor then answered six of those eight near-misses live, with citations
+ * (2026-08-21).
+ *
+ * The tool already knows this — the not-separable branch tells the operator to
+ * "widen the probe set (scope-adjacent near-misses, not only far-domain
+ * questions)". It said so only AFTER weak probes had failed to bless a floor,
+ * which is the one case where the advice is least needed.
+ *
+ * A shipped set cannot be scope-adjacent, because adjacency depends on a corpus
+ * the binary has never seen. So this is stated whenever built-ins are used, on
+ * BOTH branches, rather than pretending a better default exists.
+ */
+export const BUILT_IN_OOC_CAVEAT: string =
+  "CAVEAT: the out-of-corpus probes are the BUILT-IN set, which is entirely far-domain — a " +
+  "shipped set cannot be scope-adjacent, because adjacency depends on a corpus it has never " +
+  "seen. Far-domain probes score low against anything, so this margin is an OVER-estimate and " +
+  "a floor it blesses may still answer near-misses just outside your scope. Re-run with " +
+  "--ooc-file naming questions a reader might plausibly ask that this record does NOT cover, " +
+  "and trust that verdict over this one.";
+
 export const QUERIES_FILE_CAVEAT: string =
   "CAVEAT: --queries-file floors are measured on human/gold-derived queries — section-weighted " +
   "eval targets, NOT per-node passage samples — so this floor's low tail is a different distribution " +
@@ -344,6 +383,7 @@ export function buildReport(
     // so a hair of overlap does not read as a clean zero.
     margin: pythonRound(marginOf(points), 4),
     separable,
+    ooc_source: meta.oocSource,
     target: rec.target,
     // "Never copy a calibrated constant between corpora. Recalibrate; record
     // the measurement and its DATE beside the number" — the date was the half
@@ -377,6 +417,7 @@ export function renderReport(report: CalibrationReport): string {
     `\nmeasured on generation ${gen} (${how}), model ${report.model}, door: ${report.door}`,
   );
   lines.push(report.door === "queries-file" ? QUERIES_FILE_CAVEAT : SYNTHESIZED_CAVEAT);
+  if (report.ooc_source === "built-in") lines.push(BUILT_IN_OOC_CAVEAT);
   lines.push(`AURC = ${pythonFloatRepr(report.aurc)}  (lower = better separation)`);
   // The margin is the number that decides, and it was the one number the block
   // never printed: `paste_why` names both ends, leaving the subtraction to the

--- a/packages/content/src/calibrate/run.ts
+++ b/packages/content/src/calibrate/run.ts
@@ -223,6 +223,7 @@ export async function runCalibration(
     inQueries = normalizeQueries(synthesized);
   }
 
+  const oocSource = options.oocProbes === undefined ? "built-in" : "provided";
   const ooc = normalizeQueries(options.oocProbes ?? BUILT_IN_OOC);
   const detail = [
     ...(await scoreQueries(pool, scope, options.provider, inQueries, true)),
@@ -238,6 +239,7 @@ export async function runCalibration(
       model: options.provider.modelId,
       dim: options.provider.dim,
       door,
+      oocSource,
     },
     options.targetPrecision ?? 0.95,
   );

--- a/packages/content/src/kernel.db.test.ts
+++ b/packages/content/src/kernel.db.test.ts
@@ -304,6 +304,35 @@ describe.runIf(adminDsn !== "")("kernel db acceptance", () => {
       expect(kwServed.hits[0]?.slug).toBe("yak");
     }
 
+    // …and the case that was NOT covered, which is the common one. The test
+    // above picks a query the keyword arm can answer, so the degrade serves
+    // real hits. Ask the way a person actually asks and that arm returns
+    // NOTHING — `websearch_to_tsquery` ANDs its terms, so one word absent from
+    // the corpus empties the result (measured 12/12 on natural questions,
+    // 2026-08-21). The empty result then reached `keywordAbstains`, which
+    // abstains on no rows, and the envelope reported "abstained".
+    //
+    // So during any provider outage an UNCALIBRATED record — the default state
+    // of every fresh scaffold — told every caller it covered nothing, while the
+    // tool description instructs the agent to state that as fact and never fall
+    // back. The vector arm never ran; an empty result says nothing about
+    // coverage. Found live against published 0.0.12 with an invalid key.
+    const noKeywordMatch = await search(uncalibrated, "what does the flurbish protocol require", 5);
+    expect(
+      noKeywordMatch.ok,
+      "an outage with nothing to serve must not be a success envelope",
+    ).toBe(false);
+    if (!noKeywordMatch.ok) {
+      expect(
+        noKeywordMatch.reason,
+        `an outage is not an abstention, calibrated or not: ${JSON.stringify(noKeywordMatch)}`,
+      ).toBe("unavailable");
+      expect(
+        noKeywordMatch.abstained,
+        "and must never claim the record was checked and found wanting",
+      ).toBe(false);
+    }
+
     // The §7 rows exist for every act above (admin read bypasses RLS).
     const rows = await pool.query(
       "SELECT action, count(*)::int AS n FROM retrieval_log GROUP BY action",

--- a/packages/content/src/lib/search.ts
+++ b/packages/content/src/lib/search.ts
@@ -39,11 +39,24 @@ g AS (
 // Scoped takedown denial (decision 14): the shared `denied` set — per-node by
 // default, whole subtree when a row says so — bound PRE-fusion so a denied node
 // cannot leak by ranking. Definition lives in takedown.ts (one seam).
-const ARM_WHERE = `
+/**
+ * The arm predicate, built for the parameter numbering of the query that uses
+ * it — a FUNCTION, not a string the caller renumbers afterwards.
+ *
+ * It used to be derived with `ARM_WHERE.replaceAll("$5", "$4")`, which works
+ * only while the predicate happens to contain exactly one placeholder and no
+ * other text matching it. Adding any second parameter to the predicate breaks
+ * every derived query silently — and when it breaks, the failure arrives as a
+ * driver error that the serving layer correctly reduces to "content store
+ * temporarily unavailable", which tells you nothing about the cause. Found by
+ * tripping over it while trying a fix for issue #59; taking the number as an
+ * argument makes the coupling visible instead of textual.
+ */
+const armWhere = (kindsParam: string): string => `
         c.tenant_id = $1 AND c.generation = g.gen
           AND c.embedding_status = 'embedded' AND ${SERVABLE}
           AND n.status = 'published'
-          AND ($5::text[] IS NULL OR n.kind = ANY($5::text[]))
+          AND (${kindsParam}::text[] IS NULL OR n.kind = ANY(${kindsParam}::text[]))
           AND ${DENY}
           AND ${AUDIENCE_ALLOWED}`;
 
@@ -54,7 +67,16 @@ const JOINS = `
                       AND s.generation = c.generation
         JOIN content_nodes n ON n.node_id = s.node_id AND n.tenant_id = s.tenant_id`;
 
-const HYBRID_SQL = `
+/**
+ * Exported ONLY so a test can EXPLAIN the real thing.
+ *
+ * The index regression this fixes was announced as fixed once before, and came
+ * back through a different clause, because nothing ever asserted the RESULT —
+ * that the plan opens `idx_chunks_hnsw`. A timing threshold would be flaky and
+ * would not have caught it either; the plan shape is the property that matters
+ * (issue #59).
+ */
+export const HYBRID_SQL: string = `
 WITH RECURSIVE ${GEN_CTE}, ${DENIED_CTE},
     -- The top-k is taken by a PLAIN \`ORDER BY <distance> LIMIT\`, and the rank
     -- is numbered OUTSIDE it. Ordering by a window column instead made the
@@ -74,7 +96,7 @@ WITH RECURSIVE ${GEN_CTE}, ${DENIED_CTE},
         FROM (
             SELECT c.chunk_id, g.gen, (c.embedding <=> $3::vector) AS dist
             ${JOINS}
-            WHERE ${ARM_WHERE}
+            WHERE ${armWhere("$5")}
             ORDER BY c.embedding <=> $3::vector, c.chunk_id
             LIMIT $6
         ) ranked),
@@ -83,7 +105,7 @@ WITH RECURSIVE ${GEN_CTE}, ${DENIED_CTE},
                row_number() OVER (ORDER BY ts_rank_cd(c.search_tsv,
                    websearch_to_tsquery($9::regconfig, $4)) DESC, c.chunk_id) AS r
         ${JOINS}
-        WHERE ${ARM_WHERE}
+        WHERE ${armWhere("$5")}
           AND c.search_tsv @@ websearch_to_tsquery($9::regconfig, $4)
         ORDER BY r LIMIT $6),
     fused AS (
@@ -107,7 +129,7 @@ WITH RECURSIVE ${GEN_CTE.replace("$8", "$6")}, ${DENIED_CTE}
            ts_rank_cd(c.search_tsv, websearch_to_tsquery($7::regconfig, $3)) AS score,
            g.gen, n.permalink
     ${JOINS}
-    WHERE ${ARM_WHERE.replaceAll("$5", "$4")}
+    WHERE ${armWhere("$4")}
       AND c.search_tsv @@ websearch_to_tsquery($7::regconfig, $3)
     ORDER BY score DESC, c.chunk_id LIMIT $5`;
 
@@ -116,7 +138,7 @@ const TOP_ONE_SQL = `
 WITH RECURSIVE ${GEN_CTE.replace("$8", "$5")}, ${DENIED_CTE}
     SELECT 1 - (c.embedding <=> $3::vector) AS score
     ${JOINS}
-    WHERE ${ARM_WHERE.replaceAll("$5", "$4")}
+    WHERE ${armWhere("$4")}
     ORDER BY c.embedding <=> $3::vector, c.chunk_id
     LIMIT 1`;
 

--- a/packages/content/src/lib/vector-plan.db.test.ts
+++ b/packages/content/src/lib/vector-plan.db.test.ts
@@ -1,0 +1,127 @@
+/**
+ * What the serving query's PLAN does — pinned, because it is currently wrong.
+ *
+ * `idx_chunks_hnsw` is built, maintained, and **not opened** by the query
+ * `ksor serve` sends. The arm's filters are expressions Postgres cannot
+ * estimate (`labels->>'source_type'`, a `regexp_replace` length) and its
+ * generation comes from a join, so the ordered scan is priced as a near-full
+ * traversal and a sequential scan plus top-N heapsort wins. Measured at 20,001
+ * chunks on PG 17.7 / pgvector 0.8.2: **814 ms** with the index absent from the
+ * plan, against **1.2 ms** for the same rows from the same index when the query
+ * is simple. Issue #59.
+ *
+ * This is a CHARACTERIZATION test, not a guard on correct behaviour. It asserts
+ * today's plan so that a fix — or a further regression — arrives as a red test
+ * with the plan printed, rather than silently. **When you fix #59, this test
+ * fails; invert it and record the measurement.**
+ *
+ * It exists because the same defect was announced as fixed once before (the
+ * previous fix removed a window function from the ORDER BY) and returned
+ * through the WHERE clause, since nothing ever asserted the outcome. A timing
+ * threshold would be flaky and would not have caught it either. The plan is the
+ * property that matters, so the plan is what is asserted — of the REAL
+ * `HYBRID_SQL`, never of a query written for the test. An earlier attempt at a
+ * fix measured a simplified query instead and looked like it worked; this file
+ * is what proved it had not.
+ *
+ * Vectors are random, which is unfavourable to HNSW in 1536 dimensions. That
+ * makes it a conservative bed for the direction being asserted here.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { contentPool, runRead } from "../db.js";
+import { applySchema } from "../schema.js";
+import { HYBRID_SQL, VECTOR_TXN_GUCS } from "./search.js";
+import { WHOLE_RECORD_SCOPE } from "./audience.js";
+import type pg from "pg";
+
+const adminDsn = process.env["KSOR_DB_URL"] ?? "";
+const DB = "ksor_vector_plan";
+const TENANT = "planned";
+/** Enough rows that a sequential scan is genuinely the wrong answer. */
+const ROWS = 20_000;
+
+describe.runIf(adminDsn !== "")("the serving query opens the vector index (db)", () => {
+  let pool: pg.Pool;
+  let admin: pg.Pool;
+
+  beforeAll(async () => {
+    const { Pool } = (await import("pg")).default;
+    admin = new Pool({ connectionString: adminDsn });
+    await admin.query(`DROP DATABASE IF EXISTS ${DB} WITH (FORCE)`).catch(() => undefined);
+    await admin.query(`CREATE DATABASE ${DB}`);
+    const url = new URL(adminDsn);
+    url.pathname = `/${DB}`;
+    pool = contentPool(url.toString(), 4);
+    await applySchema(pool, 1536);
+
+    await pool.query(
+      "INSERT INTO corpora (tenant_id, corpus_id, active_generation) VALUES ($1, $1, 1)",
+      [TENANT],
+    );
+    await pool.query(
+      "INSERT INTO content_nodes (tenant_id, generation, stable_id, slug, title, kind, position, status)" +
+        " VALUES ($1, 1, 'n', 'n', 'N', 'document', 1, 'published')",
+      [TENANT],
+    );
+    await pool.query(
+      "INSERT INTO sources (tenant_id, generation, source_id, node_id, title, origin_path," +
+        " content_hash, embedding_model, chunk_policy, source_commit)" +
+        " SELECT $1, 1, 's', node_id, 'N', 'n.md', 'h', 'fake', 'p', 'c'" +
+        " FROM content_nodes WHERE tenant_id = $1 AND generation = 1",
+      [TENANT],
+    );
+    // Random unit-ish vectors: a conservative bed, see the header.
+    await pool.query(
+      `INSERT INTO chunks (tenant_id, generation, source_id, ordinal, content, chunk_hash,
+                           heading_path, embedding, embedding_status, labels)
+       SELECT $1, 1, 's', g, repeat('servable prose filler sentence ', 9), md5(g::text), '[]'::jsonb,
+              (SELECT ('[' || string_agg((random() - 0.5)::text, ',') || ']')::vector
+                 FROM generate_series(1, 1536)),
+              'embedded', '{"source_type":"prose"}'::jsonb
+       FROM generate_series(1, ${ROWS}) g`,
+      [TENANT],
+    );
+    await pool.query("VACUUM ANALYZE chunks");
+  }, 900_000);
+
+  afterAll(async () => {
+    await pool?.end().catch(() => undefined);
+    await admin?.query(`DROP DATABASE IF EXISTS ${DB} WITH (FORCE)`).catch(() => undefined);
+    await admin?.end().catch(() => undefined);
+  });
+
+  it(`the vector arm does NOT open idx_chunks_hnsw at ${ROWS} chunks — issue #59`, async () => {
+    const zero = `[${Array.from({ length: 1536 }, () => "0.001").join(",")}]`;
+    const plan = await runRead(
+      pool,
+      TENANT,
+      async (client) => {
+        const r = await client.query<{ "QUERY PLAN": string }>(`EXPLAIN ${HYBRID_SQL}`, [
+          TENANT,
+          TENANT,
+          zero,
+          "widgets",
+          null,
+          30,
+          10,
+          null,
+          "english",
+        ]);
+        return r.rows.map((row) => row["QUERY PLAN"]).join("\n");
+      },
+      { ...VECTOR_TXN_GUCS, ...WHOLE_RECORD_SCOPE },
+    );
+
+    // The defect, pinned. Read the header before changing this.
+    expect(
+      plan.includes("idx_chunks_hnsw"),
+      "the vector arm now OPENS the index — issue #59 is fixed. Invert this " +
+        `assertion and record the measurement beside it.\nPlan:\n${plan}`,
+    ).toBe(false);
+
+    // …and it is a scan, which is the shape that makes search O(corpus).
+    expect(plan, `Plan:\n${plan}`).toMatch(/Seq Scan on chunks/);
+  }, 300_000);
+});

--- a/packages/content/src/service.ts
+++ b/packages/content/src/service.ts
@@ -405,13 +405,25 @@ export async function search(ctx: ServiceContext, query: string, k = 10): Promis
 
     // "The record does not cover this" and "I could not look properly" are
     // DIFFERENT answers, and only the first is an abstention. When the embed
-    // provider is down on a calibrated record the floor cannot be evaluated at
-    // all, so withholding is right — but reporting it as an abstention told the
-    // agent the record does not cover a question it does cover, for the whole
-    // outage, and the tool description instructs the agent to state exactly
-    // that and not fall back (round-6 review of #43, reproduced live with a
-    // bogus provider key against a corpus that contains the answer).
-    const unavailable = embedFailed && inst.abstain.vectorFloor !== null;
+    // provider is down the vector arm did not run at all, so an empty result is
+    // not evidence about coverage — it is evidence that we could not look.
+    //
+    // This was first fixed for CALIBRATED records only, on the reasoning that a
+    // declared floor cannot be evaluated without an embedding (round-6 review of
+    // #43). The condition was the bug: an UNCALIBRATED record is the default
+    // state of every fresh scaffold, and there the emptiness comes from
+    // `keywordAbstains`, which abstains whenever the keyword arm returns no
+    // rows — and that arm returns nothing for almost every natural-language
+    // question, because `websearch_to_tsquery` ANDs its terms (measured 12/12
+    // on real questions, 2026-08-21). So during any provider outage an
+    // uncalibrated record told every caller it covered nothing, while the tool
+    // description instructs the agent to state exactly that and never fall back
+    // on its own knowledge. Found live against the published 0.0.12 with an
+    // invalid key — the same state a CI key rejection produced that morning.
+    //
+    // The floor is irrelevant to the question being asked here. What matters is
+    // whether we were able to look.
+    const unavailable = embedFailed;
     const reason = unavailable ? "unavailable" : unpublished ? "unpublished" : "abstained";
     return {
       ok: false,


### PR DESCRIPTION
**This does not fix #59.** I tried, the attempt failed its own guard, and I
reverted it. What lands is the instrument that proved the failure, plus one real
hazard found on the way.

## What I tried, and why it is not here

The diagnosis in #59 pointed at two things: the arm's filters are expressions
Postgres cannot estimate, and its generation comes from a join. So I made them
estimable — `source_type` and `dense_len` as STORED GENERATED columns, schema
2.5 with a forward migration — and moved the generation to a scalar subquery.

On an isolated bed that measured **814 ms → 101 ms with the index opened**. On
the REAL `HYBRID_SQL` it changed nothing: still `Seq Scan on chunks`. The
difference is the joins to `sources` and `content_nodes`, which my isolated
query did not have — **the same mistake that produced my first false all-clear
on this issue**, made a second time.

I then could not reproduce the 101 ms result at all on a clean bed: literal
vector, literal generation, estimable columns, still a sequential scan. One
unreproducible measurement is not a basis for a schema migration on every
adopter's database, so the schema change, the migration and the SERVABLE rewrite
are all reverted.

## What lands

**The plan test, as a characterization test.** It EXPLAINs the real `HYBRID_SQL`
against 20,000 chunks and asserts the index is *not* opened — today's truth,
pinned. When someone fixes #59 it goes red with the plan printed and they invert
it deliberately. That is the guard the issue asks for, and it is what caught my
own broken fix; without it I would have shipped a schema migration that did
nothing.

Timing thresholds were considered and rejected: flaky, and they would not have
caught the original regression either. The plan shape is the property that
matters.

**A parameter-renumbering hazard, removed.** The standalone arms built their
WHERE with `ARM_WHERE.replaceAll("$5", "$4")` while patching the generation CTE
separately. That works only while the predicate contains exactly one
placeholder. My attempt added a second, and every standalone keyword and top-1
query began failing with "content store temporarily unavailable" — a correct
sanitization of a driver error that tells you nothing about the cause. It cost
me two debugging cycles. The parameter number is an argument now.

I also got that renumbering wrong once in an obvious way — `KEYWORD_SQL`'s
generation is `$6` and its LIMIT is `$5`, and I compared the generation against
the row limit. Explicit arguments made that visible; string replacement had
hidden it.

Gate: 694 unit / 221 integration / 177 db.