### PR TITLE
Clear the search when the dialog closes

### DIFF
--- a/.changeset/clear-search-on-close.md
+++ b/.changeset/clear-search-on-close.md
@@ -1,0 +1,10 @@
+---
+"@panaversity/ksor": patch
+---
+
+**The search dialog forgets the last search when you close it.** The query
+lives in component state and the dialog stays mounted after closing, so the
+next time a reader opened search it came up on the previous term and its
+results — they had to clear the field before they could look for anything
+else. Closing now resets it, and the shell's own `onOpenChange` still fires,
+so nothing else about the dialog changes.

--- a/packages/ksor/templates/scaffold/system/site/components/search-dialog.tsx
+++ b/packages/ksor/templates/scaffold/system/site/components/search-dialog.tsx
@@ -19,7 +19,7 @@ import {
   SearchDialogOverlay,
   type SharedProps,
 } from "fumadocs-ui/components/dialog/search";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 
 /**
  * The search dialog, with a caveat status on the rows that have one.
@@ -63,9 +63,23 @@ function readStatuses(): Record<string, string> {
 const trimSlash = (url: string): string =>
   url.length > 1 && url.endsWith("/") ? url.slice(0, -1) : url;
 
-export default function KsorSearchDialog({ api, ...props }: KsorSearchDialogProps) {
+export default function KsorSearchDialog({ api, onOpenChange, ...props }: KsorSearchDialogProps) {
   const client = staticClient({ from: api });
   const { search, setSearch, query } = useDocsSearch({ client });
+
+  // Closing the dialog clears the query. `useDocsSearch` keeps the term in
+  // component state and the dialog stays MOUNTED when it closes, so without
+  // this the next Cmd-K reopened onto the last search and its results — a
+  // reader coming back to look for something else had to clear the field
+  // first, and a stale result list is a worse first impression than an empty
+  // one (found live 2026-08-22).
+  const handleOpenChange = useCallback(
+    (open: boolean): void => {
+      if (!open) setSearch("");
+      onOpenChange(open);
+    },
+    [onOpenChange, setSearch],
+  );
   const byUrl = useMemo(() => {
     const map = new Map<string, string>();
     for (const [url, status] of Object.entries(readStatuses())) map.set(trimSlash(url), status);
@@ -73,7 +87,13 @@ export default function KsorSearchDialog({ api, ...props }: KsorSearchDialogProp
   }, []);
 
   return (
-    <SearchDialog search={search} onSearchChange={setSearch} isLoading={query.isLoading} {...props}>
+    <SearchDialog
+      search={search}
+      onSearchChange={setSearch}
+      isLoading={query.isLoading}
+      onOpenChange={handleOpenChange}
+      {...props}
+    >
       <SearchDialogOverlay />
       <SearchDialogContent>
         <SearchDialogHeader>


### PR DESCRIPTION
## Problem

The search dialog reopened onto the previous search. `useDocsSearch` keeps the
term in component state and the dialog stays mounted after closing, so a reader
who came back to look for something else was met with their last query and its
results, and had to clear the field first.

## Solution

Closing resets the term. The handler wraps the shell's own `onOpenChange`
rather than replacing it, so nothing else about the dialog's behaviour changes.

## Behaviour

Verified in a browser against a running scaffold: type `governance` → 2 results
→ Escape → reopen → the input reads `""`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M6jwEHZ95TKEoLFNTAZokP