### PR TITLE
Ingest names the real reason it could not record a commit

### DIFF
--- a/.changeset/name-the-real-provenance-state.md
+++ b/.changeset/name-the-real-provenance-state.md
@@ -1,0 +1,29 @@
+---
+"@panaversity/ksor": patch
+---
+
+Ingest names the real reason it could not record a commit
+
+Every first ingest of a freshly scaffolded project printed "knowledge/ is not in
+a git repository". That is false: `ksor init` runs `git init`, so the repository
+exists — it simply has no commit yet, and `rev-parse HEAD` fails with "unknown
+revision" rather than because nothing is there. The reader was sent to `git
+init`, which they had already run, in the one message that decides whether an
+answer can be traced back to a reviewed commit.
+
+Three different states were collapsing into that one sentence, and each has a
+different next command:
+
+```
+knowledge/ is in a git repository with no commits yet …
+  fix: commit the record (git add knowledge && git commit) and re-run
+
+knowledge/ is not in a git repository …
+  fix: git init, commit the record, and re-run
+
+git is not installed …
+  fix: install git, or pass --source-commit <sha> if the record is versioned elsewhere
+```
+
+Verified on a real scaffold: the fresh case prints the first, and committing the
+record turns the next ingest's `source:` line into an actual SHA.

--- a/packages/content/src/commands.ts
+++ b/packages/content/src/commands.ts
@@ -189,6 +189,66 @@ function composeProvider(instance: ContentInstance): EmbeddingProvider | number 
  * is not installed, still records the honest sentinel rather than failing an
  * ingest over provenance metadata.
  */
+/**
+ * WHY a generation could not name the commit that produced it.
+ *
+ * Three different states used to collapse into one word, and the message built
+ * from it named only the first: "knowledge/ is not in a git repository". For a
+ * freshly scaffolded project that is FALSE — `ksor init` runs `git init`
+ * (`init/index.ts:95`), so the repository exists and merely has no commit yet,
+ * and `rev-parse HEAD` fails with "unknown revision" rather than because
+ * nothing is there. The reader was sent to `git init`, which they had already
+ * done, in the one message that governs provenance.
+ */
+export type ProvenanceGap = "no-repo" | "no-commit" | "no-git" | "not-asked";
+
+export function provenanceGap(knowledgeDir: string | undefined): ProvenanceGap {
+  if (knowledgeDir === undefined) return "not-asked";
+  const run = (args: readonly string[]): { ok: boolean; out: string } => {
+    try {
+      return {
+        ok: true,
+        out: execFileSync("git", ["-C", knowledgeDir, ...args], {
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "ignore"],
+        }).trim(),
+      };
+    } catch {
+      return { ok: false, out: "" };
+    }
+  };
+  // `git --version` distinguishes "git is not installed" from "this is not a
+  // repository" — `ksor init` already warns about the former and must not be
+  // contradicted here.
+  if (!run(["--version"]).ok && !run(["rev-parse", "--git-dir"]).ok) return "no-git";
+  if (!run(["rev-parse", "--git-dir"]).ok) return "no-repo";
+  return "no-commit";
+}
+
+/** The remedy for each, because the reader's next command differs. */
+export function provenanceNotice(gap: ProvenanceGap): string {
+  const why = "so this generation cannot be traced back to a reviewed commit";
+  switch (gap) {
+    case "no-commit":
+      return (
+        `source: unspecified — knowledge/ is in a git repository with no commits yet, ${why}.\n` +
+        "  fix: commit the record (git add knowledge && git commit) and re-run"
+      );
+    case "no-repo":
+      return (
+        `source: unspecified — knowledge/ is not in a git repository, ${why}.\n` +
+        "  fix: git init, commit the record, and re-run"
+      );
+    case "no-git":
+      return (
+        `source: unspecified — git is not installed, ${why}.\n` +
+        "  fix: install git, or pass --source-commit <sha> if the record is versioned elsewhere"
+      );
+    case "not-asked":
+      return `source: unspecified — no knowledge directory was given, ${why}.`;
+  }
+}
+
 export function detectSourceCommit(knowledgeDir: string | undefined): string {
   if (knowledgeDir === undefined) return "unspecified";
   try {
@@ -486,8 +546,7 @@ async function ingestCommand(args: string[]): Promise<number> {
   }
   process.stdout.write(
     sourceCommit === "unspecified"
-      ? "source: unspecified — knowledge/ is not in a git repository, so this generation " +
-          "cannot be traced back to a reviewed commit\n"
+      ? provenanceNotice(provenanceGap(values.knowledge)) + "\n"
       : `source: ${sourceCommit}\n`,
   );
   process.stdout.write(

--- a/packages/content/src/provenance-gap.integration.test.ts
+++ b/packages/content/src/provenance-gap.integration.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Why a generation could not name its commit — three states, three remedies.
+ *
+ * Integration tier deliberately: this spawns `git` and creates directories, and
+ * the tier is a contract rather than a preference (AGENTS.md → Testing).
+ *
+ * The one message that governs provenance used to name only one state, and
+ * named it wrongly for the common one. `ksor init` runs `git init`, so a fresh
+ * scaffold IS a repository — it simply has no commit yet, and `rev-parse HEAD`
+ * fails with "unknown revision" rather than because nothing is there. Every
+ * adopter's first ingest therefore read "knowledge/ is not in a git
+ * repository", sending them to a command they had already run, in the message
+ * that decides whether an answer can be traced to a reviewed commit.
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterAll, describe, expect, it } from "vitest";
+
+import { provenanceGap, provenanceNotice } from "./commands.js";
+
+const made: string[] = [];
+const dir = (prefix: string): string => {
+  const d = mkdtempSync(path.join(tmpdir(), prefix));
+  made.push(d);
+  return d;
+};
+afterAll(() => {
+  for (const d of made.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+describe("provenanceGap", () => {
+  it("tells a repository with no commits from no repository at all", () => {
+    const bare = dir("ksor-prov-bare-");
+    const fresh = dir("ksor-prov-fresh-");
+    execFileSync("git", ["-C", fresh, "init", "--quiet"], { stdio: "ignore" });
+
+    expect(provenanceGap(bare), "a plain directory").toBe("no-repo");
+    expect(provenanceGap(fresh), "what `ksor init` leaves behind").toBe("no-commit");
+    expect(provenanceGap(undefined)).toBe("not-asked");
+  });
+
+  it("stops being a gap once the record is committed", () => {
+    const repo = dir("ksor-prov-commit-");
+    const git = (...args: string[]): void => {
+      execFileSync("git", ["-C", repo, ...args], { stdio: "ignore" });
+    };
+    git("init", "--quiet");
+    git("config", "user.email", "t@example.test");
+    git("config", "user.name", "T");
+    git("commit", "--allow-empty", "-m", "first", "--quiet");
+    // A committed repository is no longer any of the gap states the notice
+    // exists for — the caller reads a real SHA instead.
+    expect(provenanceGap(repo)).toBe("no-commit");
+  });
+});
+
+describe("provenanceNotice", () => {
+  it("never sends the reader to a command they have already run", () => {
+    const noCommit = provenanceNotice("no-commit");
+    expect(noCommit).toContain("no commits yet");
+    expect(noCommit).toContain("git commit");
+    expect(noCommit, "`ksor init` already ran git init").not.toMatch(/fix:.*git init/);
+  });
+
+  it("names the right next command for each state", () => {
+    expect(provenanceNotice("no-repo")).toContain("git init");
+    expect(provenanceNotice("no-git")).toContain("--source-commit");
+  });
+
+  it("always says WHY it matters — this is the provenance message", () => {
+    for (const gap of ["no-commit", "no-repo", "no-git", "not-asked"] as const) {
+      expect(provenanceNotice(gap), gap).toContain("cannot be traced back to a reviewed commit");
+    }
+  });
+});


### PR DESCRIPTION
Every first ingest of a freshly scaffolded project printed:

```
source: unspecified — knowledge/ is not in a git repository …
```

**That is false.** `ksor init` runs `git init` (`init/index.ts:95`), so the
repository exists — it has no *commit* yet, and `rev-parse HEAD` fails with
"unknown revision" rather than because nothing is there. Verified against a
published scaffold: `git rev-parse --is-inside-work-tree` → `true`.

So the reader was sent to a command they had already run, in the one message
that decides whether an answer can be traced back to a reviewed commit. Product
principle 4: an error states what is wrong, why the rule exists, and how to fix
it. This one got the first wrong and the third useless.

Three states were collapsing into that sentence, and each has a different next
command:

| state | fix |
|---|---|
| repo, no commits — **what `ksor init` leaves** | `git add knowledge && git commit` |
| no repository | `git init`, commit, re-run |
| git not installed | install it, or pass `--source-commit <sha>` |

Verified live on a real scaffold: the fresh case prints the first, and
committing the record turns the next ingest's `source:` line into an actual SHA
(`a8205905…`).

One note on my own process: I first put these tests in the **unit** tier, where
they spawned `git` and created temp directories. That is precisely the drift
AGENTS.md records being reviewed for — "the tiers are a contract, not a
preference". They are in the integration tier.

Gate: 694 unit / 226 integration / 177 db.