### PR TITLE
Carry forward from a generation an interrupted run abandoned (#97)

### DIFF
--- a/.changeset/carry-from-abandoned-generations.md
+++ b/.changeset/carry-from-abandoned-generations.md
@@ -1,0 +1,31 @@
+---
+"@panaversity/ksor": patch
+---
+
+An interrupted ingest no longer throws away the embeddings it already paid for
+
+A killed `ksor ingest` leaves its generation in state `building`. Carry-forward
+accepted only `ready`, `active` and `retired` sources, so the rerun found nothing
+to copy and embedded the entire corpus again — paying twice for work that was
+sitting in the database, correct and complete.
+
+Found while ingesting an 81-document book into a managed Postgres. The run was
+killed at 4,736 of 6,963 chunks; the rerun reported `carried 0, pending 6963`.
+
+```
+before   structure: 82 nodes, 81 sources, 6963 chunks; carried 0,    pending 6963
+after    structure: 82 nodes, 81 sources, 6963 chunks; carried 4736, pending 2227
+```
+
+The asymmetry is what made it expensive. Interrupt a RE-ingest and a complete
+generation still exists, so the rerun carries from it and costs almost nothing.
+Interrupt the FIRST ingest and there is no complete generation at all — and the
+first ingest of a large corpus is the longest, the least familiar, and the one an
+operator is most likely to interrupt.
+
+Nothing about an abandoned run makes its vectors wrong. An embedding is a pure
+function of its input and model, the match key already establishes identity, and
+carry only ever fills chunks still marked pending. So a run's state now decides
+the ORDER sources are tried in, not whether they may be used at all: the active
+generation first, so vetted vectors always win, then complete generations newest
+first, then abandoned ones.

--- a/packages/content/src/ingest/build.ts
+++ b/packages/content/src/ingest/build.ts
@@ -31,7 +31,7 @@ import { chunkText, cleanBody, CHUNK_POLICY, headingPathText } from "./chunking.
 import {
   addedSlugs,
   allocateRun,
-  bestCarrySource,
+  carrySources,
   carryForward,
   flip,
   flipDelta,
@@ -268,16 +268,21 @@ export async function buildStructure(
       modelId,
     });
   }
-  const newest = await bestCarrySource(client, {
+  //   3. From every other generation holding vectors, best-vetted first, then
+  //      newest — including runs a kill left in `building`. Each pass fills only
+  //      what the last left pending, so priority is expressed by ORDER; an
+  //      abandoned run can never outrank the active one, and its vectors are no
+  //      less correct for the run having died (issue #97).
+  for (const source of await carrySources(client, {
     tenantId,
     corpusId: opts.corpusId,
     excludeGeneration: generation,
-  });
-  if (newest !== 0 && newest !== active) {
+  })) {
+    if (source === active) continue;
     carried += await carryForward(client, {
       tenantId,
       generation,
-      fromGeneration: newest,
+      fromGeneration: source,
       modelId,
     });
   }

--- a/packages/content/src/ingest/generation.ts
+++ b/packages/content/src/ingest/generation.ts
@@ -111,6 +111,47 @@ export async function allocateRun(
  *
  * Returns 0 when there is no complete embedded generation — the first ingest.
  */
+/**
+ * Every generation whose vectors this build may copy, best source FIRST.
+ *
+ * Ordered by how much the source has been vetted, then by recency:
+ *
+ *   1. complete runs (`ready` / `active` / `retired`), newest first
+ *   2. ABANDONED runs (`building`), newest first
+ *
+ * The second group used to be excluded outright, and that threw away work an
+ * operator had already paid for: a killed `ksor ingest` leaves its generation in
+ * `building`, so the rerun carried NOTHING and re-embedded the whole corpus.
+ * Reproduced live — an 81-document book killed at 4,736 of 6,963 chunks, whose
+ * rerun reported `carried 0, pending 6963` (issue #97).
+ *
+ * Nothing about an abandoned run makes its vectors wrong. An embedding is a pure
+ * function of (embed input, model); the match key in `carryForward` establishes
+ * identity on its own; and carry only ever fills `pending` rows, so a later pass
+ * can never overwrite an earlier, better-vetted one. The run's STATE therefore
+ * decides priority, not eligibility — which is what ordering expresses and
+ * exclusion could not.
+ */
+export async function carrySources(
+  client: pg.PoolClient,
+  opts: { tenantId: string; corpusId: string; excludeGeneration: number },
+): Promise<number[]> {
+  const res = await client.query<{ gen: string; rank: number }>(
+    `
+    SELECT DISTINCT c.generation AS gen,
+           CASE WHEN r.state IN ('ready','active','retired') THEN 0 ELSE 1 END AS rank
+      FROM chunks c
+      JOIN ingestion_runs r ON r.tenant_id = c.tenant_id AND r.generation = c.generation
+     WHERE c.tenant_id = $1 AND r.corpus_id = $2
+       AND r.state IN ('ready', 'active', 'retired', 'building')
+       AND c.generation <> $3 AND c.embedding_status = 'embedded'
+     ORDER BY rank, gen DESC
+    `,
+    [opts.tenantId, opts.corpusId, opts.excludeGeneration],
+  );
+  return res.rows.map((r) => Number(r.gen));
+}
+
 export async function bestCarrySource(
   client: pg.PoolClient,
   opts: { tenantId: string; corpusId: string; excludeGeneration: number },

--- a/packages/content/src/ingest/ingest.db.test.ts
+++ b/packages/content/src/ingest/ingest.db.test.ts
@@ -506,3 +506,107 @@ describe.runIf(adminDsn === "")("ingest pipeline db acceptance (gated)", () => {
     expect(adminDsn).toBe("");
   });
 });
+
+/**
+ * An interrupted ingest must not throw away the vectors it already paid for.
+ *
+ * A killed run leaves its generation in state `building`, and `bestCarrySource`
+ * accepted only `ready`/`active`/`retired` — so the rerun carried NOTHING and
+ * re-embedded the whole corpus. Reproduced live against a managed Postgres: an
+ * 81-document book, killed at 4,736 of 6,963 chunks, rerun reported
+ * `carried 0, pending 6963` and started paying again (issue #97).
+ *
+ * The asymmetry is what makes it expensive. Interrupt a RE-ingest and a complete
+ * generation still exists, so the rerun carries from it. Interrupt the FIRST
+ * ingest and there is none — and the first ingest of a large corpus is the
+ * longest, the least familiar, and the one most likely to be interrupted.
+ *
+ * Nothing about an abandoned run makes its vectors wrong: an embedding is a pure
+ * function of (embed input, model), the match key already establishes identity,
+ * and carry only ever fills `pending` rows. The run's state adds nothing to that
+ * judgement — so it no longer gates it.
+ *
+ * Order still matters and is preserved: the ACTIVE generation is carried from
+ * first (vetted vectors win), then complete generations newest-first, and only
+ * then abandoned ones. Each pass fills what the last left pending, so priority
+ * is expressed by order rather than by exclusion.
+ */
+describe.runIf(adminDsn !== "")("carry-forward across an interrupted run (db)", () => {
+  const DB2 = `ksor_carry_${randomBytes(4).toString("hex")}`;
+  const T2 = "carry";
+  const C2 = "carry-rulebook";
+  const fake2 = buildShippedProvider("fake", { apiKey: null, dim: DIM });
+  let pool2: pg.Pool;
+  let admin2: pg.Pool;
+  let inst2: ContentInstance;
+
+  beforeAll(async () => {
+    const { Pool } = (await import("pg")).default;
+    admin2 = new Pool({ connectionString: adminDsn });
+    await admin2.query(`CREATE DATABASE ${DB2}`);
+    const url = new URL(adminDsn);
+    url.pathname = `/${DB2}`;
+    pool2 = contentPool(url.toString(), 4);
+    await applySchema(pool2, DIM);
+    // The grant row is the ingest AUTHORIZATION — the RLS policy checks
+    // current_user after the SET LOCAL ROLE pin, so it names the ingest role.
+    await pool2.query(
+      "INSERT INTO ingest_tenant_grants (role_name, tenant_id) VALUES ('sor_content_ingest', $1)",
+      [T2],
+    );
+    inst2 = instanceOf(T2, C2);
+  }, 300_000);
+
+  afterAll(async () => {
+    await pool2?.end().catch(() => undefined);
+    await admin2?.query(`DROP DATABASE IF EXISTS ${DB2} WITH (FORCE)`).catch(() => undefined);
+    await admin2?.end().catch(() => undefined);
+  });
+
+  it("carries from a generation whose run never finished", async () => {
+    // Generation 1: built and embedded, but never flipped and never marked
+    // ready — exactly what a killed `ksor ingest` leaves behind.
+    const first = await buildGeneration(pool2, inst2, {
+      knowledgeDir: FIXTURE,
+      sourceCommit: "interrupted",
+      flip: false,
+      provider: fake2,
+    });
+    expect(first.generation).toBe(1);
+    expect(first.embedded, "the first run did embed real vectors").toBeGreaterThan(0);
+
+    // A finished-but-unflipped run lands in `ready`, which was ALREADY an
+    // accepted carry source — so building the fixture that way proves nothing.
+    // A KILLED run is the case: it never reaches the finalize step and stays
+    // `building`. That is what is reproduced here, and asserted, because the
+    // first version of this test passed against the unfixed code by testing
+    // `ready` instead.
+    await pool2.query(
+      "UPDATE ingestion_runs SET state = 'building' WHERE tenant_id = $1 AND generation = 1",
+      [T2],
+    );
+    const state = await pool2.query(
+      "SELECT state FROM ingestion_runs WHERE tenant_id = $1 AND generation = 1",
+      [T2],
+    );
+    expect(
+      String(state.rows[0].state),
+      "the fixture must be an ABANDONED run, or this proves nothing",
+    ).toBe("building");
+
+    // The rerun: same tree, nothing published, so the ONLY possible carry source
+    // is the abandoned generation.
+    const embedded: string[] = [];
+    const second = await buildGeneration(pool2, inst2, {
+      knowledgeDir: FIXTURE,
+      sourceCommit: "rerun",
+      flip: false,
+      provider: instrumented(fake2, (texts) => embedded.push(...texts)),
+    });
+    expect(
+      second.carried,
+      `the abandoned run's vectors were thrown away: ${JSON.stringify(second)}`,
+    ).toBe(first.chunks);
+    expect(embedded, "and nothing was embedded a second time").toEqual([]);
+  }, 300_000);
+});


### PR DESCRIPTION
Closes #97.

Found while doing the deployment work, not while looking for bugs. An ingest of
an 81-document book into managed Postgres was killed at 4,736 of 6,963 chunks.
The rerun said:

```
structure: 82 nodes, 81 sources, 6963 chunks; carried 0, pending 6963
```

**`carried 0`** — 4,736 correct, already-billed embeddings discarded, and the
whole corpus embedded again against a paid API.

## Cause

`bestCarrySource` accepted only `ready`, `active` and `retired` runs. A killed
ingest never reaches its finalize step, so its generation stays `building` and
was excluded — even though every chunk it embedded is marked `embedded` and every
vector is valid.

The exclusion contradicted the module's own reasoning, written twelve lines below
the query enforcing it: *"an embedding is a pure function of (embed input,
model) … so a vector copies iff all four fields match"*. If the match key
establishes correctness, the state of the run that produced it adds nothing.

## Fix

State now decides the **order** sources are tried in, not eligibility:

1. the ACTIVE generation — vetted vectors win, unchanged
2. complete runs (`ready`/`active`/`retired`), newest first
3. abandoned runs (`building`), newest first

Each pass fills only what the last left pending — a property the existing code
already relied on and stated — so priority is expressed by ordering, and an
abandoned run can never outrank the active one.

## Proven on the run that exposed it

Same corpus, same database, same two abandoned generations still sitting there:

```
before   carried 0,    pending 6963
after    carried 4736, pending 2227
```

**68% of the embedding bill reclaimed.** Generation 2's 1,216 vectors added
nothing on top, correctly — run 2 had re-embedded the same corpus in the same
order, so its chunks are a subset of generation 1's.

## A test that passed for the wrong reason first

My first version built the fixture with `flip: false` and asserted the run state
was `!== "active"`. That passed against the **unfixed** code, because an
unflipped run lands in `ready` — which was already an accepted source. The
fixture has to be a genuinely abandoned run, so it now forces `building` and
asserts it, with a comment saying why the obvious fixture proves nothing.

That is the third time this session a test agreed with me for a reason I had not
checked. The pattern is always the same: the assertion was true, and it was true
of something other than the thing I meant.

Gate: 734 unit · 227 integration · 198 db · guard.