### PR TITLE
Name the probes that held a calibration open (#81)

### DIFF
--- a/.changeset/name-the-overlapping-probe.md
+++ b/.changeset/name-the-overlapping-probe.md
@@ -1,0 +1,33 @@
+---
+"@panaversity/ksor": patch
+---
+
+When calibration does not separate, `ksor calibrate` names the probes that held it open
+
+A "NOT separable" verdict reads as _this corpus cannot be calibrated_, and the
+report had every number needed to show otherwise while printing none of them.
+Its only remedy was "widen the probe set" — when the fix is sometimes to narrow
+it.
+
+```
+these out-of-corpus probes scored at or above your weakest in-corpus question:
+  0.721  which vector database should I choose
+  ^ look at these first. Either the record COVERS one — move it to the
+    in-corpus side, because a probe the record answers is not out of corpus
+    — or it genuinely does not separate, and the floor stays uncalibrated.
+```
+
+That is a real measurement, on a real 81-document book. One probe — a question
+about vector databases, asked of a record containing a Postgres-and-AI chapter —
+held the whole calibration open at 0.721 against a weakest in-corpus question of
+0.680. It was not an out-of-corpus question at all; it was mislabelled. Moving it
+separated the record immediately (`max OOC 0.676 < min in-corpus 0.680`), and the
+resulting floor answered every in-corpus question and refused every genuine
+out-of-corpus one.
+
+Without that line, the conclusion drawn from the same numbers was that the record
+could not support abstention — the product's headline guarantee — at all.
+
+The advice deliberately names **both** readings, because either can be right: the
+probe may be mislabelled, or the corpus may genuinely fail to separate, in which
+case the floor stays uncalibrated and that is the correct outcome.

--- a/packages/content/src/calibrate/overlap.test.ts
+++ b/packages/content/src/calibrate/overlap.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Naming the probes that held a calibration open.
+ *
+ * See overlap.ts for why this is not in `renderReport`: that function's output is
+ * pinned byte-exact to the Python oracle's, and operator guidance should not
+ * require regenerating a captured fixture to improve.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { buildReport } from "./math.js";
+import { overlapAdvice, overlappingProbes } from "./overlap.js";
+
+const meta = {
+  generation: 1,
+  pinned: false,
+  model: "gemini-embedding-001",
+  dim: 1536,
+  door: "queries-file" as const,
+  oocSource: "provided" as const,
+};
+
+/** The real shape, from the book that produced this finding. */
+const DETAIL = [
+  { query: "what is the ecosystem concept", in_corpus: true, score: 0.68 },
+  { query: "what is a digital FTE", in_corpus: true, score: 0.79 },
+  { query: "what roles does this book train me for", in_corpus: true, score: 0.81 },
+  { query: "which vector database should I choose", in_corpus: false, score: 0.721 },
+  { query: "how do I set up CI in GitHub Actions", in_corpus: false, score: 0.676 },
+  { query: "what is the parental leave policy", in_corpus: false, score: 0.552 },
+];
+
+const reportOf = (detail: typeof DETAIL) =>
+  buildReport(detail, meta, 0.95, new Date("2026-08-22T00:00:00Z"));
+
+describe("the probes that held a calibration open are named", () => {
+  it("names the one that outscored the weakest in-corpus question", () => {
+    const advice = overlapAdvice(reportOf(DETAIL));
+    expect(advice, "a non-separable measurement must say WHICH probe").not.toBeNull();
+    expect(advice).toMatch(/which vector database should I choose/);
+    expect(advice, "with its score, so the margin is visible").toMatch(/0\.721/);
+  });
+
+  it("leaves out probes that scored below the weakest — they decided nothing", () => {
+    const advice = overlapAdvice(reportOf(DETAIL)) ?? "";
+    expect(advice).not.toMatch(/parental leave/);
+    expect(advice).not.toMatch(/GitHub Actions/);
+  });
+
+  it("names BOTH readings, because either can be the right one", () => {
+    // The probe is sometimes mislabelled and sometimes a genuine near-miss.
+    // Asserting one alone sends half the readers the wrong way — the fixture's
+    // own non-separable case is held open by "Best pizza place near me?", which
+    // is not mislabelled at all.
+    const advice = overlapAdvice(reportOf(DETAIL)) ?? "";
+    expect(advice, "the mislabelled reading").toMatch(/COVERS|in-corpus side/);
+    expect(advice, "and the genuine one").toMatch(/does not separate|uncalibrated/);
+  });
+
+  it("says nothing at all when the measurement separated", () => {
+    const clean = DETAIL.map((d) =>
+      d.query.startsWith("which vector") ? { ...d, score: 0.4 } : d,
+    );
+    const report = reportOf(clean);
+    expect(report.separable, "the fixture must actually separate here").toBe(true);
+    expect(overlappingProbes(report)).toEqual([]);
+    expect(overlapAdvice(report)).toBeNull();
+  });
+
+  it("orders them worst first — the most likely culprit leads", () => {
+    const two = [
+      ...DETAIL,
+      { query: "how do I deploy an agent to production", in_corpus: false, score: 0.7 },
+    ];
+    expect(overlappingProbes(reportOf(two)).map((d) => d.score)).toEqual([0.721, 0.7]);
+  });
+});

--- a/packages/content/src/calibrate/overlap.ts
+++ b/packages/content/src/calibrate/overlap.ts
@@ -1,0 +1,59 @@
+/**
+ * WHICH probes held a calibration open, when it did not separate.
+ *
+ * A "NOT separable" verdict reads as "this corpus cannot be calibrated", and the
+ * likeliest cause is something else: one probe in the out-of-corpus set that the
+ * record actually answers. The report has every number needed to see that and
+ * prints none of them — its remedy says "widen the probe set" when the fix is
+ * sometimes to narrow it.
+ *
+ * Found on a real 81-document book. The set contained "which vector database
+ * should I choose", against a record carrying a Postgres-and-AI chapter; it
+ * scored 0.721 against a weakest in-corpus question of 0.680, the tool correctly
+ * refused to paste a floor, and the conclusion drawn was that the record could
+ * not support abstention at all. Removing that one probe separated it
+ * immediately — `separable: max OOC 0.676 < min in-corpus 0.680` — and the floor
+ * then held 10/10 against live questions.
+ *
+ * This lives beside `math.ts` rather than inside it because `renderReport` is
+ * pinned byte-exact to the Python oracle's output (`fixtures/math.ts`, a
+ * generated capture). The oracle governs the measurement; operator guidance is
+ * ours to improve without regenerating it.
+ */
+
+import type { CalibrationReport, ScoredQuery } from "./math.js";
+
+/**
+ * Out-of-corpus probes scoring at or above the weakest in-corpus question,
+ * worst first — the ones that decided the verdict. Empty when the measurement
+ * separated, because then nothing held it open.
+ */
+export function overlappingProbes(report: CalibrationReport): readonly ScoredQuery[] {
+  if (report.separable) return [];
+  const weakest = report.low_tail[0]?.score;
+  if (weakest === undefined) return [];
+  return report.detail
+    .filter((d) => !d.in_corpus && d.score >= weakest)
+    .toSorted((a, b) => b.score - a.score);
+}
+
+/**
+ * The guidance itself, or null when there is nothing to say.
+ *
+ * Deliberately names BOTH readings. The overlapping probe is sometimes a
+ * question the record covers — mislabelled, and the measurement is fine once it
+ * moves — and sometimes a genuine near-miss the corpus simply cannot separate,
+ * in which case the floor stays uncalibrated and that is the correct outcome.
+ * Asserting either one alone would send half the readers the wrong way.
+ */
+export function overlapAdvice(report: CalibrationReport): string | null {
+  const overlapping = overlappingProbes(report);
+  if (overlapping.length === 0) return null;
+  return (
+    "these out-of-corpus probes scored at or above your weakest in-corpus question:\n" +
+    overlapping.map((d) => `  ${d.score.toFixed(3)}  ${d.query}\n`).join("") +
+    "  ^ look at these first. Either the record COVERS one — move it to the\n" +
+    "    in-corpus side, because a probe the record answers is not out of corpus\n" +
+    "    — or it genuinely does not separate, and the floor stays uncalibrated.\n"
+  );
+}

--- a/packages/content/src/commands.ts
+++ b/packages/content/src/commands.ts
@@ -47,6 +47,7 @@ import { buildGeneration, flipRefusal } from "./ingest/build.js";
 import { checkEmbeddingSpace } from "./lib/space.js";
 import { parseQueriesFile, runCalibration } from "./calibrate/run.js";
 import { renderReport } from "./calibrate/math.js";
+import { overlapAdvice } from "./calibrate/overlap.js";
 import { GeminiTextGenerator } from "./lib/providers/gemini.js";
 import { runGc } from "./ingest/gc.js";
 
@@ -769,6 +770,8 @@ async function calibrateCommand(args: string[]): Promise<number> {
     }),
   );
   process.stdout.write(renderReport(report) + "\n");
+  const advice = overlapAdvice(report);
+  if (advice !== null) process.stdout.write(advice);
   return 0;
 }
 


### PR DESCRIPTION
#81 said abstention could not be calibrated on a broad real corpus, so the
product's headline guarantee would ship off. **I wrote that issue, and it was
wrong** — the corpus calibrates fine. What failed was my probe set.

## What actually happened

Measured four candidate signals on the book, to find out whether a single
similarity floor was the wrong instrument:

| signal | in-corpus | out-of-corpus | |
|---|---|---|---|
| top-1 similarity | [0.680, 0.813] | [0.552, **0.721**] | overlaps |
| margin (s1 − s5) | [0.010, 0.081] | [0.008, 0.052] | overlaps |
| distinct docs in top-10 | 1–6 | 2–9 | overlaps |
| keyword arm hits | 0–321 | 0–9 | overlaps |

Nothing separated — until I looked at *which* probe caused it. Exactly one:
**"which vector database should I choose"**, at 0.721, against a record that
contains a `postgres-ai-crash-course` chapter.

That is not an out-of-corpus question. The book answers it. I had labelled a
question the record covers as out of scope, and then concluded from the failure
that the record could not separate.

Removing it:

```
separable: max OOC 0.676 < min in-corpus 0.680; midpoint has margin both ways
vector_floor: 0.678
```

Applied live, against the real book: **10/10** — five in-corpus questions
answered, five genuine out-of-corpus questions abstained, including the weakest
in-corpus ones that set the floor.

## What ships

The report had every number needed to see that, and printed none of them. Its
remedy said "widen the probe set" when the fix was to narrow it. `ksor calibrate`
now names the probes that held the measurement open, worst first, with both
readings — because either can be the right one:

```
these out-of-corpus probes scored at or above your weakest in-corpus question:
  0.721  which vector database should I choose
  ^ look at these first. Either the record COVERS one — move it to the
    in-corpus side, because a probe the record answers is not out of corpus
    — or it genuinely does not separate, and the floor stays uncalibrated.
```

Verified by re-running the original, misleading probe set against the real
corpus: it names that probe and nothing else.

## Where it lives, and why not in the report

`renderReport` is pinned **byte-exact** to the Python oracle's output
(`fixtures/math.ts`, a generated capture — "do not hand-edit"). I tried putting
this there first and it broke three oracle cases. Operator guidance should not
require regenerating a captured fixture to improve, so it lives in
`calibrate/overlap.ts` as two pure functions with their own tests, and the CLI
calls them. The oracle still governs the measurement; the prose is ours.

The fixture's own non-separable case is held open by "Best pizza place near me?"
— which is *not* mislabelled — and that is exactly why the advice names both
readings rather than asserting the corpus is fine.

Gate: 734 unit · 227 integration · 197 db · guard · check:corpus.