### PR TITLE
Say what the navigation rule now is

### DIFF
--- a/.changeset/say-what-the-rule-now-is.md
+++ b/.changeset/say-what-the-rule-now-is.md
@@ -1,0 +1,28 @@
+---
+"@panaversity/ksor": patch
+---
+
+Ingest says what the navigation rule now is, not what it used to be
+
+0.0.15 changed how a section is judged to be navigation — shape rather than
+length — and left every sentence describing it behind. So a fresh `ksor ingest`
+reported:
+
+```
+not searchable: 1 of 5 chunk(s) (20%) are shorter than the navigation threshold
+```
+
+There is no navigation threshold any more, and the page in question was not
+short: it was an index of links, which is exactly what the rule now catches. The
+remedy was wrong in the same way — "lengthen these sections" is no longer how a
+page becomes searchable, and padding a link list would not have made it one.
+
+```
+not searchable: 1 of 5 chunk(s) (20%) read as navigation rather than content
+FOUND ONLY BY NAME: knowledge/index — no searchable chunk at all; a page of
+links reads as navigation; give it prose of its own, or reach it by slug
+```
+
+Found by running the published artifact rather than by reading the diff. The
+same stale description was corrected in the three other places it had been
+copied to.

--- a/docs/status.md
+++ b/docs/status.md
@@ -6,7 +6,7 @@ updated: 2026-08-22.
 
 ## Published package
 
-`@panaversity/ksor` **0.0.14** on npm (trusted publishing, provenance
+`@panaversity/ksor` **0.0.15** on npm (trusted publishing, provenance
 attached). It ships the working `ksor init` described below — including the
 visibility model and the deploy story — AND the bundled content kernel, so
 `ksor serve`, `ksor ingest`, `ksor schema`, `ksor grant`, `ksor takedown`,
@@ -16,7 +16,7 @@ unknown verb is refused with exit `1` and a stable `error: unknown-verb` stderr
 slug. The package root exports `exitCodes`, `verbs`, and `resolveCommand`, and
 docs ship inside the tarball under `docs/`.
 
-Verified end to end against each published version (most recently 0.0.14,
+Verified end to end against each published version (most recently 0.0.15,
 2026-08-22: fresh `npm install` into a bare project, driven by the real
 `@modelcontextprotocol/client` SDK over live Postgres 17.7 + pgvector 0.8.2
 with real Gemini embeddings). What that walk covers: install · `schema` ·
@@ -40,7 +40,8 @@ almost no vocabulary with the question (2026-08-21):
   query shape this product exists to serve; the keyword arm earns its place on
   exact-term lookup, not on questions.
 
-**Short documents reach search again** (issue #55, fixed 2026-08-22). Sections
+**Short documents reach search again** (issue #55, fixed 2026-08-22, released
+in 0.0.15). Sections
 were classified navigation by LENGTH — anything under 250 code points — and
 navigation is excluded from every retrieval arm. Walked on 0.0.14 with three
 ordinary short policy statements: three of four chunks unsearchable, and a
@@ -53,6 +54,21 @@ was returned **0** times — correctness, not permissiveness. The recorded line
 lives in `packages/content/src/evals/baseline.ts` and the harness prints every
 run against it. Adopters get it by re-running `ksor ingest`; unchanged content
 is not re-embedded.
+
+Re-walked on published 0.0.15 with the corpus that failed on 0.0.14 — the same
+three short policy statements plus an index page of links. Unsearchable went
+from **3 of 4 chunks (75%)** to **1 of 5 (20%)**, and the one is the index page,
+which is what navigation means. All three questions the record answers now
+return the right document at rank 1, and the index page appears in no result:
+
+```
+Q: how long does a buyer have to send something back
+   -> refunds, escalation, badges       (0.0.14 returned the placeholder page)
+Q: who handles a dispute the agent cannot settle
+   -> escalation, refunds, example
+Q: what happens if I lose my badge
+   -> badges, escalation, refunds
+```
 
 **The vector index is NOT being used** (issue #59). `idx_chunks_hnsw` is built
 and maintained, and the query `ksor serve` sends plans a sequential scan plus a
@@ -146,9 +162,9 @@ cannot land unnoticed.
     surface (decision 11 revision 2026-08-20), `ksor init` now declares
     `@panaversity/ksor` as a scaffold dependency pinned to the exact CLI
     version, with `pnpm serve` / `pnpm ingest` scripts — so the served tool is
-    first-class in every new project. **Released in 0.0.8-0.0.14.**
+    first-class in every new project. **Released in 0.0.8-0.0.15.**
 
-- **Governance, honesty and measurement work (0.0.8-0.0.14, 2026-08-21/22).**
+- **Governance, honesty and measurement work (0.0.8-0.0.15, 2026-08-21/22).**
   Reading order is one rule across the website, `llms.txt` and the MCP
   `outline` tool — the door had been reading the predecessor's Docusaurus keys,
   which no compliant record may declare. `ksor serve` reports its own posture

--- a/packages/content/src/commands.ts
+++ b/packages/content/src/commands.ts
@@ -553,23 +553,21 @@ async function ingestCommand(args: string[]): Promise<number> {
     `ingest: generation ${report.generation} — ${report.nodes} nodes, ${report.chunks} chunks; ` +
       `embedded ${report.embedded}, carried ${report.carried}, failed ${report.failed}\n`,
   );
-  // SAY what will not be found. A chunk shorter than the navigation threshold is
-  // stored, embedded and readable — and excluded from every retrieval arm. The
-  // rule is there to keep link lists out of search and it is length-only, so
-  // short SUBSTANTIVE paragraphs are caught by it too: a real handbook measured
-  // 10 of 16 chunks unsearchable and one whole document that `read` and
-  // `outline` return but `search` can never find, while this line reported a
-  // cheerful "16 chunks; embedded 16" (issue #55).
+  // SAY what will not be found. A chunk classified as navigation is stored,
+  // embedded and readable — and excluded from every retrieval arm. Since
+  // decision 22 that classification is a SHAPE (link-dominated, or too little
+  // text left to answer anything) rather than a length, so what lands here is
+  // usually an index page and no longer, as it once was, most of a handbook.
   //
-  // Not a refusal — a short record can be perfectly healthy, and the threshold
-  // is not yet decided. But "honest absence, never silent weakness" applies to
-  // the act of publishing as much as to answering, and an adopter should not
-  // need SQL to learn that most of their record cannot be found.
+  // Not a refusal — a record made largely of link pages can be perfectly
+  // healthy. But "honest absence, never silent weakness" applies to publishing
+  // as much as to answering, and an adopter should not need SQL to learn which
+  // of their pages can only be reached by name.
   if (report.unsearchable > 0) {
     const pct = Math.round((report.unsearchable / Math.max(report.chunks, 1)) * 100);
     process.stdout.write(
-      `  not searchable: ${report.unsearchable} of ${report.chunks} chunk(s) (${pct}%) are shorter ` +
-        `than the navigation threshold — stored and readable, but no search returns them\n`,
+      `  not searchable: ${report.unsearchable} of ${report.chunks} chunk(s) (${pct}%) read as ` +
+        `navigation rather than content — stored and readable, but no search returns them\n`,
     );
     if (report.unsearchableSources.length > 0) {
       const named = report.unsearchableSources.slice(0, 10).join(", ");
@@ -577,7 +575,8 @@ async function ingestCommand(args: string[]): Promise<number> {
         report.unsearchableSources.length - Math.min(10, report.unsearchableSources.length);
       process.stdout.write(
         `  FOUND ONLY BY NAME: ${named}${more > 0 ? `, and ${more} more` : ""} — ` +
-          "no searchable chunk at all; lengthen these sections or read them by slug\n",
+          "no searchable chunk at all — a page of links reads as navigation; give it " +
+          "prose of its own, or reach it by slug\n",
       );
     }
   }

--- a/packages/content/src/evals/handbook-gold.ts
+++ b/packages/content/src/evals/handbook-gold.ts
@@ -4,19 +4,26 @@
  * The predecessor's gold (`sor-evals/gold/`, converted under decision 6) is
  * entirely curriculum: `python-crash-course`, `harness-engineering-crash-course`,
  * `foundations-everyone`. It is good gold and it cannot answer the question
- * issue #55 asks, because the classifier under test was TUNED on that corpus:
- * measuring the navigation threshold against curriculum gold would confirm 250,
- * since in a curriculum a sub-250-character segment genuinely is navigation.
+ * issue #55 asks, because the classifier under test had been TUNED on that
+ * corpus: measuring a length threshold against curriculum gold would have
+ * confirmed 250, since in a curriculum a sub-250-character segment genuinely is
+ * navigation.
  *
  * A handbook is the other shape. Its highest-value content is short and
  * declarative — "Probation: six months, with a written review at three and six"
- * — which the length-only rule cannot distinguish from a link list.
+ * — which a length-only rule cannot distinguish from a link list.
+ *
+ * It answered the question it was written for (decision 22, 2026-08-22):
+ * navigation is now decided by shape, and these categories are what proved the
+ * new rule correct rather than merely permissive — 0/9 to 9/9 on the first,
+ * 4/4 held on the second, 0 leaks on the third. It stays the standing guard
+ * against a regression, and `baseline.ts` records the line it holds.
  *
  * So the fixture carries THREE categories on purpose, and the gold names which
  * each question is for:
  *
- *   short-substantive  a complete fact under the threshold — WRONGLY excluded
- *   long-prose         over the threshold — the control, currently reachable
+ *   short-substantive  a complete fact, briefly stated — was WRONGLY excluded
+ *   long-prose         the control, reachable before and after
  *   nav                a genuine link list — RIGHTLY excluded
  *
  * A permissive classifier scores well on the first two and fails the third. A

--- a/packages/content/src/ingest/build.ts
+++ b/packages/content/src/ingest/build.ts
@@ -79,17 +79,16 @@ export interface BuildStats {
    * How much of what we just stored NO SEARCH WILL EVER RETURN.
    *
    * The serving predicate admits a chunk only when it is `prose` and has at
-   * least MIN_CONTENT_CHARS of dense text (`lib/search.ts`'s SERVABLE). A
-   * chunk shorter than NAV_MAX_CHARS is classified `nav` — the rule exists to
-   * keep link lists and breadcrumbs out of retrieval, and it is length-only,
-   * so a short SUBSTANTIVE paragraph is caught by it too.
+   * least MIN_CONTENT_CHARS of dense text (`lib/search.ts`'s SERVABLE), and
+   * `classify()` decides `prose` vs `nav` by SHAPE since decision 22 — link
+   * lines dominating, or too little text left to answer anything.
    *
-   * Counted and reported because it was previously silent: a real handbook
-   * measured 10 of 16 chunks unsearchable and one whole document findable by
-   * `read` and `outline` but never by `search`, with the ingest line reporting
-   * a cheerful "16 chunks; embedded 16" (issue #55). Whatever the right
-   * threshold turns out to be, an adopter should not have to run SQL to
-   * discover that most of their record cannot be found.
+   * Counted and reported because it was previously silent: under the older
+   * length-only rule a real handbook measured 10 of 16 chunks unsearchable and
+   * one whole document findable by `read` and `outline` but never by `search`,
+   * with the ingest line reporting a cheerful "16 chunks; embedded 16" (issue
+   * #55). The rule is fixed and the report stays: an adopter should not have to
+   * run SQL to learn which pages can only be reached by name.
    */
   readonly unsearchable: number;
   /** Sources with NO searchable chunk at all — findable by slug, never by search. */

--- a/packages/content/src/ingest/unsearchable.db.test.ts
+++ b/packages/content/src/ingest/unsearchable.db.test.ts
@@ -62,7 +62,7 @@ status: approved
 Six months, with a written review at three and six.
 `;
 
-/** Long enough to clear the navigation threshold. */
+/** Ordinary prose, searchable under any rule — the upper control. */
 const LONG = `---
 title: Expense claims
 status: approved


### PR DESCRIPTION
0.0.15 changed how a section is judged to be navigation — shape rather than
length — and I left every sentence that explains it behind. Found by running the
published artifact, not by reading the diff.

A fresh `ksor ingest` on 0.0.15 said:

```
not searchable: 1 of 5 chunk(s) (20%) are shorter than the navigation threshold
FOUND ONLY BY NAME: knowledge/index — lengthen these sections or read them by slug
```

There is no navigation threshold any more. And the page it named was not short —
it was an index of links, which is precisely what the new rule is *for*. The
remedy was wrong in the same direction: padding a link list would not have made
it searchable, so the message sent the reader to do something that could not work.

```
not searchable: 1 of 5 chunk(s) (20%) read as navigation rather than content
FOUND ONLY BY NAME: knowledge/index — no searchable chunk at all; a page of
links reads as navigation; give it prose of its own, or reach it by slug
```

Corrected in the three other places the old description had been copied to: the
`BuildStats` doc-block, the gold set's rationale (written before the question had
an answer — it now records the one it produced), and a fixture comment.

`docs/status.md` moves to 0.0.15 and records the re-walk on the published
package, against the same corpus that failed on 0.0.14:

| | 0.0.14 | 0.0.15 |
|---|---|---|
| unsearchable | 3 of 4 chunks (75%) | **1 of 5 (20%)** — the index page |
| "how long does a buyer have to send something back" | the placeholder page | **refunds**, at rank 1 |

This is the fourth time today a message described behaviour the code no longer
had. It keeps being the message, not the code — which is the argument for
walking the artifact after every behaviour change, not just after risky ones.