### PR TITLE
Report an ordering key this record does not read (#74)

### DIFF
--- a/.changeset/ordering-key-report.md
+++ b/.changeset/ordering-key-report.md
@@ -1,0 +1,25 @@
+---
+"@panaversity/ksor": patch
+---
+
+Ingest says when a document's ordering key is one this record does not read
+
+A record's reading order comes from the governed `order:` key alone. A corpus
+arriving from Docusaurus, Hugo or Jekyll carries its own — `sidebar_position`,
+`weight`, `nav_order` — and ksor ignored them in silence, falling back to file
+name. That is a WRONG order, not a missing one, and it is the order served to
+`llms.txt`, the rendered sidebar and the MCP `outline` alike.
+
+Found on a real 81-document book where 73 files declared `sidebar_position`. Its
+second chapter came out ninth; its preface came out eleventh. Nothing said why.
+
+```
+plain-tree: 73 document(s) declare `sidebar_position`, which this record does not
+read — reading order fell back to file name (about.md, how-to-sell.md,
+thesis.md, and 70 more). Rename it to `order:` to keep the intended sequence.
+```
+
+It reports on the same channel the adapter already uses for skipped files, where
+the principle was already written down: a skip is reported, never silent. A
+document that declares BOTH keys says nothing — `order:` wins, so nothing fell
+back, and a warning there would only teach the reader to ignore the channel.

--- a/packages/content/src/ingest/adapters/plain-tree.test.ts
+++ b/packages/content/src/ingest/adapters/plain-tree.test.ts
@@ -303,3 +303,72 @@ describe("frontmatterMeta", () => {
     expect(frontmatterMeta("---\nnot a mapping line\n---\n")).toEqual({});
   });
 });
+
+/**
+ * Issue #74 — an ordering key this record does not read must not be ignored in
+ * silence.
+ *
+ * Found by ingesting a real 81-document Docusaurus book: 73 files declared
+ * `sidebar_position`, ksor read only the governed `order:` key, ordering fell
+ * back to filename — alphabetical — and nothing in the output said why. That
+ * order is what `llms.txt`, the sidebar and the MCP `outline` all serve, so the
+ * book was served scrambled and the reader had no way to learn it.
+ *
+ * Ignoring the key is correct; the silence is the defect. This adapter already
+ * holds the principle for its other fallbacks: a skip is REPORTED, never silent.
+ */
+describe("a foreign ordering key is reported, not silently ignored (#74)", () => {
+  const withPos = (name: string, key: string, value: string): TreeEntry =>
+    file(name, `---\ntitle: T\n${key}: ${value}\n---\n\n# T\n\ntext\n`);
+
+  it("names the key, the count and the remedy", () => {
+    const lines: string[] = [];
+    build(
+      dir(
+        "root",
+        withPos("a.md", "sidebar_position", "3"),
+        withPos("b.md", "sidebar_position", "1"),
+        withPos("c.md", "sidebar_position", "2"),
+      ),
+      (l) => lines.push(l),
+    );
+    const said = lines.join("\n");
+    expect(said, `nothing was reported. Lines: ${JSON.stringify(lines)}`).toMatch(
+      /sidebar_position/,
+    );
+    expect(said, "the count must be there — 3 of 3 is a different problem from 3 of 300").toMatch(
+      /\b3\b/,
+    );
+    expect(said, "and the remedy: the governed key it should be renamed to").toMatch(/order:/);
+  });
+
+  it("says nothing when the document ALSO declares the governed key", () => {
+    // `order:` wins, so there is no fallback and nothing to warn about. A
+    // warning here would train the reader to ignore the channel.
+    const lines: string[] = [];
+    build(
+      dir(
+        "root",
+        file("a.md", `---\ntitle: T\norder: 1\nsidebar_position: 9\n---\n\n# T\n\ntext\n`),
+      ),
+      (l) => lines.push(l),
+    );
+    expect(lines.filter((l) => l.includes("sidebar_position"))).toEqual([]);
+  });
+
+  it("says nothing about a corpus that declares no foreign key at all", () => {
+    const lines: string[] = [];
+    build(dir("root", file("a.md"), file("b.md")), (l) => lines.push(l));
+    expect(lines.filter((l) => /ordering key/.test(l))).toEqual([]);
+  });
+
+  it("covers the other ecosystems' keys, not just Docusaurus's", () => {
+    const lines: string[] = [];
+    build(dir("root", withPos("a.md", "weight", "3"), withPos("b.md", "nav_order", "1")), (l) =>
+      lines.push(l),
+    );
+    const said = lines.join("\n");
+    expect(said).toMatch(/weight/);
+    expect(said).toMatch(/nav_order/);
+  });
+});

--- a/packages/content/src/ingest/adapters/plain-tree.ts
+++ b/packages/content/src/ingest/adapters/plain-tree.ts
@@ -274,10 +274,11 @@ export function buildManifestFromTree(
   // Same channel as a skip, and for the same reason: a fallback nobody is told
   // about produces a WRONG reading order, not a missing one (#74).
   for (const [key, paths] of foreignOrder) {
-    const shown = paths.slice(0, 3).join(", ");
-    const more = paths.length - Math.min(3, paths.length);
+    const rel = paths.map((x) => (x.startsWith(`${rootPath}/`) ? x.slice(rootPath.length + 1) : x));
+    const shown = rel.slice(0, 3).join(", ");
+    const more = rel.length - Math.min(3, rel.length);
     onSkip(
-      `plain-tree: ${paths.length} document(s) declare \`${key}\`, which this record does not ` +
+      `plain-tree: ${rel.length} document(s) declare \`${key}\`, which this record does not ` +
         `read — reading order fell back to file name (${shown}${more > 0 ? `, and ${more} more` : ""}). ` +
         "Rename it to `order:` to keep the intended sequence.",
     );

--- a/packages/content/src/ingest/adapters/plain-tree.ts
+++ b/packages/content/src/ingest/adapters/plain-tree.ts
@@ -137,6 +137,18 @@ export function buildManifestFromTree(
   const files: ManifestFile[] = [];
   const sources = new Map<string, string>();
   const skipped: string[] = [];
+  /** foreign ordering key -> the documents that declare it and no `order:`. */
+  const foreignOrder = new Map<string, string[]>();
+
+  const noteForeignOrder = (meta: Record<string, unknown>, path: string): void => {
+    if (meta["order"] !== undefined && meta["order"] !== null) return; // the governed key wins; nothing fell back
+    for (const key of FOREIGN_ORDER_KEYS) {
+      if (meta[key] === undefined || meta[key] === null) continue;
+      const seen = foreignOrder.get(key) ?? [];
+      seen.push(path);
+      foreignOrder.set(key, seen);
+    }
+  };
 
   const fullPath = (relSegs: readonly string[], name: string): string =>
     `${rootPath}/${[...relSegs, name].join("/")}`;
@@ -167,8 +179,10 @@ export function buildManifestFromTree(
         continue;
       }
       if (INDEX_NAMES.includes(f.name)) continue; // the parent section's own content — handled by the caller
+      const fileMeta = frontmatterMeta(f.text);
+      noteForeignOrder(fileMeta, fullPath(relSegs, f.name));
       ordered.push({
-        order: orderValue(frontmatterMeta(f.text)["order"]),
+        order: orderValue(fileMeta["order"]),
         tie: tieKey(f.name),
         entry: f,
       });
@@ -180,6 +194,7 @@ export function buildManifestFromTree(
       }
       const index = indexOf(d, fullPath(relSegs, d.name));
       const dirMeta = index === null ? {} : frontmatterMeta(index.text);
+      if (index !== null) noteForeignOrder(dirMeta, fullPath(relSegs, `${d.name}/${index.name}`));
       ordered.push({
         order: orderValue(dirMeta["order"]),
         tie: tieKey(d.name),
@@ -256,6 +271,17 @@ export function buildManifestFromTree(
   walk(root, [], null);
   // reported before any emptiness error, so an all-skips tree explains itself
   for (const s of skipped) onSkip(`plain-tree: skipped ${s}`);
+  // Same channel as a skip, and for the same reason: a fallback nobody is told
+  // about produces a WRONG reading order, not a missing one (#74).
+  for (const [key, paths] of foreignOrder) {
+    const shown = paths.slice(0, 3).join(", ");
+    const more = paths.length - Math.min(3, paths.length);
+    onSkip(
+      `plain-tree: ${paths.length} document(s) declare \`${key}\`, which this record does not ` +
+        `read — reading order fell back to file name (${shown}${more > 0 ? `, and ${more} more` : ""}). ` +
+        "Rename it to `order:` to keep the intended sequence.",
+    );
+  }
   if (files.length === 0)
     throw new ManifestError(`plain-tree root ${rootPath} contains no Markdown`);
 
@@ -366,6 +392,23 @@ function codePointCompare(a: string, b: string): number {
 
 // ^\uFEFF? — a BOM-prefixed file must not serve its YAML as a chunk
 // (review finding, 2026-08-19).
+/**
+ * Ordering keys OTHER ecosystems read, which this record does not.
+ *
+ * Reading order here is the governed `order:` key alone (decision 9 retired the
+ * predecessor's Docusaurus keys; the MCP door had been reading them). But a
+ * corpus arriving from Docusaurus, Hugo or Jekyll carries its own, and ignoring
+ * one silently produces a WRONG order rather than a missing one — filename
+ * order, served to `llms.txt`, the sidebar and the `outline` tool alike. Found
+ * on a real 81-document book where 73 files declared `sidebar_position` (#74).
+ */
+const FOREIGN_ORDER_KEYS: readonly string[] = [
+  "sidebar_position", // Docusaurus, and the predecessor
+  "position", // the predecessor's own
+  "weight", // Hugo
+  "nav_order", // Jekyll / Just-the-Docs
+];
+
 /** Re-exported so every reader of a document agrees where its frontmatter ENDS. */
 export const FRONTMATTER: RegExp = /^\uFEFF?---\r?\n([\s\S]*?)\r?\n---[ \t]*\r?\n?/;
 
@@ -391,8 +434,12 @@ const YAML_BOOLS: Record<string, boolean> = {
 };
 
 /**
- * Minimal PyYAML-compatible frontmatter reader for the FOUR scalar keys this
- * adapter consumes (`title`, `position`, `sidebar_position`, `sor_id`) — the
+ * Minimal PyYAML-compatible frontmatter reader. It parses every top-level
+ * scalar; the adapter consumes `title`, `order` and `sor_id`, and reads the rest
+ * only to WARN about them (see FOREIGN_ORDER_KEYS). The wording here named
+ * `position` and `sidebar_position` until now, which is what this adapter read
+ * before ordering became one governed key — the keys it names are the ones it
+ * stopped reading. The
  * kernel discards every other frontmatter key at build time (taxonomy comes
  * from the manifest), so a YAML dependency would buy nothing (guard rule 5).
  * Scope, deliberately narrow pending a shared markdown module: top-level


### PR DESCRIPTION
Closes #74.

A record's reading order comes from the governed `order:` key alone. A corpus
arriving from Docusaurus, Hugo or Jekyll carries its own, and ksor ignored them
in silence — falling back to file name. That is a **wrong** order, not a missing
one, and it is the order served to `llms.txt`, the rendered sidebar and the MCP
`outline` alike.

Found by ingesting a real 81-document book. Its second chapter came out ninth;
its preface came out eleventh. Nothing said why.

```
plain-tree: 69 document(s) declare `sidebar_position`, which this record does not
read — reading order fell back to file name (about.md, certifications.mdx,
glossary.md, and 66 more). Rename it to `order:` to keep the intended sequence.
```

Verified against that corpus — the line above is its real output.

## Why here, and why this channel

Ignoring the key is correct: decision 9 retired the predecessor's Docusaurus
keys, and the MCP door reading them was a defect fixed in 0.0.10. The silence is
what is wrong.

The adapter already holds the principle for its other fallbacks — hidden files
and symlinks are *"skipped LOUDLY … a skip is REPORTED, never silent"*
(`plain-tree.ts:71`), routed through `onSkip`. An ignored ordering key goes on
the same channel, aggregated with a count, three names and the remedy, the way
ingest already reports unsearchable chunks.

Covers `sidebar_position` (Docusaurus, and the predecessor), `position` (the
predecessor's own), `weight` (Hugo) and `nav_order` (Jekyll).

A document declaring **both** keys says nothing: `order:` wins, so nothing fell
back, and warning there would only train the reader to ignore the channel. Tested.

## One stale comment corrected

`frontmatterMeta`'s doc-block said it reads "`title`, `position`, `sidebar_position`,
`sor_id`" — the keys it read *before* ordering became one governed key. It now
says what it reads, and that the rest is read only to warn about it.

Gate: 707 unit · 227 integration · guard · check:corpus.

## Related, found in the same walk — not fixed here

Four of the 73 declaring documents never reach this warning, because a valid YAML
flow sequence in their frontmatter (`authors: ["…"]`) poisons the whole parse and
empties the metadata. They lose their **titles** too — "The System of Context:
Connecting the Records to Real Work" is stored as "System Of Context". Separate
defect, separate PR.