### PR TITLE
Scan only the checkout's source in the env drift test

### DIFF
--- a/.changeset/scan-only-the-checkouts-source.md
+++ b/.changeset/scan-only-the-checkouts-source.md
@@ -1,0 +1,21 @@
+---
+"@panaversity/ksor": patch
+---
+
+Internal: the env-contract drift test scans only the checkout's source
+
+No adopter-visible behaviour changes. The test that guarantees every
+adopter-settable environment variable is named in the scaffold's `env.example`
+walked `packages/` with a `statSync` per entry, and descended into the fake npm
+install another suite roots inside `packages/ksor`. That cost two ways: the
+copied template sources were scanned twice, and an entry deleted between the
+`readdir` and the `statSync` crashed the whole run — which is what took CI red
+on run 32526491721, on an `llms.txt` being cleaned up concurrently.
+
+The walk now takes each entry's type from the readdir snapshot itself, so a
+vanishing entry cannot crash it, and it skips transient install trees, so its
+input no longer depends on whether another suite is mid-run. The `REPO_ONLY`
+exemption list was deleted as dead: it named seven variables that no scanned
+file can contain, because the walk excludes test files in the first place. The
+honesty check that is supposed to catch stale exemptions now covers every
+exemption list, which is what its name always claimed.

--- a/packages/ksor/src/env-documented.integration.test.ts
+++ b/packages/ksor/src/env-documented.integration.test.ts
@@ -16,31 +16,13 @@
  * omission.
  */
 
-import { readdirSync, readFileSync, statSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
 
 const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
-
-/**
- * Variables that exist for THIS repository's own tests and CI, never for an
- * adopter. Naming them in a scaffold's env.example would be noise at best and
- * misleading at worst.
- */
-const REPO_ONLY = new Set([
-  "KSOR_E2E",
-  "KSOR_KEEP_DB",
-  "KSOR_TEST_DSN",
-  "KSOR_TEST_ENV_PARSE",
-  "KSOR_EXPORT_TEST_DSN",
-  "KSOR_X",
-  // A fixture STRING in serve.test.ts demonstrating requireEnv's refusal — not
-  // a variable ksor reads. The first version of this test exempted it as
-  // "documented elsewhere", and the honesty check below caught that.
-  "KSOR_INSTANCE_URI",
-]);
 
 /**
  * Variables documented for the adopter somewhere OTHER than env.example,
@@ -52,33 +34,81 @@ const DOCUMENTED_ELSEWHERE = new Map([
   ["KSOR_INSTANCE", "a CLI convenience for --instance; the flag is the documented form"],
 ]);
 
+/**
+ * Every shipped `.ts` under a directory — the SOURCE set, which is narrower than
+ * "every file" in two ways that both matter here.
+ *
+ * Test files are excluded because a variable only a test reads is not something
+ * an adopter can set; that is also why no exemption list for repo-only test
+ * variables is needed — the scan never sees them.
+ *
+ * Transient trees are excluded because they are not the checkout: another suite
+ * roots a fake npm install inside `packages/ksor` (it needs Node's upward module
+ * resolution), holding a COPY of templates/scaffold. Descending into it scanned
+ * those files a second time and made this scan's input depend on whether that
+ * suite happened to be mid-run.
+ *
+ * The type comes from the readdir snapshot rather than a follow-up `statSync`,
+ * so an entry deleted between the two calls can no longer crash the walk — it
+ * did, on an `llms.txt` being cleaned up concurrently (CI run 32526491721).
+ */
+const TRANSIENT = /^ksor-fakeinstall-/;
+
 function sourceFiles(dir: string, out: string[] = []): string[] {
-  for (const entry of readdirSync(dir)) {
-    if (entry === "node_modules" || entry === "dist" || entry.startsWith(".")) continue;
-    const full = path.join(dir, entry);
-    if (statSync(full).isDirectory()) sourceFiles(full, out);
-    else if (entry.endsWith(".ts") && !entry.endsWith(".test.ts")) out.push(full);
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const name = entry.name;
+    if (name === "node_modules" || name === "dist" || name.startsWith(".")) continue;
+    if (TRANSIENT.test(name)) continue;
+    const full = path.join(dir, name);
+    if (entry.isDirectory()) sourceFiles(full, out);
+    else if (name.endsWith(".ts") && !name.endsWith(".test.ts")) out.push(full);
   }
   return out;
 }
 
-describe("the adopter's env contract covers what the code reads", () => {
-  it("names every adopter-facing variable", () => {
-    const read = new Set<string>();
-    for (const file of sourceFiles(path.join(repoRoot, "packages"))) {
-      for (const m of readFileSync(file, "utf8").matchAll(
-        /\b(KSOR_[A-Z0-9_]+|GEMINI_API_KEY)\b/g,
-      )) {
-        read.add(m[1]!);
-      }
+/** Every adopter-settable variable name the scanned source mentions. */
+function variablesRead(): Set<string> {
+  const read = new Set<string>();
+  for (const file of sourceFiles(path.join(repoRoot, "packages"))) {
+    for (const m of readFileSync(file, "utf8").matchAll(/\b(KSOR_[A-Z0-9_]+|GEMINI_API_KEY)\b/g)) {
+      read.add(m[1]!);
     }
+  }
+  return read;
+}
+
+describe("the adopter's env contract covers what the code reads", () => {
+  it("scans the checkout's source, never another suite's transient install", () => {
+    // init.integration.test.ts roots a fake npm install INSIDE packages/ksor (it
+    // needs Node's upward module resolution to reach the real node_modules), and
+    // fills it with a COPY of templates/scaffold. This walk used to descend into
+    // it, which cost two ways: the copied .ts files were scanned twice, and a
+    // `statSync` on an entry the other suite was concurrently deleting crashed
+    // the run outright (CI 32526491721, ENOENT on a vanishing llms.txt).
+    const transient = mkdtempSync(path.join(repoRoot, "packages", "ksor", "ksor-fakeinstall-"));
+    try {
+      const nested = path.join(transient, "templates", "scaffold", "system");
+      mkdirSync(nested, { recursive: true });
+      writeFileSync(path.join(nested, "copy.ts"), "process.env.KSOR_ONLY_IN_A_TRANSIENT_COPY;");
+
+      const scanned = sourceFiles(path.join(repoRoot, "packages"));
+      expect(
+        scanned.filter((f) => f.includes("ksor-fakeinstall-")),
+        "the env scan descended into a transient install tree",
+      ).toEqual([]);
+    } finally {
+      rmSync(transient, { recursive: true, force: true });
+    }
+  });
+
+  it("names every adopter-facing variable", () => {
+    const read = variablesRead();
     const example = readFileSync(
       path.join(repoRoot, "packages", "ksor", "templates", "scaffold", "env.example"),
       "utf8",
     );
 
     const missing = [...read]
-      .filter((name) => !REPO_ONLY.has(name))
       .filter((name) => !DOCUMENTED_ELSEWHERE.has(name))
       .filter((name) => !example.includes(name))
       .sort();
@@ -86,25 +116,19 @@ describe("the adopter's env contract covers what the code reads", () => {
     expect(
       missing,
       "the code reads these and the adopter's env.example never names them — document each, " +
-        "or add it to REPO_ONLY / DOCUMENTED_ELSEWHERE with the reason: " +
+        "or add it to DOCUMENTED_ELSEWHERE with the reason: " +
         missing.join(", "),
     ).toEqual([]);
   });
 
   it("the exemption lists are honest — every name on them is still read", () => {
     // An exemption for a variable that no longer exists is a stale excuse.
-    const read = new Set<string>();
-    for (const file of sourceFiles(path.join(repoRoot, "packages"))) {
-      for (const m of readFileSync(file, "utf8").matchAll(
-        /\b(KSOR_[A-Z0-9_]+|GEMINI_API_KEY)\b/g,
-      )) {
-        read.add(m[1]!);
-      }
-    }
-    const testFiles = sourceFiles(path.join(repoRoot, "packages"));
-    void testFiles;
-    for (const name of DOCUMENTED_ELSEWHERE.keys()) {
-      expect(read.has(name), `${name} is exempted but the code no longer reads it`).toBe(true);
-    }
+    const read = variablesRead();
+    const stale = [...DOCUMENTED_ELSEWHERE.keys()].filter((name) => !read.has(name)).sort();
+    expect(
+      stale,
+      "these names are exempted but no scanned source reads them — a stale excuse: " +
+        stale.join(", "),
+    ).toEqual([]);
   });
 });


### PR DESCRIPTION
## What went red

PR #64's Integration job failed on something #64 did not touch:

```
ENOENT: stat '…/packages/ksor/ksor-fakeinstall-PjnX2A/templates/scaffold/system/site/app/llms.txt'
❯ sourceFiles packages/ksor/src/env-documented.integration.test.ts:59
```

`env-documented` walks `packages/` for source files. `init.integration.test.ts`
roots a fake npm install **inside `packages/ksor`** — deliberately, so Node's
upward module resolution reaches the real `node_modules` (the comment there
explains why a junction fails on Windows) — and fills it with a copy of
`templates/scaffold`. The two suites run in parallel. The walk `statSync`'d a
path from an already-stale `readdir` snapshot while the other suite was deleting
it.

## Three defects, only one of which is the crash

1. **The crash.** A second syscall on an entry that may already be gone.
2. **A nondeterministic scan set.** When the race *doesn't* crash, the walk
   scans 14 copied template sources a second time. The assertion is set-based so
   the duplicate is harmless today — but the test's input depending on whether
   another suite is mid-run is not a property worth keeping.
3. **A stated guarantee that never ran.** The second test is named *"the
   exemption lists are honest — every name on them is still read"*. It checked
   one of the two lists. Extending it to both goes red immediately:

   ```
   these names are exempted but no scanned source reads them — a stale excuse:
   KSOR_E2E, KSOR_EXPORT_TEST_DSN, KSOR_INSTANCE_URI, KSOR_KEEP_DB,
   KSOR_TEST_DSN, KSOR_TEST_ENV_PARSE, KSOR_X
   ```

   All seven. `REPO_ONLY` filtered nothing, because the walk excludes `.test.ts`
   and those names appear in no other file — so no name it lists can ever reach
   the filter. Deleted; the walk's comment now carries the reasoning that list
   was standing in for.

## The fix

Types come from the `readdir` snapshot (`withFileTypes`), so a vanishing entry
cannot crash the walk and the second syscall is gone. Transient trees are
skipped by name. Both were written red first — the transient test fails on the
current walker with the offending path in the message.

Checked the other four repo-tree walkers: all already use `withFileTypes`, and
none roots at `packages/`, so this was the only one exposed.

Gate: 694 unit, 227 integration (run twice, clean both times), lint/typecheck/guard/check:corpus green.

## On process

I merged #64 with this job red. The check ran, reported `fail`, and my merge
command chained past it. #64's own content was fine and CI on main is green, but
the merge was not gated the way it should have been — flagging it rather than
leaving it in the run log.