### PR TITLE
Record the 0.0.14 walk, and the finding it produced

### DIFF
--- a/.changeset/status-0-0-14.md
+++ b/.changeset/status-0-0-14.md
@@ -1,0 +1,18 @@
+---
+"@panaversity/ksor": patch
+---
+
+Internal: a pool test that raced Postgres, and a comment that had it backwards
+
+No adopter-visible behaviour changes.
+
+`idle.db.test.ts` sampled `pg_stat_activity` immediately after a previous test's
+`pool.end()`. Those are two different clocks — `end()` resolves when the client
+socket closes, while the row disappears only once the server-side backend
+actually exits — so the suite was order-coupled through the database and went
+red in CI on a branch that changed nothing but a document. Each test now waits
+for a quiet database before it starts, and states that it does.
+
+The comment added in the previous release explaining the `env.example` guard fix
+described the rename backwards: the TEMPLATE holds `env.example` and
+`materialize.ts` maps it to `.env.example` on emit, not the other way round.

--- a/docs/status.md
+++ b/docs/status.md
@@ -6,7 +6,7 @@ updated: 2026-08-22.
 
 ## Published package
 
-`@panaversity/ksor` **0.0.13** on npm (trusted publishing, provenance
+`@panaversity/ksor` **0.0.14** on npm (trusted publishing, provenance
 attached). It ships the working `ksor init` described below — including the
 visibility model and the deploy story — AND the bundled content kernel, so
 `ksor serve`, `ksor ingest`, `ksor schema`, `ksor grant`, `ksor takedown`,
@@ -16,15 +16,17 @@ unknown verb is refused with exit `1` and a stable `error: unknown-verb` stderr
 slug. The package root exports `exitCodes`, `verbs`, and `resolveCommand`, and
 docs ship inside the tarball under `docs/`.
 
-Verified end to end against each published version (most recently 0.0.13,
-2026-08-22: fresh `npm install` into a bare project, driven by a real MCP
-client over live Postgres + pgvector with real Gemini embeddings). What that
-walk covers: install · `schema` · `grant` · first `ingest` builds and flips · a
-**second ingest consumes nothing** ("unchanged — generation N already serves
-this corpus") · the shrink guard refusing a catastrophic deletion · `serve`
-boots from `.env` alone · three MCP tools · `search` returns cited passages
-carrying their generation · `read` is byte-faithful · snapshot pinning survives
-a generation flip · both surfaces refuse a withdrawn document.
+Verified end to end against each published version (most recently 0.0.14,
+2026-08-22: fresh `npm install` into a bare project, driven by the real
+`@modelcontextprotocol/client` SDK over live Postgres 17.7 + pgvector 0.8.2
+with real Gemini embeddings). What that walk covers: install · `schema` ·
+`grant` · first `ingest` builds and flips · a **second ingest consumes nothing**
+("unchanged — generation N already serves this corpus") · the shrink guard
+refusing a catastrophic deletion · `serve` boots and prints its posture · three
+MCP tools answer · `search` returns cited passages carrying their generation ·
+`read` is byte-faithful and carries provenance pinned to the serving generation
+· snapshot pinning survives a generation flip · both surfaces refuse a
+withdrawn document.
 
 ### Retrieval, measured rather than asserted
 
@@ -37,6 +39,20 @@ almost no vocabulary with the question (2026-08-21):
   matches nothing. The shipped "hybrid" is empirically vector-only for the
   query shape this product exists to serve; the keyword arm earns its place on
   exact-term lookup, not on questions.
+
+**Most of a realistic corpus never reaches search** (issue #55). Sections
+shorter than the navigation threshold are stored and readable but excluded from
+the search index. Walked on 0.0.14 with four documents — three of them ordinary
+short policy statements (a refund window, an escalation path, a badge rule),
+each 200-300 characters — and **three of the four chunks were classified
+unsearchable**, leaving the scaffold's own placeholder as the only document
+`search` could return. Asked "how long does a buyer have to send something
+back", against a record that states thirty days, the door returned the
+placeholder: the answer was in the corpus, correctly ingested, and unreachable.
+`ksor ingest` reports this honestly since 0.0.13 ("FOUND ONLY BY NAME"), which
+is how it was caught — but honest is not fixed, and short documents are what
+institutional knowledge is largely made of. The threshold's direction is
+undecided: it needs measuring against both corpus shapes before it moves.
 
 **The vector index is NOT being used** (issue #59). `idx_chunks_hnsw` is built
 and maintained, and the query `ksor serve` sends plans a sequential scan plus a
@@ -130,9 +146,9 @@ cannot land unnoticed.
     surface (decision 11 revision 2026-08-20), `ksor init` now declares
     `@panaversity/ksor` as a scaffold dependency pinned to the exact CLI
     version, with `pnpm serve` / `pnpm ingest` scripts — so the served tool is
-    first-class in every new project. **Released in 0.0.8-0.0.13.**
+    first-class in every new project. **Released in 0.0.8-0.0.14.**
 
-- **Governance, honesty and measurement work (0.0.8-0.0.13, 2026-08-21/22).**
+- **Governance, honesty and measurement work (0.0.8-0.0.14, 2026-08-21/22).**
   Reading order is one rule across the website, `llms.txt` and the MCP
   `outline` tool — the door had been reading the predecessor's Docusaurus keys,
   which no compliant record may declare. `ksor serve` reports its own posture

--- a/packages/ksor/src/scaffold-scripts.integration.test.ts
+++ b/packages/ksor/src/scaffold-scripts.integration.test.ts
@@ -139,11 +139,13 @@ describe("no document claims that serving publishes", () => {
   ];
 
   it.each(ADOPTER_FACING)("%s", (file) => {
-    // Read it OUTRIGHT. This skipped a missing file for years, and one of the
-    // five names was `.env.example` while the scaffold emits `env.example` —
-    // so the row for the file that actually carries the serve variables never
-    // ran, in the guard whose claim had already been wrong four times. A name
-    // that stops matching must fail here, not quietly stop asserting.
+    // Read it OUTRIGHT. A `try/catch { return }` here meant a name that stopped
+    // matching stopped asserting, silently: this list said `.env.example`, which
+    // is the EMITTED name — materialize.ts:23 maps `env.example` -> `.env.example`
+    // on the way out — while this guard reads the TEMPLATE tree, where the file
+    // is `env.example`. So the row covering the file that actually carries the
+    // serving variables never ran, in the guard whose claim had already been
+    // wrong four times.
     const full = path.join(here, "..", "templates", "scaffold", file);
     const text = readFileSync(full, "utf8");
     for (const shape of FUSED) {

--- a/packages/postgres/src/idle.db.test.ts
+++ b/packages/postgres/src/idle.db.test.ts
@@ -12,7 +12,7 @@
  * actually opens what it says.
  */
 
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 import { createPool, prewarmPool } from "./db.js";
 import type pg from "pg";
@@ -22,7 +22,7 @@ const DB = "ksor_idle_test";
 
 describe.runIf(adminDsn !== "")("idle connection policy (db)", () => {
   let admin: pg.Pool;
-  let dsn: string;
+  let dsn = "";
   const pools: pg.Pool[] = [];
 
   const track = (p: pg.Pool): pg.Pool => {
@@ -39,6 +39,34 @@ describe.runIf(adminDsn !== "")("idle connection policy (db)", () => {
     );
     return r.rows[0].n as number;
   };
+
+  /**
+   * Wait for Postgres's own count to reach `want`, then answer with what it
+   * actually reached — so a failure still prints the number seen.
+   *
+   * `pool.end()` resolves when the CLIENT socket closes; pg_stat_activity drops
+   * the row only once the server-side backend process exits, and those are not
+   * the same instant. Sampling the server once, immediately, raced that gap:
+   * this suite went red in CI on a branch that changed nothing but a document,
+   * because the previous test's three closing backends were still listed.
+   */
+  const backendsSettleTo = async (want: number, timeoutMs = 5_000): Promise<number> => {
+    const deadline = Date.now() + timeoutMs;
+    let seen = await backends();
+    while (seen !== want && Date.now() < deadline) {
+      await settle(50);
+      seen = await backends();
+    }
+    return seen;
+  };
+
+  // Each test states what a quiet database holds, so each must START from one.
+  // Without this the suite is order-coupled through the server, and the coupling
+  // is invisible until it fails somewhere unrelated.
+  beforeEach(async () => {
+    if (dsn === "") return;
+    expect(await backendsSettleTo(0), "a previous test's backends never drained").toBe(0);
+  });
 
   beforeAll(async () => {
     const { Pool } = (await import("pg")).default;


### PR DESCRIPTION
0.0.14 published, so `docs/status.md` — which AGENTS.md names *the only
authority on what is actually built* — said 0.0.13 in four places. Corrected,
and the correction was earned by actually running the walk rather than
editing the number.

## The walk

Fresh `npm install @panaversity/ksor@0.0.14` into a bare project, driven by the
real `@modelcontextprotocol/client` SDK against live Postgres 17.7 + pgvector
0.8.2 with real Gemini embeddings. Install · `schema` · `grant` · `ingest`
builds and flips (generation 2) · a second `ingest` consumes nothing · `serve`
boots and prints its posture · all three MCP tools answer · `read` is
byte-faithful and carries provenance pinned to the serving generation.

Three earlier fixes were visible working in the same run: a deliberately bad
provider key produced `embedded 0, failed 1` → **`NOT READY — no flip`**
(0.0.9), the provider failure was **not** dressed up as an abstention (0.0.13),
and on a freshly scaffolded project `source:` named the real state — *"in a git
repository with no commits yet"* — then became an actual SHA once the record was
committed (0.0.14, the fix this release carries).

## What the walk found — issue #55 is worse than "tuning"

I gave the record three ordinary short policy statements: a refund window, an
escalation path, a badge rule. 200-300 characters each — the shape institutional
knowledge actually comes in.

**Three of four chunks were classified unsearchable.** The only document
`search` could return was the scaffold's own placeholder. So:

> **Q.** "how long does a buyer have to send something back"
> **A.** the placeholder document — against a record that plainly states *thirty days*.

The answer was in the corpus, correctly ingested, provably readable by slug, and
unreachable by search. `ksor ingest` reports this honestly since 0.0.13 (`FOUND
ONLY BY NAME`), which is exactly how it was caught — but honest is not fixed.
Recorded in `status.md` beside the #59 measurement.

I have not changed the threshold here. Its direction is genuinely undecided and
it needs measuring against both corpus shapes first; moving it changes what is
retrievable for every adopter on re-ingest.

## One correction to my own last PR

#67 fixed a guard row that named `.env.example` where the guard reads the
template tree, and I explained it backwards in the comment: the **template**
holds `env.example`, and `materialize.ts:23` maps it to `.env.example` on
emit. The fix was right; the sentence describing it was not. Corrected here.

Docs and one test comment only — no behaviour change, hence no changeset.
Gate: 694 unit · 227 integration · guard · check:corpus.