### PR TITLE
Diagnose #59: the index is refused by a cost mispricing, and fixing it trades exactness

### DIFF
--- a/.changeset/diagnose-59.md
+++ b/.changeset/diagnose-59.md
@@ -1,0 +1,26 @@
+---
+"@panaversity/ksor": patch
+---
+
+Record why the vector index is unused, and what fixing it would cost
+
+Diagnosis only — no serving behaviour changes. Answers are unaffected, and were
+already correct: the query plans a sequential scan, and a sequential scan is
+EXACT. What grows with the corpus is the work, not the error.
+
+The cause recorded until now — a window function, then joins and predicates
+Postgres cannot estimate — was incomplete. Testing each clause on its own shows
+a cost mispricing underneath: a full sequential pass over 20,000 chunks,
+including 20,000 1536-dimension distance computations, is priced at 1904 for
+work that takes ~130 ms, while the HNSW scan's startup cost alone is 2137.
+
+A restructured arm reaches 36 ms against 648 ms — but only with `ef_search` at
+pgvector's default, which is the setting where the index missed the true nearest
+neighbour for 1 query in 100 on a bed with real cluster structure, dropping the
+top-1 similarity by 0.99. Against this record's ~0.01 abstention separation,
+that flips an abstention: the corpus holds the answer and the door says it does
+not. The speed and the approximation cannot be separated, so taking them is an
+owner decision rather than a tuning change.
+
+Both the current plan and the fix path are now pinned by tests, so neither can
+drift unnoticed.

--- a/docs/status.md
+++ b/docs/status.md
@@ -70,14 +70,40 @@ Q: what happens if I lose my badge
    -> badges, escalation, refunds
 ```
 
-**The vector index is NOT being used** (issue #59). `idx_chunks_hnsw` is built
-and maintained, and the query `ksor serve` sends plans a sequential scan plus a
-top-N heapsort instead: measured 814 ms at 20,001 chunks, against 1.2 ms for
-the same rows from the same index when the query is simple. Answers are
-correct; the work to get them grows with the corpus. Small records will not
-notice. A characterization test
-(`packages/content/src/lib/vector-plan.db.test.ts`) pins the bad plan so a fix
-cannot land unnoticed.
+**The vector index is NOT being used, and fixing it is a governance decision**
+(issue #59, diagnosed 2026-08-22). `idx_chunks_hnsw` is built and maintained,
+and the query `ksor serve` sends plans a sequential scan instead: measured
+**648 ms** at 20,001 chunks. Answers are correct — a sequential scan is EXACT —
+but the work to get them grows with the corpus.
+
+The cause recorded here previously (a window function, then joins and
+unestimable predicates) was incomplete. Each clause was tested on its own; the
+root is a cost mispricing, with three compounding contributors:
+
+- Postgres prices a full sequential pass over 20,000 chunks — including 20,000
+  × 1536-dimension distance computations — at **1904**, work that actually takes
+  ~130 ms. The HNSW scan's startup cost alone is 2137, so the index can only
+  win at small `LIMIT`s.
+- The ordered scan must therefore touch `chunks` with estimable predicates only.
+  `SERVABLE` inside it flips the plan back to sequential: **478 ms inside, 2.3 ms
+  outside**, same rows.
+- `hnsw.ef_search = 100` raises the cost further, and the ceiling is
+  size-dependent: at 20,000 rows the index is chosen up to 80 and lost at 90; at
+  5,000 rows it is never chosen at any setting — correctly, since a sequential
+  pass over 5,000 rows is fast _and_ exact.
+
+A restructured arm (order over `chunks` alone, overfetch ≤ 100, filter after)
+reaches **36 ms against 648 ms** — but only with `ef_search` at pgvector's
+default, and that is the setting where, on a bed with real cluster structure,
+the index **missed the true nearest neighbour for 1 query in 100**, dropping the
+top-1 similarity by 0.99. This record's measured in-corpus/out-of-corpus
+separation is ~0.01, so a miss that size flips an ABSTENTION: the corpus holds
+the answer and the door says it does not.
+
+So the speed and the approximation cannot be separated, and taking it is an
+owner decision rather than a tuning change. Both the plan and the fix path are
+pinned by `packages/content/src/lib/vector-plan.db.test.ts`, which fails if
+either stops being true.
 
 ## Implemented (released in 0.0.7)
 

--- a/packages/content/src/lib/vector-plan.db.test.ts
+++ b/packages/content/src/lib/vector-plan.db.test.ts
@@ -2,13 +2,55 @@
  * What the serving query's PLAN does — pinned, because it is currently wrong.
  *
  * `idx_chunks_hnsw` is built, maintained, and **not opened** by the query
- * `ksor serve` sends. The arm's filters are expressions Postgres cannot
- * estimate (`labels->>'source_type'`, a `regexp_replace` length) and its
- * generation comes from a join, so the ordered scan is priced as a near-full
- * traversal and a sequential scan plus top-N heapsort wins. Measured at 20,001
- * chunks on PG 17.7 / pgvector 0.8.2: **814 ms** with the index absent from the
- * plan, against **1.2 ms** for the same rows from the same index when the query
- * is simple. Issue #59.
+ * `ksor serve` sends. Issue #59.
+ *
+ * WHY — measured 2026-08-22, PG 17.7 / pgvector 0.8.2, 20,000 chunks of
+ * 1536 dimensions with real cluster structure. The earlier explanation in this
+ * header (joins, and predicates Postgres cannot estimate) was INCOMPLETE and
+ * partly wrong; each clause was tested on its own and the result is a cost
+ * mispricing with three compounding contributors:
+ *
+ *   1. Postgres prices a full sequential pass over 20,000 chunks — including
+ *      20,000 × 1536-dimension distance computations — at cost **1904**. That
+ *      pass actually takes ~130 ms. The HNSW scan's STARTUP cost alone is
+ *      2137, so the index can only win at small LIMITs. This is the root: the
+ *      distance operator is costed as if it were nearly free.
+ *   2. The ordered scan must therefore touch `chunks` with ESTIMABLE
+ *      predicates only. Moving `SERVABLE` (a `labels->>` lookup and a
+ *      `regexp_replace` length) inside it flips the plan back to sequential:
+ *      **478 ms with it inside, 2.3 ms with it outside** — same rows.
+ *   3. `hnsw.ef_search = 100` (set in VECTOR_TXN_GUCS) raises the scan's cost
+ *      further, and the ceiling is SIZE-DEPENDENT: at 20,000 rows the index is
+ *      chosen up to ef_search 80 and lost at 90; at 5,000 rows it is never
+ *      chosen at any setting, which is CORRECT there because a sequential pass
+ *      over 5,000 rows is both fast and exact.
+ *
+ * So today's behaviour is EXACT and slow in proportion to corpus size — not
+ * wrong. That matters for how it may be fixed: HNSW is approximate, and on the
+ * bed above, `ef_search` at its default missed the true nearest neighbour for
+ * **1 query in 100**, with the top-1 similarity falling by 0.99. This record's
+ * measured in-corpus/out-of-corpus separation is ~0.01
+ * (`behavioural.db.test.ts`), so a miss of that size would flip an ABSTENTION:
+ * the corpus holds the answer and the door would say it does not. Trading
+ * exactness for speed here is a governance decision, not a tuning one.
+ *
+ * The measured shape of a fix, for whoever takes it: order over `chunks` alone,
+ * overfetch ≤ ~100 (at 20,000 rows the crossover is between 100 and 150), then
+ * join and apply governance filtering — **36 ms against 648 ms**, the same
+ * rows. It needs BOTH halves: with `ef_search` at the shipped 100 the
+ * restructured query still plans sequentially (355 ms), and at 64 it still does
+ * (124 ms). Only pgvector's default opens the index — and that is the setting
+ * whose top-1 miss is measured above, so the two halves cannot be separated:
+ * taking the speed means taking the approximation.
+ *
+ * A second cost is recall UNDER FILTERING. Today the filters sit inside the
+ * scan, so `hnsw.iterative_scan = relaxed_order` keeps scanning until k rows
+ * survive; a fixed overfetch cannot. A corpus whose top-100 is mostly denied,
+ * unpublished, or out-of-audience would return fewer hits — and an empty result
+ * is an abstention. An adaptive fallback (retry with filters inside when
+ * survivors < k) fixes THAT half, at one extra round trip in the rare case. It
+ * does not fix the top-1 miss, which happens inside the index scan where no
+ * later step can see it.
  *
  * This is a CHARACTERIZATION test, not a guard on correct behaviour. It asserts
  * today's plan so that a fix — or a further regression — arrives as a red test
@@ -20,12 +62,9 @@
  * through the WHERE clause, since nothing ever asserted the outcome. A timing
  * threshold would be flaky and would not have caught it either. The plan is the
  * property that matters, so the plan is what is asserted — of the REAL
- * `HYBRID_SQL`, never of a query written for the test. An earlier attempt at a
- * fix measured a simplified query instead and looked like it worked; this file
- * is what proved it had not.
- *
- * Vectors are random, which is unfavourable to HNSW in 1536 dimensions. That
- * makes it a conservative bed for the direction being asserted here.
+ * `HYBRID_SQL`, never of a query written for the test. Two separate attempts at
+ * a fix measured a simplified query instead and looked like they worked; this
+ * file is what proved they had not.
  */
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -123,5 +162,61 @@ describe.runIf(adminDsn !== "")("the serving query opens the vector index (db)",
 
     // …and it is a scan, which is the shape that makes search O(corpus).
     expect(plan, `Plan:\n${plan}`).toMatch(/Seq Scan on chunks/);
+  }, 300_000);
+
+  /**
+   * The diagnosis, executable — so it cannot rot into a comment that used to be
+   * true. The header explains WHY the index is refused; this asserts the one
+   * change that lifts the refusal, which is the fix path anyone takes next.
+   *
+   * If this ever goes red, the planner or pgvector has changed and the whole
+   * header needs re-measuring before it is trusted again.
+   */
+  it("…and it OPENS the index only with BOTH changes: chunks-alone scan AND default ef_search", async () => {
+    const zero = `[${Array.from({ length: 1536 }, () => "0.001").join(",")}]`;
+    // Identical rows, identical filters, identical k. The ONLY difference is
+    // that the unestimable governance predicates are applied AFTER the ordered
+    // scan instead of inside it.
+    const restructured = `
+      WITH cand AS (
+        SELECT c.chunk_id, c.source_id, c.generation, (c.embedding <=> $2::vector) AS dist
+        FROM chunks c
+        WHERE c.tenant_id = $1 AND c.generation = 1 AND c.embedding_status = 'embedded'
+        ORDER BY c.embedding <=> $2::vector
+        LIMIT 100)
+      SELECT cand.chunk_id FROM cand
+      JOIN chunks c ON c.chunk_id = cand.chunk_id AND c.tenant_id = $1
+      JOIN sources s ON s.source_id = cand.source_id AND s.tenant_id = $1
+                    AND s.generation = cand.generation
+      JOIN content_nodes n ON n.node_id = s.node_id AND n.tenant_id = s.tenant_id
+      WHERE n.status = 'published'
+        AND c.labels->>'source_type' = 'prose'
+        AND length(regexp_replace(c.content, '\\s', '', 'g')) >= 24
+      ORDER BY cand.dist, cand.chunk_id LIMIT 30`;
+
+    const plan = await runRead(
+      pool,
+      TENANT,
+      async (client) => {
+        const r = await client.query<{ "QUERY PLAN": string }>(`EXPLAIN ${restructured}`, [
+          TENANT,
+          zero,
+        ]);
+        return r.rows.map((row) => row["QUERY PLAN"]).join("\n");
+      },
+      // NOTE the missing `hnsw.ef_search`. Restructuring alone is NOT enough:
+      // with the shipped value of 100 this same query still plans sequentially
+      // (355 ms), and at 64 it still does (124 ms). Only at pgvector's default
+      // does the index open (36 ms) — which is also the setting where a top-1
+      // miss was measured, and that is exactly why the fix is a governance
+      // decision rather than a tuning one.
+      { "hnsw.iterative_scan": "relaxed_order", ...WHOLE_RECORD_SCOPE },
+    );
+
+    expect(
+      plan.includes("idx_chunks_hnsw"),
+      "the restructured arm no longer opens the index either — the header's " +
+        `measurements are stale and must be re-taken before they are trusted.\nPlan:\n${plan}`,
+    ).toBe(true);
   }, 300_000);
 });


### PR DESCRIPTION
You asked me to fix #59. I could not ship the fix, and this PR is why — with the
measurements that make it a decision rather than an opinion.

**No serving behaviour changes here.** Answers were already correct: the query
plans a sequential scan, and a sequential scan is *exact*. What grows with the
corpus is the work, not the error.

## The recorded cause was wrong

The header said the index was refused because of a window function, then joins,
then predicates Postgres cannot estimate. I tested each clause on its own
against 20,000 chunks of 1536 dimensions, and the truth is a **cost mispricing**
with three compounding parts:

| | measured |
|---|---|
| Postgres's price for a full sequential distance pass over 20,000 chunks | **1904** — for work that takes ~130 ms |
| HNSW scan startup cost alone | **2137** |
| `SERVABLE` inside the ordered scan vs outside it | **478 ms** vs **2.3 ms**, same rows |
| `ef_search` ceiling at 20,000 rows | index up to 80, lost at 90 |
| `ef_search` ceiling at 5,000 rows | never chosen — **correctly**, seq is fast *and* exact there |

The distance operator is costed as if nearly free, so the index can only win at
small `LIMIT`s (crossover between 100 and 200).

## Why I did not ship the fix

A restructured arm — order over `chunks` alone, overfetch ≤ 100, filter after —
reaches **36 ms against 648 ms**. It needs *both* halves:

```
restructure + ef_search=100 (as shipped)     seq   355 ms
restructure + ef_search=64                   seq   124 ms
restructure + ef_search default (40)      INDEX ✓    36 ms
```

Only the default opens the index. And on a bed with real cluster structure, that
setting **missed the true nearest neighbour for 1 query in 100**, dropping the
top-1 similarity by **0.99**.

This record's measured in-corpus/out-of-corpus separation is ~**0.01**
(`behavioural.db.test.ts`). A miss that size flips an **abstention** — the corpus
holds the answer and the door says it does not. That is the one failure this
product exists to prevent, and critical rule 1 names abstention specifically.

The two halves cannot be separated: taking the speed means taking the
approximation. There is also a second, smaller cost — moving filters outside the
scan gives up `iterative_scan`'s ability to keep scanning until k rows survive,
so a heavily-denied corpus would return fewer hits. An adaptive fallback fixes
that half; nothing later in the pipeline can see the top-1 miss.

So this is your call, not a tuning change I should make quietly.

## What lands

- The header's root cause, corrected and measured.
- A second test pinning the **fix path** — the restructured arm with default
  `ef_search` — so the diagnosis is executable and fails if the planner or
  pgvector changes, rather than rotting into a comment that used to be true.
- `docs/status.md` updated: #59 is a governance decision with numbers, not a
  performance TODO.

## Process note

Twice today I measured a simplified query and believed it. It happened again
here — the isolated chunks-only query used the index at every `ef_search`, and
none of that transferred to the real `HYBRID_SQL`. The rule that caught it each
time is the one already in this file's header: **EXPLAIN the query the product
sends, never one written for the test.**

Gate: 703 unit · 178 db (real Postgres 17.7 + pgvector 0.8.2).