### PR TITLE
Decide navigation by shape, not by length (#55)

### DIFF
--- a/.changeset/nav-by-shape-not-length.md
+++ b/.changeset/nav-by-shape-not-length.md
@@ -15,7 +15,7 @@ escalation path, a badge rule, 200-300 characters each. Three of four chunks
 were unsearchable, and:
 
 > **Q.** "how long does a buyer have to send something back"
-> **A.** the scaffold's placeholder page — against a record stating *thirty days*
+> **A.** the scaffold's placeholder page — against a record stating _thirty days_
 
 The answer was in the corpus, correctly ingested, readable by slug, and
 unreachable by search.

--- a/.changeset/nav-by-shape-not-length.md
+++ b/.changeset/nav-by-shape-not-length.md
@@ -1,0 +1,38 @@
+---
+"@panaversity/ksor": patch
+---
+
+Short documents reach search again — navigation is a shape, not a length
+
+A record could be fully ingested, report "embedded 16, failed 0", and still be
+unable to answer questions it plainly contained. Sections were classified as
+navigation by LENGTH — anything under 250 characters — and navigation is
+excluded from every retrieval arm. On a handbook that inverts the intent,
+because a handbook's most valuable statements are its shortest.
+
+Walked on 0.0.14 with three ordinary policy statements — a refund window, an
+escalation path, a badge rule, 200-300 characters each. Three of four chunks
+were unsearchable, and:
+
+> **Q.** "how long does a buyer have to send something back"
+> **A.** the scaffold's placeholder page — against a record stating *thirty days*
+
+The answer was in the corpus, correctly ingested, readable by slug, and
+unreachable by search.
+
+Navigation is now decided by shape: a section is navigation when link lines are
+most of it, or when what remains after them is too short to answer anything —
+the same floor the serving predicate already applies. Length is no longer
+consulted, so a 180-character link list is navigation and a 51-character fact is
+not, which is the ordering length had backwards.
+
+Measured on an authored handbook gold set with real embeddings, paired: short
+substantive facts went **0/9 to 9/9 at rank 1**, the long-prose control held at
+**4/4**, and the link-list page was returned **0** times. That last number is the
+one that matters — admitting everything would have improved the first two and
+made the product worse.
+
+**To pick this up, re-run `ksor ingest`.** Chunks are re-classified on every
+build and unchanged content is not re-embedded, so the upgrade costs a build,
+not an embedding bill. `CHUNK_POLICY` moves to v6 because it is persisted
+provenance and the behaviour it labels has changed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -546,6 +546,46 @@ gateway` package, serve-by-spawn) is superseded._
     the tool can VERIFY rather than read — a bearer token's subject qualifies,
     an environment variable never will.
 
+22. **Navigation is a SHAPE, not a length** (2026-08-22, issue #55 — the first
+    DELIBERATE divergence from the converted oracle). `classify()` labelled any
+    segment under 250 code points `nav`, and the serving predicate admits only
+    `prose`, so a record could be fully ingested and unable to answer questions
+    it plainly contained. On the curriculum corpus the oracle was tuned against
+    the proxy holds — a short segment there really is a link list. On a handbook
+    it inverts, because a handbook's most valuable statements are its shortest.
+    Walked live on 0.0.14: three ordinary policy statements, three of four
+    chunks unsearchable, and "how long does a buyer have to send something back"
+    answered with the scaffold's placeholder against a record stating thirty
+    days.
+
+    A segment is now `nav` when link lines are most of it, or when what remains
+    after them is under `MIN_CONTENT_CHARS` — the SAME floor the serving
+    predicate applies, so this never labels `prose` something search would
+    refuse anyway. Length is not consulted: a 180-character link list is nav and
+    a 51-character fact is prose, which is the ordering length got backwards.
+
+    Measured on the handbook gold, real Gemini embeddings, paired: short
+    substantive facts **0/9 → 9/9 at rank 1**, the long-prose control held at
+    **4/4**, and the link-list negative was returned **0** times — so the gain
+    is correctness rather than permissiveness, which is the distinction the gold
+    was built to make. Recorded in `evals/baseline.ts`; the harness prints
+    current against it and the floors may not fall silently.
+
+    `CHUNK_POLICY` moves v5 → v6 because it is persisted provenance and the
+    behaviour it labels changed. The oracle fixture is NOT regenerated — it
+    stays the record that the port was faithful — and the divergence is asserted
+    as a property instead: sourceType may differ only `nav` → `prose`, only
+    where the whole section carries real prose, and everything else stays
+    byte-identical. That corpus cannot settle the question either way; it
+    contains no markdown links at all, which is asserted so the next reader does
+    not mistake its 61 `nav` labels for evidence about navigation.
+
+    Adopters get it by re-running `ksor ingest`: chunks are re-classified on
+    every build, and carry-forward sets only the embedding fields
+    (`ingest/generation.ts:174`), so unchanged content is not re-embedded.
+    Reversed only by a measurement showing the shape rule admitting navigation
+    the length rule kept out.
+
 **Open questions — decide independently when the work arrives:** ~~how
 retrieval and abstention are implemented for `serve`~~ — decided 2026-08-19,
 decision 11: the predecessor kernel converts (revision trail: recorded as

--- a/docs/status.md
+++ b/docs/status.md
@@ -40,19 +40,19 @@ almost no vocabulary with the question (2026-08-21):
   query shape this product exists to serve; the keyword arm earns its place on
   exact-term lookup, not on questions.
 
-**Most of a realistic corpus never reaches search** (issue #55). Sections
-shorter than the navigation threshold are stored and readable but excluded from
-the search index. Walked on 0.0.14 with four documents — three of them ordinary
-short policy statements (a refund window, an escalation path, a badge rule),
-each 200-300 characters — and **three of the four chunks were classified
-unsearchable**, leaving the scaffold's own placeholder as the only document
-`search` could return. Asked "how long does a buyer have to send something
-back", against a record that states thirty days, the door returned the
-placeholder: the answer was in the corpus, correctly ingested, and unreachable.
-`ksor ingest` reports this honestly since 0.0.13 ("FOUND ONLY BY NAME"), which
-is how it was caught — but honest is not fixed, and short documents are what
-institutional knowledge is largely made of. The threshold's direction is
-undecided: it needs measuring against both corpus shapes before it moves.
+**Short documents reach search again** (issue #55, fixed 2026-08-22). Sections
+were classified navigation by LENGTH — anything under 250 code points — and
+navigation is excluded from every retrieval arm. Walked on 0.0.14 with three
+ordinary short policy statements: three of four chunks unsearchable, and a
+question the record plainly answered was served the scaffold's placeholder
+instead. Navigation is now decided by SHAPE (link-dominated, or too little text
+left to answer anything), which is what the word always meant. Measured on the
+handbook gold with real Gemini embeddings: short substantive facts **0/9 → 9/9
+at rank 1**, the long-prose control held at **4/4**, and the link-list negative
+was returned **0** times — correctness, not permissiveness. The recorded line
+lives in `packages/content/src/evals/baseline.ts` and the harness prints every
+run against it. Adopters get it by re-running `ksor ingest`; unchanged content
+is not re-embedded.
 
 **The vector index is NOT being used** (issue #59). `idx_chunks_hnsw` is built
 and maintained, and the query `ksor serve` sends plans a sequential scan plus a

--- a/packages/content/src/config.ts
+++ b/packages/content/src/config.ts
@@ -25,7 +25,7 @@ export const EMBED_TASK_QUERY = "RETRIEVAL_QUERY";
 export const EMBED_RECIPE: string = `${EMBED_MODEL}/d${EMBED_DIM}/${EMBED_TASK_DOCUMENT}`;
 export const RRF_K = 60;
 /** bump ⇒ provenance (v5: CommonMark fences). All char limits count CODE POINTS (Python len parity). */
-export const CHUNK_POLICY = "heading-aware-1500-content-only-v5";
+export const CHUNK_POLICY = "heading-aware-1500-content-only-v6";
 export const MAX_CHARS = 1500;
 export const NAV_MAX_CHARS = 250;
 /** < Gemini's 2048-token embed input. */

--- a/packages/content/src/evals/baseline.ts
+++ b/packages/content/src/evals/baseline.ts
@@ -1,0 +1,85 @@
+/**
+ * The recorded measurement a change is judged against.
+ *
+ * Every retrieval change before this one was argued from a fresh number with
+ * nothing to compare it to, which makes "better" a matter of whoever ran it
+ * last. A baseline turns that into a delta: the harness prints current against
+ * recorded, and the guarantees below fail rather than drift.
+ *
+ * WHAT RATCHETS AND WHAT DOES NOT, following the testing contract:
+ *   - `shortSubstantiveAt1` and `longProseAt1` are FLOORS. They may rise and a
+ *     rise should be recorded here; they may not fall without a decision.
+ *   - `navNegativeHits` is a CEILING, and it is the one that stops "improve
+ *     recall" from meaning "return everything". A classifier that admits the
+ *     link-list index page scores better on both floors and is worse.
+ *   - `oocAnswered` is REPORTED, never asserted: the fixture declares no
+ *     abstention floor, so every out-of-corpus probe is answered by design and
+ *     the number measures the fixture's posture, not the retriever's quality.
+ *     It becomes meaningful only once the fixture is calibrated.
+ *
+ * Absolute values are gold-dependent — trust the paired delta, not the number.
+ * Re-measure with:
+ *   KSOR_DB_URL=… GEMINI_API_KEY=… pnpm vitest run --config vitest.db.config.ts \
+ *     --disable-console-intercept packages/content/src/evals/retrieval-measure.db.test.ts
+ */
+
+export interface RetrievalBaseline {
+  /** When this line was measured, and against which corpus and space. */
+  readonly measuredAt: string;
+  readonly corpus: string;
+  readonly embedding: string;
+  /** Floors: distinct-node success@1 by gold category. */
+  readonly shortSubstantiveAt1: number;
+  readonly shortSubstantiveTotal: number;
+  readonly longProseAt1: number;
+  readonly longProseTotal: number;
+  /** Ceiling: gold questions that returned the link-list page. */
+  readonly navNegativeHits: number;
+  /** Reported only — the fixture declares no floor, so this is its posture. */
+  readonly oocAnswered: number;
+  readonly oocTotal: number;
+  /** What changed since the previous line, in one sentence. */
+  readonly note: string;
+}
+
+/**
+ * The line in force. Supersede it by REPLACING it and moving the old one into
+ * `RETRIEVAL_HISTORY` below — a baseline with no history is just a number.
+ */
+export const RETRIEVAL_BASELINE: RetrievalBaseline = {
+  measuredAt: "2026-08-22",
+  corpus: "evals/fixtures/handbook (6 documents, 13 gold questions, 8 ooc probes)",
+  embedding: "gemini-embedding-001 @ 1536",
+  shortSubstantiveAt1: 9,
+  shortSubstantiveTotal: 9,
+  longProseAt1: 4,
+  longProseTotal: 4,
+  navNegativeHits: 0,
+  oocAnswered: 8,
+  oocTotal: 8,
+  note:
+    "Issue #55: `classify()` decides navigation by SHAPE rather than length. " +
+    "Short substantive facts went 0/9 -> 9/9 at rank 1, the long-prose control " +
+    "held at 4/4, and the link-list page was returned 0 times — so the gain is " +
+    "correctness, not permissiveness.",
+};
+
+/** Superseded lines, newest first. Kept so a regression can be dated. */
+export const RETRIEVAL_HISTORY: readonly RetrievalBaseline[] = [
+  {
+    measuredAt: "2026-08-21",
+    corpus: "evals/fixtures/handbook (6 documents, 13 gold questions, 8 ooc probes)",
+    embedding: "gemini-embedding-001 @ 1536",
+    shortSubstantiveAt1: 0,
+    shortSubstantiveTotal: 9,
+    longProseAt1: 4,
+    longProseTotal: 4,
+    navNegativeHits: 0,
+    oocAnswered: 8,
+    oocTotal: 8,
+    note:
+      "The defect, characterized: every short substantive fact was unreachable at " +
+      "any k because `classify()` labelled anything under 250 code points `nav`, " +
+      "and the serving predicate admits only `prose`.",
+  },
+];

--- a/packages/content/src/evals/retrieval-measure.db.test.ts
+++ b/packages/content/src/evals/retrieval-measure.db.test.ts
@@ -37,6 +37,7 @@ import { embedQueryVlit } from "../lib/query-embed.js";
 import { keyRingFromEnv } from "../lib/snapshot.js";
 import { applySchema } from "../schema.js";
 import { search } from "../service.js";
+import { RETRIEVAL_BASELINE } from "./baseline.js";
 import { HANDBOOK_GOLD, HANDBOOK_OOC, NAV_NEGATIVE_SLUG, type GoldKind } from "./handbook-gold.js";
 import type { ContentInstance } from "../instance.js";
 import type { ServiceContext } from "../service.js";
@@ -168,6 +169,23 @@ describe.runIf(canMeasure)("what a handbook-shaped record can be asked (db, live
       lines.push("  UNREACHABLE at k=10:");
       for (const m of missed) lines.push(`    ${m}`);
     }
+    // Against the recorded line, so a change arrives as a DELTA rather than as
+    // a fresh number with nothing to compare it to.
+    const b = RETRIEVAL_BASELINE;
+    const delta = (now: number, was: number): string =>
+      now === was ? "=" : now > was ? `+${now - was}` : `${now - was}`;
+    lines.push(
+      "",
+      `  vs baseline ${b.measuredAt} (${b.embedding}):`,
+      `    short-substantive @1  ${at(byKind("short-substantive"), 1)}/${b.shortSubstantiveTotal}` +
+        `   baseline ${b.shortSubstantiveAt1}   ${delta(at(byKind("short-substantive"), 1), b.shortSubstantiveAt1)}`,
+      `    long-prose        @1  ${at(byKind("long-prose"), 1)}/${b.longProseTotal}` +
+        `   baseline ${b.longProseAt1}   ${delta(at(byKind("long-prose"), 1), b.longProseAt1)}`,
+      `    nav negative          ${scored.filter((s) => s.hitNav).length}` +
+        `      baseline ${b.navNegativeHits}   ${delta(scored.filter((s) => s.hitNav).length, b.navNegativeHits)}`,
+      `  baseline note: ${b.note}`,
+    );
+
     console.log(lines.join("\n"));
 
     // The ONE gating assertion: the measurement must still be able to tell a
@@ -190,17 +208,52 @@ describe.runIf(canMeasure)("what a handbook-shaped record can be asked (db, live
     ).toBe(prose.length);
   });
 
-  it("characterizes TODAY: short substantive facts are NOT reachable (issue #55)", () => {
-    // This assertion is expected to FLIP when the classifier is fixed. That is
-    // its purpose — the change arrives as a reviewed diff with numbers, not as
-    // a silent shift in what the record can answer.
+  it("short substantive facts are reachable — the #55 fix, held", () => {
+    // This assertion USED to read "NOT reachable", pinning the defect: all nine
+    // of these questions returned nothing, against a corpus that answers every
+    // one of them. It flipped when `classify()` started deciding navigation by
+    // shape instead of by length, which is what it was written to do — the
+    // change arrived as a reviewed diff with numbers rather than as a silent
+    // shift in what the record can answer.
     const short = scored.filter((s) => s.kind === "short-substantive");
-    const unreachable = short.filter((s) => s.rank === null).length;
+    const unreachable = short.filter((s) => s.rank === null);
     expect(
-      unreachable,
-      `if this is no longer all of them, the classifier changed — update the characterization ` +
-        `and record the measurement: ${JSON.stringify(short.map((s) => [s.q, s.rank]))}`,
-    ).toBe(short.length);
+      unreachable.map((s) => s.q),
+      "a short substantive fact stopped being reachable — #55 is regressing",
+    ).toEqual([]);
+  });
+
+  it("the nav negative is never the answer — correct, not merely permissive", () => {
+    // The guard that separates a fixed classifier from a broken one. Admitting
+    // everything would make every recall number above look better and make the
+    // product worse: the index page is a list of links and must never be what a
+    // content question retrieves.
+    const leaked = scored.filter((s) => s.hitNav);
+    expect(
+      leaked.map((s) => s.q),
+      "the link-list index page was returned as an answer to a content question",
+    ).toEqual([]);
+  });
+
+  it("does not fall below the recorded baseline", () => {
+    // Floors may RISE — record the rise in baseline.ts when they do. They may
+    // not fall silently: a retrieval change that costs reach is a decision, and
+    // this is where it has to be taken rather than noticed later.
+    const at1 = (kind: GoldKind): number =>
+      scored.filter((s) => s.kind === kind && s.rank !== null && s.rank <= 1).length;
+    expect(
+      at1("short-substantive"),
+      `short-substantive success@1 fell below the ${RETRIEVAL_BASELINE.measuredAt} baseline`,
+    ).toBeGreaterThanOrEqual(RETRIEVAL_BASELINE.shortSubstantiveAt1);
+    expect(
+      at1("long-prose"),
+      `the long-prose control fell below the ${RETRIEVAL_BASELINE.measuredAt} baseline`,
+    ).toBeGreaterThanOrEqual(RETRIEVAL_BASELINE.longProseAt1);
+    // The ceiling, which is what keeps "better recall" honest.
+    expect(
+      scored.filter((s) => s.hitNav).length,
+      "more gold questions returned the link-list page than the baseline allows",
+    ).toBeLessThanOrEqual(RETRIEVAL_BASELINE.navNegativeHits);
   });
 
   it("skips without KSOR_DB_URL and GEMINI_API_KEY", () => {

--- a/packages/content/src/ingest/chunking.test.ts
+++ b/packages/content/src/ingest/chunking.test.ts
@@ -6,6 +6,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  classify,
   CHUNK_POLICY,
   HARD_MAX_CHARS,
   chunkText,
@@ -13,6 +14,7 @@ import {
   headingPathText,
   stripPresentationJsx,
   stripStyleBlocks,
+  isNavShaped,
 } from "./chunking.js";
 import { chunkingFixtures } from "./fixtures/chunking.fixture.js";
 import { contentHash } from "./markdown.js";
@@ -24,8 +26,15 @@ const chunksFor = (cleaned: string, maxChars: number | null) =>
   maxChars === null ? chunkText(cleaned) : chunkText(cleaned, maxChars);
 
 describe("chunk policy", () => {
-  it("matches the oracle's policy string — the port must never need a bump", () => {
-    expect(CHUNK_POLICY).toBe(chunkingFixtures.policy);
+  it("has moved ONE version past the oracle, deliberately", () => {
+    // The port needed no bump for three releases, which is what the previous
+    // wording recorded. Issue #55 is the first DELIBERATE divergence: the
+    // oracle decides `nav` by length and we decide it by shape. The policy
+    // string is persisted per source row and gates carry-forward, so this bump
+    // is what makes an existing corpus RE-CHUNK instead of serving chunks
+    // labelled by a rule that no longer exists.
+    expect(chunkingFixtures.policy).toBe("heading-aware-1500-content-only-v5");
+    expect(CHUNK_POLICY).toBe("heading-aware-1500-content-only-v6");
   });
 });
 
@@ -45,13 +54,16 @@ describe("oracle fixture equality", () => {
 
       got.forEach((chunk, i) => {
         const want = c.chunks[i]!;
+        // Everything the oracle decided about SHAPE stays byte-identical. Only
+        // `sourceType` may differ, and only in the one direction issue #55
+        // allows — see the divergence assertions below.
         expect(chunk, `${c.name} chunk ${i}; got ${JSON.stringify(chunk)}`).toEqual({
           ordinal: want.ordinal,
           content: want.content,
           chunkHash: want.chunkHash,
           headingPath: want.headingPath,
           anchor: want.anchor,
-          sourceType: want.sourceType,
+          sourceType: chunk.sourceType,
         });
         expect(
           headingPathText(chunk.headingPath),
@@ -136,5 +148,132 @@ describe("cleanBody — CRLF normalized BEFORE the strippers (review 2026-08-19)
 
   it("leaves a bare \\r (no following \\n) as content", () => {
     expect(cleanBody("line1\rline2")).toBe("line1\rline2");
+  });
+});
+
+/**
+ * Issue #55 — navigation is a SHAPE, not a length.
+ *
+ * The converted rule classified any segment under NAV_MAX_CHARS (250 code
+ * points) as `nav`, and the serving predicate admits only `prose`. On the
+ * curriculum corpus the oracle was tuned against, that proxy holds: a short
+ * segment there really is a link list. On a handbook it inverts — the highest
+ * value content is short and declarative, so the rule silently deleted it from
+ * search. Walked live on 0.0.14: three ordinary policy statements, three of
+ * four chunks unsearchable, and "how long does a buyer have to send something
+ * back" answered with the scaffold's placeholder against a record that states
+ * thirty days.
+ *
+ * The bodies below are the fixture corpus in `evals/fixtures/handbook`, which
+ * exists to make this decision measurable rather than arguable.
+ */
+describe("nav is decided by shape, not by length (#55)", () => {
+  const SHORT_FACT = "\nSix months, with a written review at three and six.\n";
+  const LINK_LIST =
+    "\n- [Probation](probation.md)\n- [Notice periods](notice-periods.md)\n" +
+    "- [Expense limits](expense-limits.md)\n- [Travel](travel.md)\n" +
+    "- [Incidents](incidents.md)\n\nSee also the finance intranet.\n";
+
+  it("a complete short fact is prose — 51 characters, and the whole answer", () => {
+    expect(classify(SHORT_FACT, ["Probation"])).toBe("prose");
+  });
+
+  it("a link list is nav even though it is LONGER than the fact", () => {
+    // 180-odd characters against the fact's 51: length ranks these the wrong
+    // way round, which is exactly why length cannot be the rule.
+    expect(LINK_LIST.length).toBeGreaterThan(SHORT_FACT.length);
+    expect(classify(LINK_LIST, ["Handbook"])).toBe("nav");
+  });
+
+  it("a heading with nothing under it is still nav", () => {
+    expect(classify("\n\n", ["Empty"])).toBe("nav");
+  });
+
+  it("a stub too short to answer anything is still nav", () => {
+    expect(classify("\nTODO\n", ["Stub"])).toBe("nav");
+  });
+
+  it("prose that happens to CONTAIN a link is prose", () => {
+    expect(
+      classify("\nClaim within thirty days; see the [expenses page](x.md) to file.\n", [
+        "Expenses",
+      ]),
+    ).toBe("prose");
+  });
+
+  it("a one-line 'see also' pointer is nav", () => {
+    expect(classify("\n- [Finance intranet](https://example.com)\n", ["See also"])).toBe("nav");
+  });
+});
+
+/**
+ * We diverge from the oracle on exactly one field, and the divergence is a
+ * property rather than a list — so it stays true as fixtures change, and a
+ * change of direction fails loudly.
+ *
+ * The oracle's corpus cannot settle the nav question either way: it contains
+ * NO markdown links at all (asserted below). Its 61 `nav` labels are artifacts
+ * of short synthetic bodies, not of navigation. That is why the handbook
+ * fixture in `evals/fixtures/handbook` exists.
+ */
+describe("how we differ from the oracle, and only how", () => {
+  const diffs = chunkingFixtures.cases.flatMap((c) => {
+    const got = chunksFor(clean(c.raw), c.maxChars);
+    return got.flatMap((chunk, i) => {
+      const want = c.chunks[i];
+      return want !== undefined && chunk.sourceType !== want.sourceType
+        ? [
+            {
+              case: c.name,
+              was: want.sourceType,
+              now: chunk.sourceType,
+              body: chunk.content,
+              headingPathText: headingPathText(chunk.headingPath),
+            },
+          ]
+        : [];
+    });
+  });
+
+  it("differs ONLY on sourceType, and only nav -> prose", () => {
+    // The dangerous direction is prose -> nav: that DELETES something from
+    // search. Nothing may take it without a decision of its own.
+    const wrongWay = diffs.filter((d) => !(d.was === "nav" && d.now === "prose"));
+    expect(
+      wrongWay.map((d) => `${d.case}: ${d.was} -> ${d.now} ${JSON.stringify(d.body.slice(0, 60))}`),
+      "a chunk changed classification in a direction #55 does not license",
+    ).toEqual([]);
+  });
+
+  it("promotes only chunks whose SECTION carries real prose", () => {
+    // The unit of classification is the heading-segment, not the chunk: the
+    // oracle's own invariant is that a split section never orphans a heading
+    // piece as nav, so a two-word fragment of a substantial section is
+    // correctly prose. Asserting per chunk measures the wrong thing — it flags
+    // "After the fence." while its section is a page of text. So the section is
+    // reassembled and asked the question the implementation asks.
+    const bySection = new Map<string, string>();
+    for (const c of chunkingFixtures.cases) {
+      for (const chunk of chunksFor(clean(c.raw), c.maxChars)) {
+        const key = `${c.name}\u0000${headingPathText(chunk.headingPath)}`;
+        bySection.set(key, (bySection.get(key) ?? "") + chunk.content);
+      }
+    }
+    const unjustified = diffs.filter((d) => {
+      const section = bySection.get(`${d.case}\u0000${d.headingPathText}`) ?? d.body;
+      return isNavShaped(section);
+    });
+    expect(
+      unjustified.map((d) => `${d.case}: ${JSON.stringify(d.body.slice(0, 60))}`),
+      "a chunk was promoted to prose although its whole section is navigation",
+    ).toEqual([]);
+  });
+
+  it("the oracle corpus cannot settle the nav question — it has no links", () => {
+    // Recorded because it is the reason the handbook fixture had to be written:
+    // measuring a navigation rule against a corpus with no navigation in it
+    // would have confirmed whatever rule was already there.
+    const withLinks = chunkingFixtures.cases.filter((c) => /\[[^\]]+\]\([^)]+\)/.test(c.cleaned));
+    expect(withLinks.map((c) => c.name)).toEqual([]);
   });
 });

--- a/packages/content/src/ingest/chunking.ts
+++ b/packages/content/src/ingest/chunking.ts
@@ -45,7 +45,7 @@ export {
   HARD_MAX_CHARS,
   MIN_CONTENT_CHARS,
 } from "../config.js";
-import { MAX_CHARS, NAV_MAX_CHARS, HARD_MAX_CHARS } from "../config.js";
+import { MAX_CHARS, NAV_MAX_CHARS, HARD_MAX_CHARS, MIN_CONTENT_CHARS } from "../config.js";
 
 // --- Python text semantics, reproduced exactly ------------------------------
 
@@ -431,6 +431,50 @@ function teachingBody(content: string): string {
   );
 }
 
+/**
+ * A line that is navigation rather than prose: strip its list marker and what
+ * remains is nothing but links.
+ *
+ * Deliberately narrow. A line with prose AROUND a link ("Claim within thirty
+ * days; see the [expenses page](x) to file.") is prose, because the sentence is
+ * the content and the link is incidental.
+ */
+const NAV_LINE =
+  /^(?:[-*+]\s+|\d+[.)]\s+)?(?:\[[^\]]*\]\([^)]*\)|<https?:\/\/[^>]*>|https?:\/\/\S+)(?:[\s,;·|>—–-]*(?:\[[^\]]*\]\([^)]*\)|<https?:\/\/[^>]*>|https?:\/\/\S+))*[\s.,;:]*$/;
+
+/**
+ * Is this segment NAVIGATION — a thing that points at content rather than
+ * being content?
+ *
+ * The oracle answered this with length: under NAV_MAX_CHARS (250) meant nav.
+ * On the curriculum corpus it was tuned against, that proxy holds — a short
+ * segment there really is a link list. On a handbook it inverts, because a
+ * handbook's most valuable statements are its shortest ("Six months, with a
+ * written review at three and six"), and `nav` is excluded from search. Issue
+ * #55, walked live on 0.0.14: three of four chunks in an ordinary policy
+ * record were unsearchable, and a question the record plainly answered was
+ * served the scaffold's placeholder instead.
+ *
+ * So the question is asked about SHAPE, which is what "navigation" always
+ * meant. A segment is nav when link lines are most of it, or when what is left
+ * after them is too little to answer anything (MIN_CONTENT_CHARS — the same
+ * floor the serving predicate applies, so this never labels `prose` something
+ * search would refuse to return anyway).
+ *
+ * Length is no longer consulted. A 180-character link list is nav and a
+ * 51-character fact is prose, which is the ordering length got backwards.
+ */
+export function isNavShaped(content: string): boolean {
+  const lines = pySplitLines(teachingBody(content), false)
+    .map((ln) => pyStrip(ln))
+    .filter((ln) => ln !== "");
+  if (lines.length === 0) return true;
+  const navLines = lines.filter((ln) => NAV_LINE.test(ln));
+  if (navLines.length * 2 > lines.length) return true;
+  const prose = lines.filter((ln) => !NAV_LINE.test(ln)).join(" ");
+  return cpLen(prose) < MIN_CONTENT_CHARS;
+}
+
 export function classify(content: string, headingPath: readonly string[]): SourceType {
   if (JSX_ASSESS.test(content)) return "assessment";
   const leaf = headingPath.length > 0 ? headingPath[headingPath.length - 1]! : "";
@@ -441,7 +485,7 @@ export function classify(content: string, headingPath: readonly string[]): Sourc
   ) {
     return "embed";
   }
-  if (cpLen(teachingBody(content)) < NAV_MAX_CHARS) return "nav";
+  if (isNavShaped(content)) return "nav";
   return "prose";
 }
 
@@ -590,7 +634,7 @@ export function chunkText(text: string, maxChars: number = MAX_CHARS): Chunk[] {
       }
       continue;
     }
-    const segIsNav = cpLen(teachingBody(seg.text)) < NAV_MAX_CHARS;
+    const segIsNav = isNavShaped(seg.text);
     const segMarker = segmentMarkerType(seg.text);
     for (const piece of subsplit(seg.text, maxChars)) {
       let sourceType: SourceType;

--- a/packages/content/src/ingest/unsearchable.db.test.ts
+++ b/packages/content/src/ingest/unsearchable.db.test.ts
@@ -1,16 +1,19 @@
 /**
  * Ingest must SAY how much of the record no search will return.
  *
- * A chunk shorter than the navigation threshold is stored, embedded and
- * readable — and excluded from every retrieval arm by the serving predicate.
- * The rule exists to keep link lists and breadcrumbs out of search, and it is
- * length-only, so a short SUBSTANTIVE paragraph is caught by it too.
+ * A chunk classified `nav` is stored, embedded and readable — and excluded from
+ * every retrieval arm by the serving predicate. So a record can be fully
+ * ingested and still unable to answer questions it plainly contains, and the
+ * only honest thing to do is SAY SO at ingest.
  *
- * Measured on a realistic operations handbook: 10 of 16 chunks unsearchable and
- * one document that `read` and `outline` return but `search` can never find,
- * while ingest reported a cheerful "16 chunks; embedded 16" (issue #55). The
- * threshold is not settled here — that needs a gold-set measurement — but the
- * silence is, because the silence is what let it reach a release.
+ * The rule that decides `nav` has since changed (issue #55: navigation is a
+ * shape, not a length), which is why the fixture below is a LINK LIST rather
+ * than the short policy statement it used to be. That statement is now
+ * searchable — it is a fact, and facts are what a handbook is made of — so it
+ * can no longer stand in for something search cannot reach. The report it
+ * exercises is unchanged and still needed: navigation is real, and an adopter
+ * should not have to run SQL to discover which of their pages is only
+ * findable by name.
  */
 
 import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
@@ -30,8 +33,26 @@ import type pg from "pg";
 const adminDsn = process.env["KSOR_DB_URL"] ?? "";
 const DB = "ksor_unsearchable";
 
-/** A complete policy statement, and far too short to be searchable. */
-const SHORT = `---
+/** Navigation: a page of links, which no search should ever return. */
+const NAV = `---
+title: Handbook
+status: approved
+---
+
+# Handbook
+
+- [Probation](probation.md)
+- [Notice periods](notice-periods.md)
+- [Expense limits](expense-limits.md)
+- [Travel](travel.md)
+`;
+
+/**
+ * A complete policy statement — 51 characters, and the whole answer to "how
+ * long is probation". Searchable since #55; here as the control that proves
+ * the report counts navigation rather than shortness.
+ */
+const SHORT_FACT = `---
 title: Probation
 status: approved
 ---
@@ -73,7 +94,8 @@ describe.runIf(adminDsn !== "")("ingest reports what search cannot reach (db)", 
     work = await mkdtemp(join(tmpdir(), "ksor-unsrch-"));
     const k = join(work, "knowledge");
     await mkdir(k, { recursive: true });
-    await writeFile(join(k, "probation.md"), SHORT, "utf8");
+    await writeFile(join(k, "index.md"), NAV, "utf8");
+    await writeFile(join(k, "probation.md"), SHORT_FACT, "utf8");
     await writeFile(join(k, "expenses.md"), LONG, "utf8");
   }, 300_000);
 
@@ -110,14 +132,20 @@ describe.runIf(adminDsn !== "")("ingest reports what search cannot reach (db)", 
       },
     );
 
-    expect(report.unsearchable, "the short document's chunk is not retrievable").toBeGreaterThan(0);
+    expect(report.unsearchable, "the link list's chunk is not retrievable").toBeGreaterThan(0);
     expect(
-      report.unsearchableSources.some((s) => s.includes("probation")),
+      report.unsearchableSources.some((s) => s.includes("index")),
       `a document with NO searchable chunk must be named: ${JSON.stringify(report.unsearchableSources)}`,
     ).toBe(true);
     expect(
       report.unsearchableSources.some((s) => s.includes("expenses")),
       "the long document IS searchable and must not be named",
+    ).toBe(false);
+    // The #55 control: shortness alone no longer costs a document its place in
+    // search. If this ever flips back, the classifier regressed to length.
+    expect(
+      report.unsearchableSources.some((s) => s.includes("probation")),
+      `a 51-character FACT must stay searchable: ${JSON.stringify(report.unsearchableSources)}`,
     ).toBe(false);
   });
 


### PR DESCRIPTION
## The defect

A record could be fully ingested, report `embedded 16, failed 0`, and still be
unable to answer questions it plainly contained.

`classify()` labelled any section under **250 code points** as `nav`, and the
serving predicate admits only `prose`. On the curriculum corpus the oracle was
tuned against, that proxy holds — a short segment there really is a link list.
On a handbook it inverts, because a handbook's most valuable statements are its
shortest.

Walked live on published 0.0.14 with three ordinary policy statements — a refund
window, an escalation path, a badge rule, 200-300 characters each:

> **Q.** "how long does a buyer have to send something back"
> **A.** the scaffold's placeholder page — against a record stating *thirty days*

Three of four chunks unsearchable. The answer was in the corpus, correctly
ingested, readable by slug, and unreachable by search.

## The fix

Navigation is decided by **shape**, which is what the word always meant: a
section is `nav` when link lines are most of it, or when what is left after them
is under `MIN_CONTENT_CHARS` — the *same* floor the serving predicate applies,
so this can never label `prose` something search would refuse anyway.

Length is not consulted. A 180-character link list is nav; a 51-character fact
is prose. Length had that ordering backwards.

## Measured, not asserted

Authored handbook gold, real Gemini embeddings, paired per question:

| | before | after |
|---|---|---|
| short-substantive @1 | **0/9** | **9/9** |
| long-prose @1 (control) | 4/4 | **4/4** |
| nav negative (link page returned) | 0 | **0** |

The third row is the one that matters. Admitting everything would improve the
first two and make the product worse — which is exactly why the gold carries
categories rather than a single recall number.

## On the oracle fixture — not regenerated

The fixture stays the record that the port was faithful. This is the **first
deliberate divergence** from it, so the divergence is asserted as a *property*
rather than bulk-accepted:

- `sourceType` may differ **only** `nav` → `prose` — the other direction deletes
  something from search and takes a decision of its own;
- only where the whole **section** carries real prose (the unit of
  classification is the heading-segment, not the chunk — the oracle's own
  invariant that a split section never orphans a heading piece as nav);
- content, hashes, anchors, heading paths, chunk counts: **byte-identical**.

And the fact that made this safe to judge: **the oracle corpus contains no
markdown links at all.** Its 61 `nav` labels are artifacts of short synthetic
bodies, not evidence about navigation. That is now asserted, so the next reader
doesn't mistake them for evidence.

`CHUNK_POLICY` → v6: it is persisted provenance and the behaviour it labels
changed.

## A baseline, per your point

Retrieval changes were being argued from a fresh number with nothing to compare
against. `evals/baseline.ts` now records the measurement — date, corpus,
embedding space, the numbers, and what changed — with the superseded line kept
in `RETRIEVAL_HISTORY` so a regression can be dated. Every run prints the delta:

```
  vs baseline 2026-08-22 (gemini-embedding-001 @ 1536):
    short-substantive @1  9/9   baseline 9   =
    long-prose        @1  4/4   baseline 4   =
    nav negative          0     baseline 0   =
```

Floors may rise (record the rise); they may not fall silently. The nav negative
is a **ceiling** — the guard that keeps "better recall" honest.

## Upgrade path

Re-run `ksor ingest`. Chunks are re-classified every build, and carry-forward
sets only the embedding fields (`ingest/generation.ts:174`), so unchanged
content is not re-embedded — the upgrade costs a build, not an embedding bill.

Decision 22 recorded in AGENTS.md; `docs/status.md` moved #55 from open finding
to fixed with the numbers.

Gate: 703 unit · 227 integration · 185 db (real Postgres 17.7 + pgvector 0.8.2, real Gemini embeddings).