### PR TITLE
A value this reader does not model is not an invalid document (#78)

### DIFF
--- a/.changeset/unmodelled-is-not-invalid.md
+++ b/.changeset/unmodelled-is-not-invalid.md
@@ -1,0 +1,44 @@
+---
+"@panaversity/ksor": patch
+---
+
+A YAML list in frontmatter no longer costs the document its title
+
+The frontmatter reader emptied a document's ENTIRE metadata whenever a top-level
+value opened with `[ { | > & * !`. One `authors: ["…"]` line beside the title,
+and the title went with it — along with `order:` and `sor_id:`.
+
+Found on a real 81-document book, where four chapters were served under names
+derived from their filenames:
+
+| served as                    | declared                                                        |
+| ---------------------------- | --------------------------------------------------------------- |
+| `Preface Agent Native`       | `Preface: The Right Side of the Line`                           |
+| `System Of Context`          | `The System of Context: Connecting the Records to Real Work`    |
+| `Designing The Vertical Sor` | `Designing the Vertical System of Record from First Principles` |
+
+Titles reach the site, `llms.txt` and the MCP `outline`, so this was wrong on
+every surface at once, and silently.
+
+The reader is documented as PyYAML-compatible and empties the map only where
+PyYAML raises. PyYAML does not raise on a flow sequence — it parses it. Two
+different things were being conflated:
+
+- **invalid** — an unquoted `a: b: c`, a trailing `:`. PyYAML raises; the map is
+  still emptied, unchanged.
+- **valid but not modelled here** — a flow sequence or mapping, a block scalar,
+  an anchor. PyYAML parses these. Only the KEY is beyond the reader now; the
+  document survives.
+
+**One identity change to know about.** A document that declares `sor_id:`
+_alongside_ such a value previously had that override silently dropped, so its
+stable_id fell back to the path. The override now stands, on both surfaces
+together — so re-ingesting changes the stable_id of exactly those documents, and
+any takedown row keyed on the old path-derived id must be re-pointed. The site
+and the kernel change in step, which is the property `stable-id-conformance`
+exists to hold.
+
+One governance guard gets quieter and no weaker: ingest used to REFUSE a
+document declaring `visibility:` beside a flow list, because the map was emptied
+and the tier silently defaulted. The cause is gone, so it ingests with the right
+visibility; the refusal still stands for frontmatter PyYAML genuinely rejects.

--- a/packages/content/src/ingest/adapters/plain-tree.test.ts
+++ b/packages/content/src/ingest/adapters/plain-tree.test.ts
@@ -299,7 +299,60 @@ describe("frontmatterMeta", () => {
 
   it("poisons the WHOLE meta on YAML PyYAML would refuse", () => {
     expect(frontmatterMeta("---\ntitle: Rule 10: Machine Badges\nposition: 3\n---\n")).toEqual({});
-    expect(frontmatterMeta("---\ntitle: >\n  folded\n---\n")).toEqual({});
     expect(frontmatterMeta("---\nnot a mapping line\n---\n")).toEqual({});
+    // A block scalar is NOT in this list: PyYAML parses it, so the document is
+    // valid and only the key is beyond this reader (#78).
+    expect(frontmatterMeta("---\ntitle: >\n  folded\n---\n")).toEqual({ title: null });
+  });
+});
+
+/**
+ * Issue #78 — a value this reader does not model is not an invalid document.
+ *
+ * `scalarValue` refused anything opening with `[ { | > & * !` and the caller
+ * treated the refusal as poison, emptying the whole meta. So one YAML list
+ * alongside the title took the title with it, and four documents in a real book
+ * were served under filename-derived names — "The System of Context: Connecting
+ * the Records to Real Work" stored as "System Of Context".
+ *
+ * The reader is documented as PyYAML-compatible, and PyYAML parses a flow
+ * sequence perfectly well. Only what PyYAML would REJECT may empty the meta.
+ */
+describe("valid YAML this reader does not model keeps the rest (#78)", () => {
+  const KEEPS = {
+    "a flow sequence": 'authors: ["Panaversity Team"]',
+    "a flow mapping": "slides: { height: 700 }",
+    "a block scalar": "summary: |",
+    "an anchor": "base: &defaults",
+  };
+  for (const [what, line] of Object.entries(KEEPS)) {
+    it(`${what} does not cost the document its title`, () => {
+      const meta = frontmatterMeta(
+        `---\ntitle: "Preface: The Right Side"\n${line}\norder: 3\n---\n\nbody\n`,
+      );
+      expect(meta["title"], `meta was emptied by ${what}: ${JSON.stringify(meta)}`).toBe(
+        "Preface: The Right Side",
+      );
+      expect(meta["order"], "and the governed ordering key went with it").toBe(3);
+    });
+  }
+
+  const POISONS = {
+    "an unquoted plain scalar containing ': '": "title: Preface: The Right Side",
+    "a key with a trailing colon in its value": "title: Preface:",
+  };
+  for (const [what, line] of Object.entries(POISONS)) {
+    it(`${what} still empties the meta — PyYAML raises there`, () => {
+      expect(frontmatterMeta(`---\n${line}\norder: 3\n---\n\nbody\n`)).toEqual({});
+    });
+  }
+
+  it("the real shape that lost four titles", () => {
+    const meta = frontmatterMeta(
+      '---\ntitle: "Preface: The Right Side of the Line"\n' +
+        'authors: ["Panaversity Team"]\ndate: "2026-07-04"\nsidebar_position: -9\n---\n\nbody\n',
+    );
+    expect(meta["title"]).toBe("Preface: The Right Side of the Line");
+    expect(meta["sidebar_position"], "so #74's warning can see it too").toBe(-9);
   });
 });

--- a/packages/content/src/ingest/adapters/plain-tree.ts
+++ b/packages/content/src/ingest/adapters/plain-tree.ts
@@ -440,9 +440,29 @@ function scalarValue(raw: string): ScalarResult {
   if (/^[-+]?(?:\.[0-9]+|[0-9][0-9_]*\.[0-9_]*)(?:[eE][-+]?[0-9]+)?$/.test(plain)) {
     return { ok: true, value: Number.parseFloat(plain.replaceAll("_", "")) };
   }
-  // PyYAML refuses these in a plain value position; anything it would instead
-  // read as a non-scalar (flow map/seq) is equally outside this reader's scope.
+  // VALID YAML this reader does not model: a flow sequence or mapping, a block
+  // scalar, an anchor/alias/tag. PyYAML parses every one — the DOCUMENT is fine
+  // and only this KEY is beyond the reader, so it must not empty the map.
+  // Checked BEFORE the ": " test, because a flow mapping legitimately contains
+  // one (`meta: {a: 1}`).
+  //
+  // Refusing them used to poison the whole meta, which cost four documents in a
+  // real book their titles: "The System of Context: Connecting the Records to
+  // Real Work" was served as "System Of Context" because one `authors: [...]`
+  // line sat beside the title (issue #78). Recorded as a non-string, so
+  // `stableIdOf` still declines to take it as an override — which is what keeps
+  // this in step with the site (see denial-rule.ts).
+  if (/^[|>&*!{[]/.test(plain)) return { ok: true, value: null };
+  // INVALID: PyYAML raises on a plain scalar carrying ": " or ending in ":", so
+  // the oracle's error path empties the whole meta and so does this.
   if (/:[ \t]/.test(plain) || plain.endsWith(":")) return { ok: false, value: null };
-  if (/^[|>&*!{[]/.test(plain)) return { ok: false, value: null };
+  // VALID, but not modelled here: a flow sequence or mapping, a block scalar, an
+  // anchor/alias/tag. PyYAML parses every one of these — so the document is fine
+  // and only this KEY is beyond the reader. Refusing them used to poison the
+  // whole meta, which cost four documents in a real book their titles: "The
+  // System of Context: Connecting the Records to Real Work" was served as
+  // "System Of Context", because one `authors: [...]` line sat beside the title
+  // (issue #78). The key is recorded present-with-unknown-value; the keys this
+  // adapter actually consumes survive.
   return { ok: true, value: plain };
 }

--- a/packages/content/src/ingest/governance.test.ts
+++ b/packages/content/src/ingest/governance.test.ts
@@ -101,15 +101,17 @@ describe("list shapes the site accepts", () => {
 });
 
 describe("visibility is read from the TEXT, never from a map a sibling can empty", () => {
-  it("REFUSES when an unrelated key makes the parser drop the whole map", () => {
-    // `frontmatterMeta` empties the WHOLE map on any parse failure, so one
-    // sibling key this narrow parser cannot read silently dropped
-    // `visibility:` — the document took the default tier and was served while
-    // the site still hid it. The leak, entering through a third door.
+  it("READS visibility beside a flow list — the shape that used to drop it", () => {
+    // This case used to REFUSE, and refusing was right at the time: the reader
+    // emptied the WHOLE map on any shape it could not model, so a sibling
+    // `tags: [...]` silently dropped `visibility:` and the document took the
+    // default tier — served while the site still hid it, the leak's third door.
+    //
+    // #78 removed the cause: a flow list is valid YAML, so it no longer empties
+    // anything and `visibility` arrives intact. The guard below still stands for
+    // frontmatter PyYAML would genuinely reject.
     const text = doc(["title: T", "tags: [hr, payroll]", "visibility: internal"].join("\n"));
-    expect(() => read(text)).toThrow(/could not resolve it/i);
-    // and it names the actual cause, not just the symptom
-    expect(() => read(text)).toThrow(/flow list/i);
+    expect(read(text).visibility).toBe("internal");
   });
 
   it("REFUSES for an unquoted value containing a colon-space, the other poison shape", () => {
@@ -131,8 +133,12 @@ describe("one frontmatter grammar, not two", () => {
   // Two regexes disagreeing about where a block ENDS is how the leak found a
   // fourth door: a `----` or `--- ` close satisfied the adapter (poisoning its
   // map) and not this reader (so both guards went silent).
+  // The vehicle is a genuinely-poisoning shape — an unquoted value carrying
+  // ": ", which PyYAML rejects. It used to be a flow list, which #78 established
+  // is valid YAML and no longer empties anything; the point of THIS test is the
+  // block terminator, not the poison, so only the vehicle changed.
   const poisoned = (close: string): string =>
-    `---\ntitle: T\ntags: [hr, payroll]\nvisibility: internal\n${close}\n\nBody.\n`;
+    `---\ntitle: Report: Q3\nvisibility: internal\n${close}\n\nBody.\n`;
 
   for (const close of ["---", "----", "--- "]) {
     it(`REFUSES a poisoned map whatever closes the block: ${JSON.stringify(close)}`, () => {

--- a/packages/content/src/lib/denial-rule.ts
+++ b/packages/content/src/lib/denial-rule.ts
@@ -136,8 +136,16 @@ function readScalar(raw: string): ScalarRead {
   // override — which is what the kernel does. Kept in step with `scalarValue`
   // in ingest/adapters/plain-tree.ts and bound to it by
   // `stable-id-conformance.test.ts`.
+  // VALID YAML this reader does not model: a flow sequence or mapping, a block
+  // scalar, an anchor/alias/tag. PyYAML parses every one — the DOCUMENT is fine
+  // and only this KEY is beyond the reader, so it must not empty the map.
+  // Checked BEFORE the ": " test, because a flow mapping legitimately contains
+  // one (`meta: {a: 1}`).
+  // `typed` rather than `refused`: the key exists but is not a string, so this
+  // map (which holds strings) omits it and no override is taken — exactly what
+  // the kernel now does with `value: null` (issue #78).
+  if (/^[|>&*!{[]/.test(plain)) return { kind: "typed", value: "" };
   if (/:[ \t]/.test(plain) || plain.endsWith(":")) return { kind: "refused", value: "" };
-  if (/^[|>&*!{[]/.test(plain)) return { kind: "refused", value: "" };
   if (YAML_TYPED.test(plain)) return { kind: "typed", value: "" };
   return { kind: "string", value: plain };
 }

--- a/packages/content/src/lib/stable-id-conformance.test.ts
+++ b/packages/content/src/lib/stable-id-conformance.test.ts
@@ -96,10 +96,21 @@ describe("one stable_id, both surfaces", () => {
     }
   });
 
-  it("the FLOW LIST case is genuinely poisoned — or this table proves nothing", () => {
-    // A control: if the kernel ever stops poisoning, these cases become
-    // trivially equal and the table would still pass while testing nothing.
+  it("a flow list no longer costs the document its override (#78)", () => {
+    // This used to assert the opposite, and the opposite was the defect: the
+    // kernel emptied the whole map, so `sor_id:` was dropped and the id fell
+    // back to the path. A flow list is valid YAML; the override now stands, and
+    // BOTH readers take it — which is the property this file exists to hold.
     const text = doc("title: Policy\ntags: [hr, payroll]\nsor_id: hr/policy");
+    expect(frontmatterMeta(text)["sor_id"], "the kernel keeps the override").toBe("hr/policy");
+    expect(stableIdFrom(RECORD, REL, blockOf(text)), "and so does the site").toBe("hr/policy");
+  });
+
+  it("a GENUINELY poisoned map still drops the override on both sides", () => {
+    // The control that keeps the table honest: if nothing poisoned any more,
+    // every case would be trivially equal and this file would prove nothing.
+    // An unquoted value carrying ": " is what PyYAML actually rejects.
+    const text = doc("title: Note: quoting\nsor_id: hr/policy");
     expect(Object.keys(frontmatterMeta(text)), "the kernel drops the whole map").toEqual([]);
     expect(
       stableIdFrom(RECORD, REL, blockOf(text)),

--- a/packages/ksor/templates/scaffold/system/site/lib/denial-rule.ts
+++ b/packages/ksor/templates/scaffold/system/site/lib/denial-rule.ts
@@ -136,8 +136,16 @@ function readScalar(raw: string): ScalarRead {
   // override — which is what the kernel does. Kept in step with `scalarValue`
   // in ingest/adapters/plain-tree.ts and bound to it by
   // `stable-id-conformance.test.ts`.
+  // VALID YAML this reader does not model: a flow sequence or mapping, a block
+  // scalar, an anchor/alias/tag. PyYAML parses every one — the DOCUMENT is fine
+  // and only this KEY is beyond the reader, so it must not empty the map.
+  // Checked BEFORE the ": " test, because a flow mapping legitimately contains
+  // one (`meta: {a: 1}`).
+  // `typed` rather than `refused`: the key exists but is not a string, so this
+  // map (which holds strings) omits it and no override is taken — exactly what
+  // the kernel now does with `value: null` (issue #78).
+  if (/^[|>&*!{[]/.test(plain)) return { kind: "typed", value: "" };
   if (/:[ \t]/.test(plain) || plain.endsWith(":")) return { kind: "refused", value: "" };
-  if (/^[|>&*!{[]/.test(plain)) return { kind: "refused", value: "" };
   if (YAML_TYPED.test(plain)) return { kind: "typed", value: "" };
   return { kind: "string", value: plain };
 }


### PR DESCRIPTION
Closes #78.

`scalarValue` returned `{ ok: false }` for any top-level value opening with
`[ { | > & * !`, and the caller treats that as poison — emptying the document's
whole metadata. So one `authors: ["Panaversity Team"]` line beside the title took
the title with it, along with `order:` and `sor_id:`.

Four chapters of a real 81-document book were served under filename-derived names:

| served as | declared |
|---|---|
| `Preface Agent Native` | `Preface: The Right Side of the Line` |
| `System Of Context` | `The System of Context: Connecting the Records to Real Work` |
| `Designing The Vertical Sor` | `Designing the Vertical System of Record from First Principles` |

The reader is documented as *"Minimal **PyYAML-compatible** … Mirroring the
oracle's error path (`parse_frontmatter` catches YAMLError → `{}`)"*. PyYAML does
not raise on a flow sequence. We were stricter than the oracle we claim to
mirror, on syntax the oracle's own fixtures never exercise — which is why it was
never caught.

**invalid** (PyYAML raises: unquoted `a: b: c`, trailing `:`) still empties the
map. **Valid but unmodelled** (flow seq/map, block scalar, anchor) now records the
key with a non-string value and leaves the rest alone. The unmodelled check runs
*first*, because a flow mapping legitimately contains `": "`.

## Both surfaces, together

This is decision-18 territory. `stable-id-conformance.test.ts` exists because the
site and the kernel once disagreed on `sor_id` for exactly this shape, and **a
takedown was honoured by the MCP door and ignored by the site build**. So the
change lands in all three copies at once — kernel, site, and the scaffold's
byte-identical copy — with the site recording `typed` where the kernel records a
non-string, so both decline the override and both keep the map.

**One identity change to know about:** a document declaring `sor_id:` beside such
a value used to have the override dropped and fell back to a path-derived id. The
override now stands. Re-ingesting changes the stable_id of exactly those
documents, and a takedown keyed on the old id must be re-pointed. Both surfaces
move together, so they cannot diverge.

## Four characterizations corrected, not bulk-updated

Six tests asserted the old behaviour and each needed a different answer:

- **governance** — used to REFUSE a document declaring `visibility:` beside a flow
  list, because the emptied map silently defaulted the tier (the leak's third
  door). The cause is gone, so it now READS `internal`. The refusal still stands
  for genuine poison — that test never went red.
- **block-terminator grammar** — its subject is where a block ENDS, not poisoning.
  Only the vehicle changed, to a shape PyYAML actually rejects.
- **`title: >`** — a block scalar is valid YAML, so it moved out of the poison list.
- **the conformance control** — asserted the kernel poisons, "or this table proves
  nothing". Re-aimed at a genuinely-poisoned map, so the table stays non-trivial.

Gate: 711 unit · 227 integration · 177 db · guard · check:corpus.