### PR TITLE
A citation pin no longer outlives a restriction (#87)

### DIFF
--- a/.changeset/pins-yield-to-governance.md
+++ b/.changeset/pins-yield-to-governance.md
@@ -1,0 +1,30 @@
+---
+"@panaversity/ksor": patch
+---
+
+A citation pin no longer outlives a restriction
+
+A snapshot token pins a generation so a citation keeps resolving to the same
+bytes. It was also deciding the _audience_ question — evaluating `visibility` on
+the pinned row — so a document restricted after the token was issued kept reading
+in full for the token's life, to a caller the record had just closed it to.
+
+Three routes refused it and one served it, on the same surface, in the same
+second: `outline` omitted it, `search` filtered it, an unpinned `read` refused it,
+and `read` with a pre-flip token returned the whole document.
+
+The generation pointers are why the obvious guard missed it. A flip sets
+`rollback_generation` to the generation just superseded, so a pre-flip pin is
+exactly the rollback pointer — servable by design, and the check that narrows a
+pin to {active, rollback} passed it.
+
+**Governance is now read from the record as it stands.** A pin still decides
+which generation's content is served; it no longer decides whether the caller may
+have it. A document the record no longer contains cannot be resurrected by one
+either. Unpinned reads are unaffected — with nothing pinned, the two generations
+are the same one and the check is an identity.
+
+The cost is deliberate: a citation can stop resolving within the token's 30
+minutes when the record restricts what it points at. That is what "the record
+changed" should look like. The alternative is a window in which a withdrawal is
+not a withdrawal.

--- a/packages/content/src/governance-chain.db.test.ts
+++ b/packages/content/src/governance-chain.db.test.ts
@@ -39,6 +39,7 @@ import { buildGeneration } from "./ingest/build.js";
 import { buildShippedProvider } from "./lib/providers/registry.js";
 import { embedQueryVlit } from "./lib/query-embed.js";
 import { UnknownSlug } from "./lib/read.js";
+import { mint } from "./lib/snapshot.js";
 import { keyRingFromEnv } from "./lib/snapshot.js";
 import { applySchema } from "./schema.js";
 import { outlineDocuments, readDocument, search } from "./service.js";
@@ -419,4 +420,161 @@ describe.runIf(adminDsn === "")("the governance chain (db) — gated", () => {
   it("skips without KSOR_DB_URL", () => {
     expect(adminDsn).toBe("");
   });
+});
+
+/**
+ * Issue #87 — a pin decides which generation's CONTENT is served, never whether
+ * the caller may still have it.
+ *
+ * A snapshot token exists so a citation keeps resolving to the same bytes. It
+ * pins a generation, and the audience predicate evaluated `visibility` on the
+ * PINNED row — which still said `public` for a document the record had since
+ * restricted. Reproduced end to end: `outline` omitted it, an unpinned `read`
+ * refused it, and `read` with a pre-flip token served it in full to a public
+ * caller. Three routes refusing and one serving, on the same surface, in the
+ * same second — decision 19 failing inside one door.
+ *
+ * `servableGenerations` did not catch it: a flip sets `rollback_generation` to
+ * the generation just superseded, so a pre-flip pin IS the rollback pointer and
+ * is servable by design.
+ *
+ * The rule now: governance is read from the record as it stands. Pins yield.
+ * A citation may stop resolving within the token's life, which is what "the
+ * record changed" should look like — and the alternative is a window in which a
+ * withdrawal is not a withdrawal.
+ */
+describe.runIf(adminDsn !== "")("a pin does not outlive a restriction (db)", () => {
+  const DB2 = "ksor_pin_governance";
+  const T = "pincorp";
+  let pool2: pg.Pool;
+  let admin2: pg.Pool;
+  let work2: string;
+  let inst2: ContentInstance;
+
+  // ONE ring for the whole suite. `keyRingFromEnv(undefined)` mints a RANDOM key
+  // per call, so minting with one and validating with another makes every token
+  // silently invalid — the read then "refreshes" to the active generation and
+  // looks like a refusal. That artifact hid this defect from a first draft of
+  // these tests; the token has to be genuinely valid for the assertion to mean
+  // anything.
+  const RING = keyRingFromEnv(undefined);
+
+  const doorAt = (audience: string | null): ServiceContext => ({
+    pool: pool2,
+    instance: inst2,
+    ring: RING,
+    instanceDigest: createHash("sha256").update("pin").digest("hex"),
+    embedQuery: (q: string) =>
+      embedQueryVlit(q, { provider: buildShippedProvider("fake", { apiKey: null }) }),
+    audience,
+  });
+
+  const pinFor = (generation: number): string =>
+    mint(
+      RING,
+      {
+        corpusId: inst2.corpusId,
+        tenantId: inst2.tenantId,
+        instanceDigest: createHash("sha256").update("pin").digest("hex"),
+      },
+      generation,
+    ).token;
+
+  const write = async (visibility: string): Promise<void> => {
+    writeFileSync(
+      path.join(work2, "knowledge", "layoffs.md"),
+      `---\ntitle: Layoffs\nstatus: approved\nvisibility: ${visibility}\n---\n\n` +
+        `# Layoffs\n\nThe restructuring plan ${SECRET} covers three sites and the timetable ` +
+        `for consultation, including which roles are affected and when each group is told. ` +
+        `It is the reference managers use when preparing individual conversations.\n`,
+      "utf8",
+    );
+  };
+
+  beforeAll(async () => {
+    const { Pool } = (await import("pg")).default;
+    admin2 = new Pool({ connectionString: adminDsn });
+    await admin2.query(`DROP DATABASE IF EXISTS ${DB2} WITH (FORCE)`).catch(() => undefined);
+    await admin2.query(`CREATE DATABASE ${DB2}`);
+    const url = new URL(adminDsn);
+    url.pathname = `/${DB2}`;
+    pool2 = contentPool(url.toString(), 4);
+    await applySchema(pool2, 1536);
+    await grantIngest(pool2, T);
+    work2 = mkdtempSync(path.join(tmpdir(), "ksor-pin-"));
+    mkdirSync(path.join(work2, "knowledge"), { recursive: true });
+    writeFileSync(
+      path.join(work2, "knowledge", "handbook.md"),
+      `---\ntitle: Handbook\nstatus: approved\nvisibility: public\n---\n\n# Handbook\n\n` +
+        `Onboarding, expenses and travel, written for everyone and left untouched by this ` +
+        `test so the control means something.\n`,
+      "utf8",
+    );
+    await write("public");
+    inst2 = {
+      name: T,
+      corpusId: T,
+      tenantId: T,
+      dsnEnv: "KSOR_DB_URL",
+      abstain: { vectorFloor: null, keywordFloor: null },
+      textSearchConfig: "english",
+      maximumResponseCharacters: 120_000,
+      instructions: "",
+      audiences: ["public", "internal"],
+      defaultVisibility: "public",
+      embeddingProvider: "fake",
+      embeddingModel: "fake-embed-001",
+      embeddingDim: 1536,
+    } as ContentInstance;
+    await buildGeneration(pool2, inst2, {
+      provider: buildShippedProvider("fake", { apiKey: null }),
+      knowledgeDir: path.join(work2, "knowledge"),
+      flip: true,
+      sourceCommit: "gen1",
+    });
+  }, 600_000);
+
+  afterAll(async () => {
+    await pool2?.end().catch(() => undefined);
+    await admin2?.query(`DROP DATABASE IF EXISTS ${DB2} WITH (FORCE)`).catch(() => undefined);
+    await admin2?.end().catch(() => undefined);
+    if (work2 !== undefined && work2 !== "") rmSync(work2, { recursive: true, force: true });
+  });
+
+  it("serves the pinned read while the document is still public — the control", async () => {
+    const doc = await readDocument(doorAt("public"), "layoffs", { snapshotToken: pinFor(1) });
+    expect(doc.text, "a public caller may pin and read a public document").toContain(SECRET);
+  }, 120_000);
+
+  it("REFUSES the same pinned read once the record restricts it", async () => {
+    await write("internal");
+    await buildGeneration(pool2, inst2, {
+      provider: buildShippedProvider("fake", { apiKey: null }),
+      knowledgeDir: path.join(work2, "knowledge"),
+      flip: true,
+      sourceCommit: "gen2",
+    });
+
+    // Every other route already refuses; this is the fourth.
+    await expect(
+      readDocument(doorAt("public"), "layoffs"),
+      "unpinned read — already refused before this fix",
+    ).rejects.toBeInstanceOf(UnknownSlug);
+    await expect(
+      readDocument(doorAt("public"), "layoffs", { snapshotToken: pinFor(1) }),
+      "and the PIN must not re-open what the record just closed",
+    ).rejects.toBeInstanceOf(UnknownSlug);
+  }, 120_000);
+
+  it("still serves the pinned read to the tier the record DOES allow", async () => {
+    const doc = await readDocument(doorAt("internal"), "layoffs", { snapshotToken: pinFor(1) });
+    expect(doc.text, "governance decides, not the pin — internal may still read it").toContain(
+      SECRET,
+    );
+  }, 120_000);
+
+  it("leaves an untouched document pinning exactly as before", async () => {
+    const doc = await readDocument(doorAt("public"), "handbook", { snapshotToken: pinFor(1) });
+    expect(doc.text, "the property pins exist for is unaffected").toContain("Onboarding");
+  }, 120_000);
 });

--- a/packages/content/src/lib/read.ts
+++ b/packages/content/src/lib/read.ts
@@ -26,6 +26,28 @@ g AS (
         (SELECT active_generation FROM corpora
           WHERE tenant_id = $1 AND corpus_id = $2)
     ) AS gen
+),
+-- The generation the record is on RIGHT NOW, which decides governance even when
+-- content is served from a pinned one.
+--
+-- A snapshot pin exists so a citation keeps resolving to the same bytes. It used
+-- to decide the audience question too, by evaluating visibility on the pinned
+-- row — so a document restricted after the token was issued kept reading in full
+-- for the token's life, while outline, search and an unpinned read all
+-- refused it in the same second. servableGenerations could not catch it: a
+-- flip sets rollback_generation to the generation just superseded, so a pre-flip
+-- pin IS the rollback pointer and is servable by design (issue #87).
+--
+-- Pins yield. A citation may stop resolving within the token's life, which is
+-- what "the record changed" should look like — the alternative is a window in
+-- which a withdrawal is not a withdrawal, and decision 19 says a surface that
+-- refuses must refuse everywhere, which includes its own fourth route.
+--
+-- When nothing is pinned this is the SAME generation as g, so the join is an
+-- identity and no unpinned read changes behaviour.
+live AS (
+    SELECT active_generation AS gen FROM corpora
+     WHERE tenant_id = $1 AND corpus_id = $2
 )`;
 
 // Takedown denial is SCOPED (decision 14): per-node by default, whole subtree
@@ -60,7 +82,12 @@ SELECT n.node_id, n.slug, n.title, n.stable_id, n.path, n.generation, n.permalin
 FROM tree n
 JOIN content_nodes self ON self.node_id = n.node_id AND self.tenant_id = $1
                        AND self.generation = n.generation
-WHERE n.slug = $4 AND ${DENY} AND ${audienceAllowed("self")}
+-- INNER join, so a document the record no longer contains cannot be
+-- resurrected by a pin either: no live row, no read.
+JOIN live ON TRUE
+JOIN content_nodes now ON now.tenant_id = $1 AND now.generation = live.gen
+                      AND now.stable_id = self.stable_id
+WHERE n.slug = $4 AND ${DENY} AND ${audienceAllowed("now")}
 ORDER BY n.path`;
 
 export const ALIAS_SQL: string = `
@@ -79,8 +106,11 @@ export const NODE_BY_STABLE_ID_SQL: string = `
 WITH RECURSIVE ${GEN}, ${DENIED_CTE}
 SELECT n.node_id, n.slug, n.title, n.stable_id, n.stable_id::text AS path, n.generation, n.permalink
 FROM content_nodes n JOIN g ON n.generation = g.gen
+JOIN live ON TRUE
+JOIN content_nodes now ON now.tenant_id = $1 AND now.generation = live.gen
+                      AND now.stable_id = n.stable_id
 WHERE n.tenant_id = $1 AND n.stable_id = $4 AND n.status = 'published' AND ${DENY}
-  AND ${AUDIENCE_ALLOWED}`;
+  AND ${audienceAllowed("now")}`;
 
 export const DOCUMENT_CHUNKS_SQL: string = `
 WITH ${GEN}


### PR DESCRIPTION
Closes #87.

A snapshot token pins a generation so a citation keeps resolving to the same
bytes. It was also deciding the **audience** question, by evaluating `visibility`
on the pinned row — so a document restricted after the token was issued kept
reading in full for the token's life.

```
pointers            {active_generation: 2, rollback_generation: 1}
public outline      layoffs absent
public search       layoffs filtered
public read         UnknownSlug
public read + pin   SERVED  gen 1, full body        ← the fourth route
```

Three routes refusing and one serving, on the same surface, in the same second.
Decision 19 says a surface that refuses must refuse on both surfaces; this was it
failing **inside** one.

`servableGenerations` could not catch it: a flip sets `rollback_generation` to the
generation just superseded, so a pre-flip pin *is* the rollback pointer, and
narrowing a pin to {active, rollback} passes it by design.

## The rule

**Governance is read from the record as it stands.** One `live` CTE resolves the
node in the active generation, and the audience predicate evaluates against that
row on both resolution arms — by slug and by stable_id. The pin still decides
which generation's *content* is served; it no longer decides whether the caller
may have it.

The join is INNER, so a document the record no longer contains cannot be
resurrected by a pin either.

**Unpinned reads are unaffected by construction** — with nothing pinned the two
generations are the same one and the join is an identity.

The cost is deliberate and stated in the changeset: a citation can stop resolving
within the token's 30 minutes when the record restricts what it points at. The
alternative is a window in which a withdrawal is not a withdrawal.

## A test that lied to me first

My first version of these tests **passed against the unfixed code**, and the
reason is worth recording: `keyRingFromEnv(undefined)` mints a random key per
call, so minting with one ring and validating with another made every token
silently invalid. `readDocument` then "refreshed" to the active generation and
refused — which looks exactly like the fix working.

I only caught it because I probed the raw behaviour separately and got the
opposite answer. The suite now shares one ring, with a comment saying why, and
goes red on the unfixed code for the right reason:

```
AssertionError: promise resolved "{ slug: 'layoffs', …(5) }" instead of rejecting
```

Four cases: the control while the document is still public, the refusal after it
is restricted, the tier that *is* allowed still reading it pinned, and an
untouched document pinning exactly as before.

Gate: 724 unit · 227 integration · 197 db.