### PR TITLE
Decide widget dominance by shape, not by length (#75)

### DIFF
--- a/.changeset/widget-dominance-by-shape.md
+++ b/.changeset/widget-dominance-by-shape.md
@@ -1,0 +1,29 @@
+---
+"@panaversity/ksor": patch
+---
+
+A quiz no longer swallows the explanation that precedes it
+
+The previous release moved navigation from a length test to a shape test, so a
+short fact stopped being mistaken for a link list. The rule that decides whether
+a whole section is *a widget* — a quiz, a slide embed — was left on the old
+threshold: under 250 characters of teaching before the widget, and the entire
+section was labelled `assessment` or `embed`, neither of which any search
+returns.
+
+So a section carrying a complete 180-character explanation followed by a
+knowledge check lost the explanation too. Same defect as the last one, one path
+over.
+
+Both paths now ask the same question: is what comes BEFORE the widget actually
+navigation-shaped? A heading with only a quiz under it is still a quiz. A link
+list before a quiz is still a quiz. An explanation before a quiz is an
+explanation, and stays searchable.
+
+Found by ingesting a real 81-document curriculum corpus, where 610 chunks landed
+as `assessment` and 186 as `embed` — together 79% of everything unsearchable in
+that record.
+
+`CHUNK_POLICY` moves to v7 (persisted provenance; the labels it names changed),
+and `NAV_MAX_CHARS` is deleted — nothing reads it now. **Re-run `ksor ingest` to
+pick this up**; unchanged content is not re-embedded.

--- a/.changeset/widget-dominance-by-shape.md
+++ b/.changeset/widget-dominance-by-shape.md
@@ -6,7 +6,7 @@ A quiz no longer swallows the explanation that precedes it
 
 The previous release moved navigation from a length test to a shape test, so a
 short fact stopped being mistaken for a link list. The rule that decides whether
-a whole section is *a widget* — a quiz, a slide embed — was left on the old
+a whole section is _a widget_ — a quiz, a slide embed — was left on the old
 threshold: under 250 characters of teaching before the widget, and the entire
 section was labelled `assessment` or `embed`, neither of which any search
 returns.

--- a/packages/content/src/config.ts
+++ b/packages/content/src/config.ts
@@ -25,9 +25,8 @@ export const EMBED_TASK_QUERY = "RETRIEVAL_QUERY";
 export const EMBED_RECIPE: string = `${EMBED_MODEL}/d${EMBED_DIM}/${EMBED_TASK_DOCUMENT}`;
 export const RRF_K = 60;
 /** bump ⇒ provenance (v5: CommonMark fences). All char limits count CODE POINTS (Python len parity). */
-export const CHUNK_POLICY = "heading-aware-1500-content-only-v6";
+export const CHUNK_POLICY = "heading-aware-1500-content-only-v7";
 export const MAX_CHARS = 1500;
-export const NAV_MAX_CHARS = 250;
 /** < Gemini's 2048-token embed input. */
 export const HARD_MAX_CHARS = 4000;
 /** The servable-candidate floor (shared by every retrieval arm). */

--- a/packages/content/src/ingest/chunking.test.ts
+++ b/packages/content/src/ingest/chunking.test.ts
@@ -26,15 +26,16 @@ const chunksFor = (cleaned: string, maxChars: number | null) =>
   maxChars === null ? chunkText(cleaned) : chunkText(cleaned, maxChars);
 
 describe("chunk policy", () => {
-  it("has moved ONE version past the oracle, deliberately", () => {
-    // The port needed no bump for three releases, which is what the previous
-    // wording recorded. Issue #55 is the first DELIBERATE divergence: the
-    // oracle decides `nav` by length and we decide it by shape. The policy
-    // string is persisted per source row and gates carry-forward, so this bump
-    // is what makes an existing corpus RE-CHUNK instead of serving chunks
-    // labelled by a rule that no longer exists.
+  it("has moved TWO versions past the oracle, deliberately", () => {
+    // The port needed no bump for three releases. Both bumps since are the same
+    // decision applied twice: navigation is a SHAPE, not a length. v6 moved
+    // `classify()` (issue #55); v7 moved widget dominance, which had been left
+    // on the old threshold so a section with real explanation before a quiz lost
+    // the explanation too (issue #75). The policy string is persisted per source
+    // row and gates carry-forward, so each bump is what makes an existing corpus
+    // RE-CHUNK instead of serving chunks labelled by a rule that no longer runs.
     expect(chunkingFixtures.policy).toBe("heading-aware-1500-content-only-v5");
-    expect(CHUNK_POLICY).toBe("heading-aware-1500-content-only-v6");
+    expect(CHUNK_POLICY).toBe("heading-aware-1500-content-only-v7");
   });
 });
 
@@ -275,5 +276,43 @@ describe("how we differ from the oracle, and only how", () => {
     // would have confirmed whatever rule was already there.
     const withLinks = chunkingFixtures.cases.filter((c) => /\[[^\]]+\]\([^)]+\)/.test(c.cleaned));
     expect(withLinks.map((c) => c.name)).toEqual([]);
+  });
+});
+
+/**
+ * Issue #75 — the same question, asked in the neighbouring path.
+ *
+ * #55 moved `classify()` from length to shape. `segmentMarkerType()`, which
+ * decides whether a WHOLE heading-segment is dominated by a widget, was left on
+ * the old threshold: under 250 characters of teaching body before the widget and
+ * every fragment of the section is labelled `assessment` or `embed`, both of
+ * which no retrieval arm returns. So a section carrying real explanation before
+ * a quiz lost the explanation too.
+ */
+describe("widget dominance is decided by shape as well (#75)", () => {
+  const QUIZ = '\n<Quiz questions={[{ question: "q", options: ["a","b"], answer: 0 }]} />\n';
+
+  it("a heading with only a quiz under it is still widget-dominated", () => {
+    const chunks = chunkText("## Check\n" + QUIZ);
+    expect(chunks.every((c) => c.sourceType === "assessment")).toBe(true);
+  });
+
+  it("real explanation before a quiz keeps its own classification", () => {
+    // 180 characters — under the old threshold, and a complete explanation.
+    const teaching =
+      "\nA governed slice is one bounded promise a Worker makes, with the record " +
+      "behind it and a named owner who answers for it when it is wrong.\n";
+    expect(teaching.length).toBeLessThan(250);
+    const chunks = chunkText("## Slices\n" + teaching + QUIZ);
+    expect(
+      chunks.some((c) => c.sourceType === "prose"),
+      `the explanation was swallowed by the quiz: ${JSON.stringify(chunks.map((c) => c.sourceType))}`,
+    ).toBe(true);
+  });
+
+  it("a link list before a quiz is NOT teaching, so the section stays widget-dominated", () => {
+    const links = "\n- [One](a.md)\n- [Two](b.md)\n- [Three](c.md)\n";
+    const chunks = chunkText("## See also\n" + links + QUIZ);
+    expect(chunks.every((c) => c.sourceType === "assessment")).toBe(true);
   });
 });

--- a/packages/content/src/ingest/chunking.ts
+++ b/packages/content/src/ingest/chunking.ts
@@ -38,14 +38,8 @@ import { createHash } from "node:crypto";
 // alone — two copies once stamped sources.chunk_policy and
 // retrieval_log.chunk_policy_version from DIFFERENT files, drifting the
 // provenance the carry-forward skip-gate rests on (review, 2026-08-19).
-export {
-  CHUNK_POLICY,
-  MAX_CHARS,
-  NAV_MAX_CHARS,
-  HARD_MAX_CHARS,
-  MIN_CONTENT_CHARS,
-} from "../config.js";
-import { MAX_CHARS, NAV_MAX_CHARS, HARD_MAX_CHARS, MIN_CONTENT_CHARS } from "../config.js";
+export { CHUNK_POLICY, MAX_CHARS, HARD_MAX_CHARS, MIN_CONTENT_CHARS } from "../config.js";
+import { MAX_CHARS, HARD_MAX_CHARS, MIN_CONTENT_CHARS } from "../config.js";
 
 // --- Python text semantics, reproduced exactly ------------------------------
 
@@ -446,7 +440,7 @@ const NAV_LINE =
  * Is this segment NAVIGATION — a thing that points at content rather than
  * being content?
  *
- * The oracle answered this with length: under NAV_MAX_CHARS (250) meant nav.
+ * The oracle answered this with length: under 250 code points meant nav.
  * On the curriculum corpus it was tuned against, that proxy holds — a short
  * segment there really is a link list. On a handbook it inverts, because a
  * handbook's most valuable statements are its shortest ("Six months, with a
@@ -475,32 +469,50 @@ export function isNavShaped(content: string): boolean {
   return cpLen(prose) < MIN_CONTENT_CHARS;
 }
 
+/**
+ * Does a line-leading widget DOMINATE this span?
+ *
+ * The widget regexes match an opening tag only, so the tag's position is where
+ * teaching stops and markup begins. The question is therefore about what comes
+ * BEFORE it: if that is navigation-shaped, the span is the widget; if it is real
+ * explanation, the widget is a minority of a teaching passage.
+ *
+ * This used to be a length test — 250 characters of teaching body before the
+ * widget and the whole span became `assessment`, which no retrieval arm returns.
+ * #55 moved navigation from length to shape and left this path behind, so a
+ * section carrying 180 characters of real explanation before a `<Quiz>` lost the
+ * explanation with it (issue #75).
+ */
+function dominantWidget(span: string): SourceType | null {
+  for (const [re, label] of [
+    [JSX_ASSESS, "assessment"],
+    [JSX_EMBED, "embed"],
+  ] as const) {
+    const m = re.exec(span);
+    if (m !== null && isNavShaped(span.slice(0, m.index))) return label;
+  }
+  return null;
+}
+
 export function classify(content: string, headingPath: readonly string[]): SourceType {
-  if (JSX_ASSESS.test(content)) return "assessment";
+  const widget = dominantWidget(content);
+  if (widget !== null) return widget;
   const leaf = headingPath.length > 0 ? headingPath[headingPath.length - 1]! : "";
-  if (
-    JSX_EMBED.test(content) ||
-    content.includes("docs.google.com/presentation") ||
-    leaf.includes("Teaching Aid")
-  ) {
+  // Declared purpose rather than measured shape: a "Teaching Aid" heading and a
+  // slide-deck link say what the section IS. Left on the oracle's taxonomy
+  // deliberately — weighing these is a separate policy question.
+  if (content.includes("docs.google.com/presentation") || leaf.includes("Teaching Aid")) {
     return "embed";
   }
   if (isNavShaped(content)) return "nav";
   return "prose";
 }
 
-/** A segment DOMINATED by a line-leading widget (with < NAV_MAX_CHARS of
- * teaching body before it) labels EVERY fragment — a char-sliced widget must
- * not leak as prose. */
+/** A segment dominated by a line-leading widget labels EVERY fragment — a
+ * char-sliced widget must not leak as prose. Same question as `classify`, asked
+ * of the whole segment rather than one piece of it. */
 function segmentMarkerType(span: string): SourceType | null {
-  for (const [re, label] of [
-    [JSX_ASSESS, "assessment"],
-    [JSX_EMBED, "embed"],
-  ] as const) {
-    const m = re.exec(span);
-    if (m !== null && cpLen(teachingBody(span.slice(0, m.index))) < NAV_MAX_CHARS) return label;
-  }
-  return null;
+  return dominantWidget(span);
 }
 
 interface Segment {


### PR DESCRIPTION
Closes #75.

0.0.15 moved navigation from a length test to a shape test, so a short fact
stopped being mistaken for a link list. The rule deciding whether a whole
heading-segment *is* a widget was left behind on the old threshold:

```ts
if (m !== null && cpLen(teachingBody(span.slice(0, m.index))) < NAV_MAX_CHARS) return label;
```

Under 250 characters of teaching before a `<Quiz>`, and the entire section became
`assessment` — which no retrieval arm returns. So a section carrying a complete
180-character explanation followed by a knowledge check lost the explanation too.
The same defect as #55, one path over.

## The fix

Both paths now ask one question, and it is the question the word *dominance*
always meant: **is what comes before the widget navigation-shaped?**

| section | before | after |
|---|---|---|
| heading + quiz only | assessment | assessment ✓ |
| link list + quiz | assessment | assessment ✓ |
| 180 chars of real explanation + quiz | assessment ✗ | **prose** ✓ |

`classify()` and `segmentMarkerType()` share the helper, so the two can no longer
drift apart — which is how this survived the first fix.

## Found on a real corpus

Ingesting an 81-document curriculum book (6,912 chunks): 610 chunks landed as
`assessment` and 186 as `embed`, together **79% of everything unsearchable** in
that record. Most are genuinely widgets; this is about the ones that were not.

## Housekeeping the fix earned

`NAV_MAX_CHARS` is deleted — this was its last reader. The comments that named it
now name the number it was, so nothing points at a constant that no longer exists.

`CHUNK_POLICY` → **v7**: it is persisted per source row and gates carry-forward,
so the bump is what makes an existing corpus re-chunk rather than serve labels
from a rule that no longer runs. Adopters re-run `ksor ingest`; unchanged content
is not re-embedded.

The oracle-divergence property test already constrains this: `sourceType` may
move only `nav -> prose`, never the other way, and only where the section carries
real prose. It stays green.

Gate: 706 unit · guard · typecheck.