### PR TITLE
Stage the record under a lock, so one build cannot short its own site

### DIFF
--- a/.changeset/olive-donkeys-repeat.md
+++ b/.changeset/olive-donkeys-repeat.md
@@ -1,0 +1,25 @@
+---
+"@panaversity/ksor": patch
+---
+
+Stage the record under a lock, so a build that evaluates its config more than
+once cannot publish a short site.
+
+A site build evaluates `source.config.ts` in more than one process — seven of
+them staged the record in one measured build — and staging was destructive on
+every evaluation: delete the whole per-audience stage, refill it. Two of those
+overlapping deleted a tree the other was copying into. Six
+concurrent evaluations of a 150-document record failed 42 of 48 runs — `ENOENT`
+and `EINVAL` out of `copyFileSync`, `ENOTEMPTY` out of `rmSync` despite its
+retries, and, in 27 of the 48, no error at all: staging returned success and
+handed the build a stage a third of the record short. That last shape is the one
+that matters — a crash fails a build, a short stage publishes one, with
+documents missing from `/docs`, `llms.txt` and the search index and nothing
+saying so.
+
+Staging now takes a lock file (`system/site/.staged-knowledge.lock`, gitignored,
+stamped with the holder's pid so a killed build's lock is broken rather than
+waited on), and an evaluation that finds the stage already holding exactly its
+plan — byte for byte — leaves it alone instead of rebuilding it. Together those
+mean the destructive path runs once per build, alone. No behaviour changes for a
+build that was already succeeding.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,4 +207,9 @@ jobs:
       # — AGENTS.md assigns repo-tree scans here — so name them explicitly or
       # Windows stops running the checks it is best placed to catch.
       - run: pnpm exec vitest run --config vitest.integration.config.ts packages/ksor/src/audience-rule-drift.integration.test.ts packages/ksor/src/denial-rule-drift.integration.test.ts packages/ksor/src/scaffold-scripts.integration.test.ts packages/ksor/src/discovery-document.integration.test.ts
+      # The stage lock rests on three primitives whose Windows semantics are
+      # the whole question: exclusive create (`wx`), pid liveness, and removing
+      # a file another process may hold. Named here for the same reason as the
+      # drift tests above — this runner is the one placed to catch them.
+      - run: pnpm exec vitest run --config vitest.integration.config.ts packages/ksor/src/stage-concurrency.integration.test.ts
       - run: pnpm test:unit

--- a/packages/ksor/src/stage-concurrency.integration.test.ts
+++ b/packages/ksor/src/stage-concurrency.integration.test.ts
@@ -1,0 +1,239 @@
+/**
+ * The stage survives a build that evaluates its config more than once.
+ *
+ * A site build evaluates `source.config.ts` in more than one process, and
+ * staging was destructive on every evaluation: delete the whole stage, refill
+ * it. Two of those overlapping is the ordinary case, not a rare interleaving —
+ * this suite, against the code as it stood, failed 42 of 48 worker runs in four
+ * shapes: `ENOENT` and `EINVAL` out of `copyFileSync` (the reported symptom,
+ * issue #100), `ENOTEMPTY` out of `rmSync` despite its retries, and — the
+ * majority, 27 of 48 — no error at all: staging returned SUCCESS and handed the
+ * build a stage a third of the record short.
+ *
+ * The silent shape is what these tests are really for. A crash fails a build; a
+ * short stage publishes one, with documents missing from /docs, llms.txt and
+ * the search index, and nothing anywhere saying so. So every worker does not
+ * merely stage — it reads back what it was handed and checks it against the
+ * record, which is exactly what the build does next.
+ *
+ * The scaffold's site lib is TypeScript that Next compiles; here it runs under
+ * Node's own type stripping, which needs explicit extensions on relative
+ * imports. That rewrite is the ONE difference between this harness and the
+ * shipped module, and it is asserted rather than assumed.
+ */
+
+import { spawn } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const LIB = fileURLToPath(new URL("../templates/scaffold/system/site/lib/", import.meta.url));
+
+/** Node strips types but does not resolve `./audience` — only `./audience.ts`. */
+const EXTENSIONLESS = /(from ")(\.\/[A-Za-z0-9._-]+)(")/g;
+
+/** One worker: stage, then read back what staging handed us, `rounds` times. */
+const HARNESS = `
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { knowledgeSourceDir } from "./lib/stage-knowledge.ts";
+
+const walk = (dir) =>
+  readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
+    const p = path.join(dir, e.name);
+    return e.isDirectory() ? walk(p) : [p];
+  });
+
+const record = path.resolve("../../knowledge");
+const expected = walk(record);
+const rounds = Number(process.argv[2] ?? 1);
+
+for (let i = 0; i < rounds; i += 1) {
+  const dir = path.resolve(knowledgeSourceDir());
+  const got = walk(dir);
+  if (got.length !== expected.length) {
+    console.error(\`SHORT STAGE: \${got.length} files, expected \${expected.length}\`);
+    process.exit(3);
+  }
+  for (const from of expected) {
+    const to = path.join(dir, path.relative(record, from));
+    if (!readFileSync(from).equals(readFileSync(to))) {
+      console.error(\`WRONG BYTES: \${to}\`);
+      process.exit(4);
+    }
+  }
+}
+console.log(path.resolve(knowledgeSourceDir()));
+`;
+
+interface Project {
+  readonly root: string;
+  readonly site: string;
+  readonly record: string;
+  readonly stage: string;
+  readonly lock: string;
+}
+
+function project(root: string, options: { documents: number; audiences: boolean }): Project {
+  const site = path.join(root, "system", "site");
+  const record = path.join(root, "knowledge");
+  mkdirSync(path.join(site, "lib"), { recursive: true });
+  mkdirSync(record, { recursive: true });
+
+  const model = options.audiences
+    ? "audiences:\n  - public\n  - internal\ndefault_visibility: public\n"
+    : "";
+  writeFileSync(
+    path.join(root, "instance.md"),
+    `---\nname: stage-race\n${model}---\n\n# Stage Race\n\nA record used to hold staging honest under concurrency.\n`,
+  );
+  for (let i = 0; i < options.documents; i += 1) {
+    writeFileSync(
+      path.join(record, `doc-${i}.md`),
+      `---\ntitle: Doc ${i}\nstatus: approved\n---\n\nBody of document ${i}.\n`,
+    );
+  }
+
+  let rewritten = 0;
+  for (const entry of readdirSync(LIB)) {
+    const source = readFileSync(path.join(LIB, entry), "utf8");
+    rewritten += [...source.matchAll(EXTENSIONLESS)].length;
+    writeFileSync(path.join(site, "lib", entry), source.replace(EXTENSIONLESS, "$1$2.ts$3"));
+  }
+  expect(
+    rewritten,
+    "the harness rewrote no imports — it is not running the scaffold's lib",
+  ).toBeGreaterThan(0);
+  writeFileSync(path.join(site, "stage-once.mjs"), HARNESS);
+
+  return {
+    root,
+    site,
+    record,
+    stage: path.join(site, ".staged-knowledge"),
+    lock: path.join(site, ".staged-knowledge.lock"),
+  };
+}
+
+interface Run {
+  readonly code: number | null;
+  readonly out: string;
+}
+
+function stage(site: string, rounds: number): Promise<Run> {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, ["stage-once.mjs", String(rounds)], { cwd: site });
+    let out = "";
+    child.stdout.on("data", (chunk) => (out += chunk));
+    child.stderr.on("data", (chunk) => (out += chunk));
+    child.on("close", (code) => resolve({ code, out }));
+  });
+}
+
+const DOCUMENTS = 150;
+const WORKERS = 6;
+const ROUNDS = 3;
+
+describe("staging under a build that evaluates its config more than once", () => {
+  let work: string;
+  let fixture: Project;
+
+  beforeAll(() => {
+    // realpath: on macOS the tmpdir is a symlink, so a child's cwd resolves to
+    // /private/var while this path says /var, and every path comparison below
+    // would compare two spellings of the same directory.
+    work = realpathSync(mkdtempSync(path.join(tmpdir(), "ksor-stage-race-")));
+    fixture = project(path.join(work, "concurrent"), { documents: DOCUMENTS, audiences: true });
+  });
+
+  afterAll(() => rmSync(work, { recursive: true, force: true }));
+
+  it(`${WORKERS} concurrent evaluations each get the WHOLE record, byte for byte`, async () => {
+    const runs = await Promise.all(
+      Array.from({ length: WORKERS }, () => stage(fixture.site, ROUNDS)),
+    );
+    const failed = runs.filter((run) => run.code !== 0);
+    expect(
+      failed.length,
+      failed
+        .map((run) => run.out)
+        .join("\n")
+        .slice(-3000),
+    ).toBe(0);
+    // Every worker was handed the same staged directory.
+    expect(new Set(runs.map((run) => run.out.trim().split("\n").pop()))).toEqual(
+      new Set([fixture.stage]),
+    );
+  }, 60_000);
+
+  it("leaves the stage holding exactly the record, and no lock behind", () => {
+    expect(readdirSync(fixture.stage).length).toBe(DOCUMENTS);
+    expect(existsSync(fixture.lock), "a lock outlived the build that took it").toBe(false);
+  });
+
+  it("breaks a lock whose holder is gone, rather than waiting on a dead process", async () => {
+    // A build killed mid-stage leaves its lock. Nothing else will ever remove
+    // it, so a waiter that trusts the file forever hangs every later build.
+    writeFileSync(fixture.lock, "2147483646");
+    const run = await stage(fixture.site, 1);
+    expect(run.code, run.out).toBe(0);
+    expect(existsSync(fixture.lock)).toBe(false);
+  }, 30_000);
+
+  it("breaks a lock a holder died before stamping", async () => {
+    // The pid is written in the call that creates the file, so a BLANK lock is
+    // a holder that died between the two — indistinguishable from a live one
+    // on a single look, which is why the check looks twice.
+    writeFileSync(fixture.lock, "");
+    const run = await stage(fixture.site, 1);
+    expect(run.code, run.out).toBe(0);
+    expect(existsSync(fixture.lock)).toBe(false);
+  }, 30_000);
+
+  it("a refused build leaves no stage — the previous, wider one must not survive", async () => {
+    const refusing = project(path.join(work, "refusing"), { documents: 3, audiences: true });
+    expect((await stage(refusing.site, 1)).code, "the permissive build should pass").toBe(0);
+    expect(existsSync(refusing.stage)).toBe(true);
+
+    // Every document above the build's tier: the record is not empty, this
+    // audience's slice of it is.
+    for (const entry of readdirSync(refusing.record)) {
+      const file = path.join(refusing.record, entry);
+      writeFileSync(
+        file,
+        readFileSync(file, "utf8").replace("status: approved", "visibility: internal"),
+      );
+    }
+    const run = await stage(refusing.site, 1);
+    expect(run.code, run.out).not.toBe(0);
+    expect(run.out).toContain("ksor-audience-empty");
+    expect(existsSync(refusing.stage), "a refused build left its stage on disk").toBe(false);
+    expect(existsSync(refusing.lock), "a refused build kept the lock").toBe(false);
+  }, 30_000);
+
+  it("a record with no audiences serves itself, and a stale stage is removed", async () => {
+    const level0 = project(path.join(work, "level-0"), { documents: 3, audiences: false });
+    mkdirSync(level0.stage, { recursive: true });
+    writeFileSync(path.join(level0.stage, "left-over.md"), "---\ntitle: Stale\n---\n\nStale.\n");
+    const run = await stage(level0.site, 1);
+    expect(run.code, run.out).toBe(0);
+    expect(run.out.trim().split("\n").pop()).toBe(level0.record);
+    expect(
+      existsSync(level0.stage),
+      "a stage nothing governs outlived the model that made it",
+    ).toBe(false);
+    expect(existsSync(level0.lock)).toBe(false);
+  }, 30_000);
+});

--- a/packages/ksor/templates/.gitignore
+++ b/packages/ksor/templates/.gitignore
@@ -13,3 +13,4 @@ scaffold/**/*.tsbuildinfo
 scaffold/.env*
 scaffold/**/.DS_Store
 scaffold/system/site/.staged-knowledge/
+scaffold/system/site/.staged-knowledge.lock

--- a/packages/ksor/templates/scaffold/gitignore
+++ b/packages/ksor/templates/scaffold/gitignore
@@ -8,6 +8,9 @@ system/site/out/
 # the per-audience copy of the record a build stages — a filtered derivative,
 # never a second record; committing it would publish what a build excluded
 system/site/.staged-knowledge/
+# and the lock that keeps one evaluation of a build staging at a time; it only
+# outlives a build that was killed mid-stage, and the next build clears it
+system/site/.staged-knowledge.lock
 *.tsbuildinfo
 
 # secrets never enter the record — system/ is their future home (serve)

--- a/packages/ksor/templates/scaffold/system/site/lib/stage-knowledge.ts
+++ b/packages/ksor/templates/scaffold/system/site/lib/stage-knowledge.ts
@@ -1,11 +1,13 @@
 import {
   copyFileSync,
+  existsSync,
   mkdirSync,
   readFileSync,
   readdirSync,
   rmSync,
   statSync,
   watch,
+  writeFileSync,
 } from "node:fs";
 import path from "node:path";
 
@@ -343,47 +345,191 @@ function planStage(recordDir: string, denied: DenylistManifest): StagePlan {
   return { files: [...documents, ...assets], documents: documents.length, total };
 }
 
+/** How often a waiter looks again. */
+const LOCK_POLL_MS = 25;
+/** How long a wait goes unexplained. A build that looks hung must say why. */
+const LOCK_ANNOUNCE_MS = 10_000;
+
+/** Synchronous, because everything on this path is: a bundler cannot await. */
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    // EPERM is a process that exists and is not ours to signal.
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+/**
+ * Is this lock abandoned — stamped with a process that no longer exists?
+ *
+ * Blank is the one ambiguous read: the holder writes its pid in the same call
+ * that creates the file, so a blank lock is either a holder caught between the
+ * two (microseconds) or one that died there (forever). Looking twice tells
+ * them apart, and only the second look may break a lock.
+ */
+function lockIsAbandoned(lockFile: string): boolean {
+  for (const look of [0, 1]) {
+    let stamp: string;
+    try {
+      stamp = readFileSync(lockFile, "utf8").trim();
+    } catch {
+      // Released while we read it; the next acquire attempt takes it.
+      return false;
+    }
+    const pid = Number(stamp);
+    if (Number.isInteger(pid) && pid > 0) return !isAlive(pid);
+    if (look === 0) sleepSync(LOCK_POLL_MS * 2);
+  }
+  return true;
+}
+
+/**
+ * Hold the stage lock for the duration of `work`: ONE evaluation writes the
+ * stage at a time, and this file says which.
+ *
+ * A build evaluates `source.config.ts` in more than one process — SEVEN of
+ * them staged the record in one measured `next build` of a scaffolded site
+ * (2026-08-23) — and staging was destructive on every evaluation: delete the
+ * whole stage, refill it. Two of those overlapping is not a rare interleaving,
+ * it is what seven of them do — six concurrent evaluations of a 150-document
+ * record failed 42 of 48 runs, in four shapes: `ENOENT` and `EINVAL` out of `copyFileSync` (the reported one,
+ * issue #100), `ENOTEMPTY` out of `rmSync` *with* its retries already in
+ * place, and — 27 of the 48, the majority — no error at all: staging returned
+ * success and handed the build a stage a third of the record short.
+ *
+ * The silent shape is why this is a lock and not another retry. A crash fails
+ * a build; a short stage PUBLISHES one, with documents missing from /docs,
+ * llms.txt and the search index, and nothing anywhere saying so.
+ *
+ * `wx` is the whole primitive: create-if-absent, atomically, on every
+ * filesystem Node supports — and it stamps the holder's pid in the same call,
+ * so a waiter can tell a live holder from a killed one.
+ *
+ * Waiting on a LIVE holder is unbounded on purpose: it is another evaluation
+ * of the same build, staging the same bytes from the same record, and this
+ * build is not finished until it has. Unbounded is not silent, though — a wait
+ * long enough to look like a hang names what it is waiting for.
+ */
+function withStageLock<T>(stageDir: string, work: () => T): T {
+  const lockFile = `${stageDir}.lock`;
+  let waited = 0;
+  let announced = false;
+  for (;;) {
+    try {
+      writeFileSync(lockFile, String(process.pid), { flag: "wx" });
+      break;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      if (lockIsAbandoned(lockFile)) {
+        rmSync(lockFile, { force: true });
+        continue;
+      }
+      sleepSync(LOCK_POLL_MS);
+      waited += LOCK_POLL_MS;
+      if (waited >= LOCK_ANNOUNCE_MS && !announced) {
+        announced = true;
+        console.warn(
+          `[ksor] waiting on ${path.basename(lockFile)} — another evaluation of this build is ` +
+            "staging the record. Delete that file if no build is running.",
+        );
+      }
+    }
+  }
+  try {
+    return work();
+  } finally {
+    rmSync(lockFile, { force: true });
+  }
+}
+
 /**
  * Remove the stage, asking for the retries this exact failure needs.
  *
- * `force: true` suppresses ENOENT; it does NOT retry anything. Node retries
- * EBUSY / EMFILE / ENFILE / ENOTEMPTY / EPERM only when `maxRetries` is set,
- * and it defaults to zero. The build evaluates `source.config.ts` more than
- * once when the bundler wants it in more than one place, so two runs can
- * overlap: one removing the stage while the other is still copying into it.
- * That surfaced as `ENOTEMPTY` out of `rmSync` and failed the whole site build
- * (CI, 2026-08-21) — a race that is safe to lose, because the stage is a
- * deterministic function of the record and the denylist, so redoing it produces
- * the same bytes.
+ * Callers hold the stage lock, so no OTHER evaluation is writing here — but
+ * `force: true` suppresses ENOENT and does NOT retry anything, and Node
+ * retries EBUSY / EMFILE / ENFILE / ENOTEMPTY / EPERM only when `maxRetries`
+ * is set (it defaults to zero). Those are what a Windows indexer or an
+ * antivirus scanner holding a handle looks like — not ksor, and not something
+ * the lock can serialise. Losing that race is safe: the stage is a
+ * deterministic function of the record and the denylist, so redoing it
+ * produces the same bytes.
  */
 function removeStage(stageDir: string): void {
   rmSync(stageDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
 }
 
+/**
+ * Does the stage already hold EXACTLY this plan, byte for byte?
+ *
+ * The wipe-and-refill is the destructive half of staging, and it is pure waste
+ * whenever the answer is yes — which is every evaluation after the first in
+ * one build, since the plan is a deterministic function of the record and the
+ * denylist. Skipping it is not an optimisation: while a wipe is running there
+ * is a window in which the stage is not the record, and an evaluation that has
+ * already returned is reading it. The lock stops two writers colliding; this
+ * stops the second writer existing at all.
+ *
+ * Bytes, not names and not timestamps: the alternative is serving a previous
+ * build's copy of a document that has since been edited.
+ */
+function stageHolds(recordDir: string, stageDir: string, plan: StagePlan): boolean {
+  let staged: string[];
+  try {
+    staged = walkFiles(stageDir);
+  } catch {
+    return false;
+  }
+  if (staged.length !== plan.files.length) return false;
+  const expected = new Map(
+    plan.files.map((from) => [path.join(stageDir, path.relative(recordDir, from)), from]),
+  );
+  for (const file of staged) {
+    const from = expected.get(file);
+    if (from === undefined) return false;
+    if (!readFileSync(from).equals(readFileSync(file))) return false;
+  }
+  return true;
+}
+
 /** Fill a clean stage with exactly the set this build may publish. */
 function fillStage(recordDir: string, stageDir: string, denied: DenylistManifest): void {
-  // The old stage goes first, before any refusal can throw: a refused build
-  // that leaves the previous, more permissive stage on disk hands the next
-  // careless build a filtered copy nothing governs (review finding,
-  // 2026-08-19).
-  removeStage(stageDir);
-  const plan = planStage(recordDir, denied);
-  // An empty record is its own problem, reported by the page that renders it;
-  // an empty AUDIENCE is a misconfiguration that would otherwise surface as
-  // "the record has no documents" against a record full of them.
-  if (plan.documents === 0 && plan.total > 0) {
-    refuse(
-      "ksor-audience-empty",
-      `no document in the record is visible to the ${buildAudience} build (${plan.total} document${plan.total === 1 ? "" : "s"}, all above that tier)`,
-      "a site with nothing on it is a deploy that looks successful and serves nobody — and the record is not empty, this audience's slice of it is",
-      "build a wider audience with KSOR_AUDIENCE, lower default_visibility in instance.md, or give at least one document this tier",
-    );
-  }
-  for (const from of plan.files) {
-    const to = path.join(stageDir, path.relative(recordDir, from));
-    mkdirSync(path.dirname(to), { recursive: true });
-    copyFileSync(from, to);
-  }
+  withStageLock(stageDir, () => {
+    let plan: StagePlan;
+    try {
+      plan = planStage(recordDir, denied);
+      // An empty record is its own problem, reported by the page that renders
+      // it; an empty AUDIENCE is a misconfiguration that would otherwise
+      // surface as "the record has no documents" against a record full of them.
+      if (plan.documents === 0 && plan.total > 0) {
+        refuse(
+          "ksor-audience-empty",
+          `no document in the record is visible to the ${buildAudience} build (${plan.total} document${plan.total === 1 ? "" : "s"}, all above that tier)`,
+          "a site with nothing on it is a deploy that looks successful and serves nobody — and the record is not empty, this audience's slice of it is",
+          "build a wider audience with KSOR_AUDIENCE, lower default_visibility in instance.md, or give at least one document this tier",
+        );
+      }
+    } catch (error) {
+      // No refusal may leave the previous, more permissive stage on disk: it
+      // hands the next careless build a filtered copy nothing governs (review
+      // finding, 2026-08-19). The removal used to lead this function, which is
+      // why nothing could ask whether the stage was already correct.
+      removeStage(stageDir);
+      throw error;
+    }
+    if (stageHolds(recordDir, stageDir, plan)) return;
+    removeStage(stageDir);
+    for (const from of plan.files) {
+      const to = path.join(stageDir, path.relative(recordDir, from));
+      mkdirSync(path.dirname(to), { recursive: true });
+      copyFileSync(from, to);
+    }
+  });
 }
 
 /**
@@ -421,13 +567,17 @@ function refuseVisibilityWithoutAudiences(recordDir: string): void {
  * published build is always staged from scratch.
  */
 function refreshStage(recordDir: string, stageDir: string, denied: DenylistManifest): void {
-  const permitted = new Set(planStage(recordDir, denied).files);
-  for (const staged of walkFiles(stageDir)) {
-    const from = path.join(recordDir, path.relative(stageDir, staged));
-    if (!permitted.has(from)) continue;
-    if (readFileSync(from).equals(readFileSync(staged))) continue;
-    copyFileSync(from, staged);
-  }
+  // Under the lock like every other write here: a save landing while another
+  // evaluation is refilling the stage is the same race from the other side.
+  withStageLock(stageDir, () => {
+    const permitted = new Set(planStage(recordDir, denied).files);
+    for (const staged of walkFiles(stageDir)) {
+      const from = path.join(recordDir, path.relative(stageDir, staged));
+      if (!permitted.has(from)) continue;
+      if (readFileSync(from).equals(readFileSync(staged))) continue;
+      copyFileSync(from, staged);
+    }
+  });
 }
 
 let watching = false;
@@ -484,8 +634,11 @@ export function knowledgeSourceDir(): string {
     // Nothing to filter — serve the record itself, the level-0 fast path.
     // A stage left behind by an earlier model would be a filtered copy of the
     // record nothing governs any more — removed before the refusal below can
-    // throw, so a refused build never leaves one behind either.
-    removeStage(stageDir);
+    // throw, so a refused build never leaves one behind either. Under the lock,
+    // because two evaluations removing one tree is the `ENOTEMPTY` shape of the
+    // same race; the existence check keeps a record that never stages from
+    // taking a lock on every build.
+    if (existsSync(stageDir)) withStageLock(stageDir, () => removeStage(stageDir));
     refuseVisibilityWithoutAudiences(recordDir);
     return RECORD_DIR;
   }


### PR DESCRIPTION
Closes #100.

## The problem

The issue reported one `ENOENT` out of `copyFileSync` and called it a flake. It
is not a flake, and the reported crash is the least of it.

A `next build` of a scaffolded site evaluates `source.config.ts` in **seven
processes** — measured, by stamping every `fillStage` entry with its pid through
one real build. Staging was destructive on every one of them: delete the whole
per-audience stage, refill it. So seven processes were deleting trees the others
were copying into.

Driving the real `stage-knowledge.ts` with six concurrent evaluations of a
150-document record, **42 of 48 runs failed**, in four shapes:

| shape | of 48 runs |
| --- | --- |
| **`SHORT STAGE`** — staging returned SUCCESS with a third of the record missing | **27** |
| `ENOENT` out of `copyFileSync` (the reported symptom) | 7 |
| `ENOTEMPTY` out of `rmSync`, *despite* the `maxRetries` added for it on 2026-08-21 | 5 |
| `EINVAL` out of `copyFileSync` | 3 |
| green | 6 |

The majority shape is the silent one, and it is why this is a lock rather than
the retry the issue offered as its first direction. A crash fails a build; a
short stage **publishes** one — documents missing from `/docs`, `llms.txt` and
the search index, with nothing anywhere saying so.

## The solution

Two halves, both load-bearing:

1. **A single-flight lock.** `writeFileSync(…, { flag: "wx" })` on
   `system/site/.staged-knowledge.lock` — create-if-absent, atomically, stamping
   the holder's pid in the same call, so a waiter can tell a live holder from a
   killed one and breaks an abandoned lock instead of waiting on it forever. A
   blank lock (a holder that died between create and stamp) is settled by looking
   twice. Every write to the stage now goes through it: `fillStage`, the dev
   watcher's `refreshStage`, and the level-0 removal.
2. **Idempotent staging.** An evaluation that finds the stage already holding
   exactly its plan — byte for byte — returns without touching it.

Neither half suffices alone. The lock by itself still lets the second process
wipe and refill while the first, which has already returned, is *reading* what it
was handed. The identity check by itself still lets two first-fills collide.
Together, the destructive path runs once per build, alone, and the other six
evaluations do nothing.

The refusal guarantee is preserved and widened: **any** throw while planning now
removes the stage, where before only the audience-empty refusal did. Ordering
changed only because the removal used to lead the function, which is exactly why
nothing could ask whether the stage was already correct.

## Behaviour

Nothing changes for a build that was already succeeding. A build that would have
raced now serialises, and a build that would have published short does not.

A wait long enough to look like a hang says so on stderr and names the file to
delete. The lock is gitignored in newly scaffolded projects; existing adopters
own their `.gitignore` (decision 4), so a build killed mid-stage leaves one
visible untracked file there until their next build clears it.

## Verification

- **New `stage-concurrency.integration.test.ts`** — watched **red** against the
  code as it stood (3 of its 6 cases, including the concurrency case), green
  after. It does not merely stage: every worker reads back what staging handed
  it and checks it against the record, which is what the build does next — so the
  silent shape is a test failure, not a passing test. Covers concurrency, a
  dead-pid lock, a blank lock, refusal-leaves-no-stage, and level-0 stale-stage
  removal.
- 96/96 workers green at 12-way concurrency, against 6/48 before.
- **The job from the issue**: `KSOR_E2E=1 … visibility-conformance` — 14 passed,
  1 skipped, exit 0, both shells.
- unit 796 · integration 27 files / 254 tests · typecheck, guard, `check:corpus`,
  lint, fmt. The scaffold's site lib is not covered by `pnpm typecheck` (it is a
  template with its own tsconfig), so it was typechecked separately under those
  options.
- The test is named into the **Windows** job. The lock rests on three primitives
  whose Windows semantics are the whole question — exclusive create, pid
  liveness, and removing a file another process may hold — and that job's own
  comment says to name such tests explicitly or Windows stops running the checks
  it is best placed to catch.

## Out of scope

`workbench/shells/docusaurus/lib/visibility.ts` stages the same destructive way.
It is the swap-seam proof, not the shipped path (`ksor init` only ever emits
Fumadocs, decision 9), and it is left untouched deliberately rather than
overlooked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
