### PR TITLE
Ship the deployment artifacts in the scaffold

### DIFF
--- a/.changeset/deploy-artifacts-in-the-scaffold.md
+++ b/.changeset/deploy-artifacts-in-the-scaffold.md
@@ -1,0 +1,34 @@
+---
+"@panaversity/ksor": patch
+---
+
+Ship the deployment artifacts: `ksor init` now emits a `Dockerfile` and
+`.dockerignore`, and its `vercel.json` declares both surfaces — the static site
+and the MCP door — behind one domain.
+
+The served MCP rung is a core surface, not an optional extra, so a scaffolded
+project should be able to reach a host without anyone hand-writing a container
+recipe first. The emitted `Dockerfile` names no vendor: it installs the pinned
+`@panaversity/ksor`, honours `$PORT`, and runs `ksor serve`, so the same image
+runs on Cloud Run, Fly, Render, ECS, Kubernetes or a VPS. `vercel.json` points
+AT that file rather than replacing it, which is what keeps the host a choice —
+moving is a redeploy, not a rewrite. A test asserts that neutrality directly,
+and CI now builds the emitted image, boots it against real Postgres and asks it
+a question over MCP, with no hosting vendor involved.
+
+Verified live before shipping, and the verification paid for itself: a
+project-level `trailingSlash: true` — harmless while the config was static-only
+— 308-redirected every door route including `POST /mcp`. It is removed (the
+site's own Next config already sets it where it belongs); shipping it would have
+broken the MCP endpoint of every adopter who deployed.
+
+Two new documents: `docs/deploying.md` (both surfaces onto a host, the
+configuration each needs, and what a cold start costs — measured) and
+`docs/ingesting.md` (why serving does not publish, so a first deploy with no
+ingest serves an empty record; where ingest belongs, which is never inside the
+container; and how the abstention gate gets turned on).
+
+Also drops the scaffold's build-script denials for `@google/genai` and
+`protobufjs`. The embedding provider speaks the vendor's REST API directly now,
+so neither package is installed at all and the entries described a dependency
+that no longer exists.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,3 +213,39 @@ jobs:
       # drift tests above — this runner is the one placed to catch them.
       - run: pnpm exec vitest run --config vitest.integration.config.ts packages/ksor/src/stage-concurrency.integration.test.ts
       - run: pnpm test:unit
+
+  container:
+    name: Container acceptance (no vendor)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    services:
+      postgres:
+        image: pgvector/pgvector:pg17
+        env:
+          POSTGRES_USER: ksor
+          POSTGRES_PASSWORD: ksor
+          POSTGRES_DB: ksor
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U ksor"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      - run: pnpm build
+      # `ksor init` ships a Dockerfile, and the claim on it is that a served
+      # record runs anywhere. A claim only checked by deploying to one vendor is
+      # a claim about that vendor — so this walks the emitted artifact on plain
+      # Docker: scaffold, publish a generation, build the image, boot it, and
+      # ask it a question over MCP. It installs the LOCAL build, and asserts the
+      # Dockerfile it builds differs from the emitted one by exactly the line
+      # that brings that tarball in.
+      - run: node scripts/container-acceptance.mjs
+        env:
+          KSOR_DB_URL: postgresql://ksor:ksor@localhost:5432/ksor
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,7 +214,23 @@ reverse it, and a reversed decision keeps its entry with a revision note.
    variables a rung needs is an ANSWERED one, and it is the only place those
    values can live without being pasted into a shell. `.gitignore` gains
    `!.env.example` so the example survives the `.env*` rule that hides real
-   secrets._
+   secrets._ _Revision 2026-08-23: the closed root set gains TWO more,
+   `Dockerfile` and `.dockerignore`. The reasoning is the `.env.example` one
+   applied to the surface that IS the product: MCP serving is core (decision 11
+   revision 2026-08-20), a served record therefore has to reach a host, and
+   every container runtime asks for exactly these two files. Emitting them is
+   what makes "vendor-free is the ownership argument" true in the artifact
+   rather than only in the prose — the Dockerfile names no host, and
+   `vercel.json` POINTS AT it instead of replacing it, so moving hosts is a
+   redeploy and not a rewrite. A test asserts that neutrality directly, because
+   it is cheap to lose to one convenient host-specific line and nothing else
+   would go red. The same revision extends `vercel.json` from one static build
+   to two services (site + door) behind one domain. Verified live before it
+   shipped, and the verification earned its cost: a project-level
+   `trailingSlash: true` — harmless while the project was static-only —
+   308-redirected **every door route including `POST /mcp`**, which would have
+   broken the MCP endpoint of every adopter who deployed. It is removed; the
+   site's own Next config already sets it where it belongs._
 9. **Site shell: one in core — Next.js + Fumadocs + shadcn** (owner,
    2026-08-18), replacing Docusaurus natively before v1 traffic. No shell
    selector at init (one obvious way; a flag forks every skill, test, and

--- a/packages/ksor/docs/deploying.md
+++ b/packages/ksor/docs/deploying.md
@@ -1,0 +1,233 @@
+---
+title: Deploying
+status: draft
+---
+
+# Deploying a Knowledge System of Record
+
+A KSoR publishes two surfaces from one record, and they deploy differently
+because they are different things:
+
+| surface      | what it is                                       | how it deploys                         |
+| ------------ | ------------------------------------------------ | -------------------------------------- |
+| **the site** | a fully static export — HTML, `llms.txt`, search | upload a folder to any static host     |
+| **the door** | the MCP server, a live process reading Postgres  | run a container that listens on a port |
+
+`ksor init` emits everything both need: `Dockerfile` and `.dockerignore` for the
+door, and a `vercel.json` that puts the two behind one domain. This page is the
+walkthrough, executed rather than described.
+
+**Publishing is a third thing, and it is not on this page's critical path.**
+Neither surface ingests. The door serves whatever generation is already active
+in the database, and the site renders `knowledge/` from the repository. Getting
+content INTO the database is [ingesting.md](./ingesting.md), and it is a deploy
+step you run, never something a booting container does.
+
+## The shape
+
+```
+                     ┌───────────────────────────────┐
+   a reader  ────────▶  /            the site        │  static files
+                     │  /docs/…                      │
+                     ├───────────────────────────────┤
+   an agent  ────────▶  /mcp         the door        │  container ──▶ Postgres
+                     │  /health /ready               │
+                     │  /.well-known/oauth-…         │
+                     └───────────────────────────────┘
+```
+
+One domain, two services. An agent that finds `https://your-host/mcp` and a
+person who opens `https://your-host/` are reading the same record.
+
+## The container is the portable artifact
+
+The emitted `Dockerfile` names no host. It installs the pinned
+`@panaversity/ksor` from your `package.json`, honours `$PORT`, and runs
+`ksor serve`:
+
+```sh
+docker build -t my-record .
+docker run --rm -p 8080:80 --env-file .env my-record
+```
+
+That runs on Cloud Run, Fly, Render, ECS, Kubernetes, or a VPS with no changes.
+`vercel.json` **points at this same file** rather than replacing it, which is
+what keeps the host a choice — the artifact is yours, and moving it is a
+redeploy, not a rewrite.
+
+What the image deliberately does NOT contain (see `.dockerignore`):
+
+- **`.env`** — configuration arrives from the environment at run time. A DSN
+  baked into a layer is published to anyone who can pull the image.
+- **`knowledge/`** — the door reads Postgres. Copying the corpus in would
+  suggest the container reads it, and it never does.
+- **`system/`** — that is the other surface, built and hosted separately.
+
+## Deploying both surfaces to Vercel
+
+The emitted `vercel.json` declares both services and routes between them:
+
+```json
+{
+  "services": {
+    "site": { "root": ".", "buildCommand": "pnpm build", "outputDirectory": "system/site/out" },
+    "door": { "root": ".", "runtime": "container", "entrypoint": "Dockerfile" }
+  },
+  "rewrites": [
+    { "source": "/mcp(.*)", "destination": { "service": "door" } },
+    { "source": "/.well-known/oauth-protected-resource(.*)", "destination": { "service": "door" } },
+    { "source": "/health", "destination": { "service": "door" } },
+    { "source": "/ready", "destination": { "service": "door" } },
+    { "source": "/(.*)", "destination": { "service": "site" } }
+  ]
+}
+```
+
+Deploy from the repository **root**, never from `system/site/`:
+
+```sh
+vercel deploy --prod
+```
+
+Two things about this file are worth knowing before you edit it.
+
+**The catch-all must stay last.** Rewrites match in order, so a `/(.*)` rule
+moved above the door's routes silently sends `POST /mcp` to the static site,
+where it becomes a 404 and reads like the door is down.
+
+**Do not add a project-level `trailingSlash`.** The site's own Next config
+already sets it and exports `index.html` directories, so it buys nothing — and
+at the project level it applies to the door too, where it redirects `POST /mcp`
+to `/mcp/` with a 308. Found exactly that way: every door route 308ed until the
+setting came out.
+
+## Configuration
+
+The door takes everything from the environment. Set these on the deployment, not
+in a file:
+
+| variable                | why                                                                      |
+| ----------------------- | ------------------------------------------------------------------------ |
+| `KSOR_DB_URL`           | the record's Postgres store                                              |
+| `GEMINI_API_KEY`        | embeds the incoming query, so retrieval works at all                     |
+| `KSOR_SNAPSHOT_KEYS`    | `kid=secret` — **required in practice**, see below                       |
+| `KSOR_ALLOWED_HOSTS`    | the host you serve on (DNS-rebind defence)                               |
+| `KSOR_MCP_RESOURCE_URL` | this record's canonical URL, e.g. `https://your-host/mcp`                |
+| auth, one of two        | `KSOR_SSO_URL` + audiences, **or** `KSOR_ALLOW_PUBLIC_UNAUTHENTICATED=1` |
+
+`KSOR_SNAPSHOT_KEYS` is listed as a production knob but behaves as a
+requirement on any host that scales to zero. Unset, the signing key is generated
+**per process** — so a citation minted before a scale-down stops validating
+after it, with a single instance and no replicas involved. Generate one:
+
+```sh
+KSOR_SNAPSHOT_KEYS="k1=$(openssl rand -hex 32)"
+```
+
+The value is `kid=secret`, not `kid:secret`, and the first entry is the active
+one. Multiple entries let you rotate without invalidating outstanding
+citations.
+
+### The site build needs the DSN too
+
+Once `instance.md` declares a `database:` block, `pnpm build` runs
+`pnpm export-denylist` first — it asks the database what has been withdrawn and
+writes `.ksor-denylist.json`. Without `KSOR_DB_URL` the build **refuses**:
+
+```
+KSOR_DB_URL is unset, and instance.md declares a database
+  why: a takedown lives in that database. Without it this build cannot tell
+       'nothing is denied' from 'nobody asked'
+```
+
+That refusal is the design working. A takedown reaches the door instantly (it is
+a row) and reaches the site at its next build (it reads a file), so a site built
+without the DSN would keep publishing what the door already refuses. Set
+`KSOR_DB_URL` on the site build as well as on the door.
+
+## Authorization, or the deliberate absence of it
+
+`ksor serve` **refuses to boot unauthenticated on a public bind.** There is no
+auth-off default, and that refusal is the last real step of a deployment. Two
+ways past it:
+
+- **Configure the SSO door** — `KSOR_SSO_URL`, `KSOR_MCP_RESOURCE_URL`,
+  `KSOR_JWT_ALLOWED_AUDIENCES`. Worked recipes for two different authorization
+  servers: [authorization.md](./authorization.md).
+- **Set `KSOR_ALLOW_PUBLIC_UNAUTHENTICATED=1`** — a deliberate decision that
+  serves your whole record to anyone who can reach the port. Correct for a
+  genuinely public record, or behind your own gateway. Never as a way to get a
+  deploy green.
+
+Check which one you got. `/health` says so plainly:
+
+```json
+{
+  "corpus_id": "book",
+  "abstain_gate": "OFF (no floor declared — will not refuse out-of-corpus questions)",
+  "embedding_space": "gemini-embedding-001/d1536 ok",
+  "auth": "disabled"
+}
+```
+
+`"auth":"disabled"` on a public host means the second option is in effect.
+
+## What a cold start costs
+
+The door is built for a runtime that suspends it. It holds **no idle database
+connections** — the pool minimum is 0 and an unused connection closes after 10s
+— so a quiet instance keeps nothing open against a serverless Postgres, and the
+first request after a suspend both wakes the database and retries the connect
+rather than failing.
+
+Measured against a live deployment on Vercel, Neon behind it, an 81-document
+record of 6,963 chunks:
+
+|                                        |           |
+| -------------------------------------- | --------- |
+| warm request                           | **~1.7s** |
+| cold start (container + database wake) | **~9.1s** |
+
+Most of the cold number is the two wakes, not ksor. If that matters for your
+readers, the levers are your host's minimum instance count and your database's
+suspend delay — both outside this tool.
+
+`SIGTERM` drains and exits within 8s (`KSOR_DRAIN_TIMEOUT_MS`), inside the ~10s
+a scale-to-zero runtime usually allows before `SIGKILL`.
+
+## Verifying a deployment
+
+In order, because each answers a different question:
+
+```sh
+B=https://your-host
+
+curl -s $B/health          # the door booted, and on which posture
+curl -s $B/ready           # the database answers
+curl -s -o /dev/null -w '%{http_code}\n' $B/   # the site is served
+
+curl -s -X POST $B/mcp \
+  -H 'content-type: application/json' \
+  -H 'accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{
+       "protocolVersion":"2025-11-25","capabilities":{},
+       "clientInfo":{"name":"probe","version":"1"}}}'
+```
+
+If `/health` answers but a search returns nothing, the door is fine and the
+**record was never published** — go to [ingesting.md](./ingesting.md). A first
+deploy with no ingest serves an empty record, which is the single most common
+"it deployed but does not work".
+
+If `/mcp` returns HTML, the catch-all rewrite is matching before the door's
+route.
+
+## Deploying anywhere else
+
+Nothing above is Vercel-specific except `vercel.json`. On any other host:
+
+1. Build the site — `pnpm build` — and upload `system/site/out/` as static files.
+2. Build and run the container, giving it the environment above.
+3. Put the door at `/mcp` on the same domain, or a different one; if it is a
+   different domain, set `KSOR_MCP_RESOURCE_URL` to the door's real URL, since
+   that value is the record's identity in a token's audience, not a guess.

--- a/packages/ksor/docs/index.md
+++ b/packages/ksor/docs/index.md
@@ -32,6 +32,14 @@ instead of their training memory. The corpus grows with each implemented verb.
   export the manifest the site build reads), `ksor calibrate` (measure the
   abstention floor) and `ksor gc` (reap retired generations). Only `ksor dev` and `ksor build` remain designed, not
   implemented: each prints an honest notice and exits `2`.
+  - **[deploying.md](./deploying.md)** — getting both surfaces onto a host. The
+    scaffold emits a `Dockerfile` that names no vendor, and a `vercel.json` that
+    points at it to put the site and the MCP door behind one domain. Includes
+    what a cold start costs, measured.
+  - **[ingesting.md](./ingesting.md)** — publishing the record and keeping it
+    current. Serving does not publish, so a first deploy with no ingest serves
+    an empty record; this is the page that explains why, where ingest belongs
+    (never inside the container), and how the abstention gate gets turned on.
   - **[authorization.md](./authorization.md)** — putting the record behind an
     authorization server, with worked recipes for two of them, executed rather
     than written. `ksor serve` refuses to boot unauthenticated on a public bind,

--- a/packages/ksor/docs/ingesting.md
+++ b/packages/ksor/docs/ingesting.md
@@ -1,0 +1,159 @@
+---
+title: Ingesting
+status: draft
+---
+
+# Publishing the record — `ksor ingest`
+
+Serving does not publish. That split is deliberate and it is the thing most
+worth understanding before a first deployment: `ksor serve` opens a port against
+whatever generation is already active, and `ksor ingest` is what makes a
+generation exist. A container that ingested on boot would pay the whole record's
+embedding cost on every cold start and would need write credentials at runtime.
+
+So **a first deploy with no ingest serves an empty record.** It is not broken;
+nothing was ever published to it.
+
+## The order, once
+
+```sh
+pnpm provision   # ksor schema --apply, then ksor grant
+pnpm refresh     # ksor ingest --flip, then ksor gc
+```
+
+`provision` is separate because applying DDL and granting ingest are acts an
+operator performs, not side effects of starting a server. Both are re-runnable
+and report what they found — an applied schema says "already applied", an
+existing grant says "already granted".
+
+Then, after every change to `knowledge/`:
+
+```sh
+pnpm refresh
+```
+
+## What a generation is
+
+Each ingest builds a **fresh generation** — invisible until activated — and
+carries every unchanged embedding forward from the last complete one, matched by
+content hash. Only changed or previously-failed chunks are re-embedded.
+
+`--flip` swaps the active pointer. The previous generation stays as a rollback
+target; `ksor gc` reaps the ones nothing points at any more.
+
+Three consequences worth knowing:
+
+- **Re-ingest is cheap.** An ordinary edit makes a handful of provider calls,
+  not a corpus-worth.
+- **An unchanged record costs nothing at all.** Ingest compares what it just
+  read against the generation already serving and, when they are identical at
+  the same commit, consumes no generation and writes no rows:
+  `unchanged — generation N already serves this corpus`.
+- **Reordering is free.** Changing `order:` frontmatter re-ingests with no
+  embedding at all; only the ordering moved.
+
+A flip that would drop more than `KSOR_MAX_SHRINK` of the record (default
+`0.15`, i.e. 15%) **refuses**. When a large deletion is intended, say so:
+`KSOR_ALLOW_SHRINK=1`.
+
+## Where ingest runs — not on the host
+
+Ingest is a long job. It embeds every new chunk through the provider, and that
+is bounded by the provider's throughput rather than by anything ksor does.
+
+**Measured:** an 81-document book — 6,963 chunks — took **about 50 minutes**
+against a remote Postgres on a first, cold ingest with nothing to carry forward.
+
+Compare that with the request timeouts of the platforms people reach for first:
+a serverless function caps out in the region of 300–800 seconds depending on
+plan. Ingest is **an order of magnitude past that**, so it cannot be a route, a
+build step, or anything else the platform is allowed to kill.
+
+Run it where nothing is watching a clock:
+
+- **From your machine**, with `KSOR_DB_URL` pointing at the deployment's
+  database. This is the honest default for a record one person maintains.
+- **From CI**, as a job triggered on changes to `knowledge/` — the right shape
+  once more than one person edits, because it makes publishing an auditable
+  event rather than something someone did locally.
+
+It does not matter whether the process that ingests is the process that serves.
+They meet in the database and nowhere else.
+
+### If an ingest is interrupted
+
+Nothing is corrupted — an unactivated generation is invisible by construction.
+Run it again. The next attempt finds the incomplete generation's work and
+carries forward everything that was already embedded, including from a
+generation that was still `building` when it died, so a resumed run pays only
+for what the first one had not reached.
+
+## Endpoints, poolers, and what actually matters
+
+If your provider offers both a **pooled** and a **direct** endpoint (Neon's
+`-pooler` host, or anything on port 6432), ksor detects which one you gave it
+and says so in the boot report. That line is **informational**: it classifies,
+it never transforms. The hazard it descends from — a transaction pooler and
+server-side prepared statements — cannot arise here, because node-postgres does
+not auto-prepare.
+
+For the record: the 6,963-chunk ingest above ran through a **pooled** endpoint
+without incident, and the same DSN serves. Use whichever your provider gives
+you, and reach for the direct endpoint only if you actually hit pooler
+connection limits under a parallel ingest — not pre-emptively.
+
+`KSOR_DB_POOLED_ENDPOINT=1` forces the classification when your host name does
+not announce itself.
+
+## Turning the abstention gate on
+
+This is a separate act, done once, **after** the record is serving — because it
+is a measurement of this corpus in this embedding space, and there is nothing to
+measure until the corpus is in there.
+
+```sh
+pnpm exec ksor calibrate --instance instance.md
+```
+
+It prints a recommended `vector_floor`. Paste it in with the date you measured
+it, and restart:
+
+```yaml
+retrieval:
+  vector_floor: 0.55 # measured by ksor calibrate on 2026-08-23
+```
+
+Until you do, `/health` reports the gate as `OFF (no floor declared — will not
+refuse out-of-corpus questions)` and every search envelope carries
+`gate: "off"`. That is honest absence, and an agent reading the envelope knows
+an answer is not evidence of coverage.
+
+**Never copy a floor from another corpus.** The number means nothing away from
+the corpus and embedding space it was measured in.
+
+If calibrate reports `NOT separable`, read what it names underneath: it lists
+the out-of-corpus probes that scored at or above your weakest in-corpus
+question. Usually one of them is a question your record actually answers, and it
+belongs on the in-corpus side — moving it separates the measurement. Sometimes
+it is a genuine near-miss the corpus cannot separate, and then the floor
+correctly stays uncalibrated.
+
+## Withdrawing a document
+
+A takedown is a row, not a file, so it reaches the door immediately:
+
+```sh
+pnpm exec ksor takedown --instance instance.md <stable-id> \
+  --reason "legal request 2026-08" --actor "j.smith"
+```
+
+`--actor` is required, and there is no default. A name taken from the
+environment reads like a person and is whatever the shell happened to be
+(`runner` under CI, `root` in a container) — worse than no name at all in the
+one row that exists to record who did this.
+
+**The site stops at its next build.** It reads `.ksor-denylist.json`, which
+`pnpm build` refreshes via `pnpm export-denylist`. So after a takedown, rebuild
+and redeploy the site, or the human surface keeps publishing what the agent
+surface already refuses. See [deploying.md](./deploying.md) for why that build
+needs `KSOR_DB_URL`.

--- a/packages/ksor/src/init.integration.test.ts
+++ b/packages/ksor/src/init.integration.test.ts
@@ -34,6 +34,7 @@ const pkgVersion = (JSON.parse(readFileSync(pkgManifest, "utf8")) as { version: 
 const EMITTED_NAMES: ReadonlyMap<string, string> = new Map([
   ["gitignore", ".gitignore"],
   ["env.example", ".env.example"],
+  ["dockerignore", ".dockerignore"],
 ]);
 
 function emittedPath(templateRel: string): string {
@@ -243,16 +244,22 @@ describe("ksor init — acceptance (spec clauses 1-3)", () => {
     // install must not be frozen — otherwise an adopter's very first Vercel
     // import dies on ERR_PNPM_OUTDATED_LOCKFILE before any build (review,
     // 2026-08-20). The repo's own e2e suites already had to make this switch.
+    // It lives on the SITE service since the config gained the door alongside
+    // it; the property is unchanged and belongs wherever the site is built.
     const vercel = JSON.parse(
       readFileSync(path.join(dir, "served-sor", "vercel.json"), "utf8"),
-    ) as { installCommand?: string };
-    expect(vercel.installCommand, "the deploy install must tolerate the stamped dep").toContain(
-      "--no-frozen-lockfile",
-    );
-    // The kernel's build-scripted deps must be explicitly denied, or pnpm 11
-    // exits 1 on the adopter's first install (found live 2026-08-20).
-    expect(workspace, "@google/genai build denied").toMatch(/"@google\/genai":\s*false/);
-    expect(workspace, "protobufjs build denied").toMatch(/protobufjs:\s*false/);
+    ) as { services?: { site?: { installCommand?: string } } };
+    expect(
+      vercel.services?.site?.installCommand,
+      "the deploy install must tolerate the stamped dep",
+    ).toContain("--no-frozen-lockfile");
+    // Build-scripted deps must be explicitly decided, or pnpm 11 exits 1 on
+    // the adopter's first install (found live 2026-08-20). The site's two are
+    // the whole set now: dropping the Gemini SDK for its REST API took
+    // @google/genai and protobufjs out of the tree entirely, and a denial for
+    // a package that is never installed documents a dependency we do not have.
+    expect(workspace, "esbuild build denied").toMatch(/esbuild:\s*false/);
+    expect(workspace, "sharp build denied").toMatch(/sharp:\s*false/);
   });
 
   it.runIf(process.platform !== "win32")(
@@ -559,6 +566,9 @@ describe("ksor init — scaffold contents (spec: emitted-tree contract)", () => 
       [
         ".agents",
         ".claude",
+        // The container build's exclusions — secrets, the corpus, the site
+        // (decision 8 revision 2026-08-23).
+        ".dockerignore",
         // The served rung's variables, including the auth posture serve
         // requires (decision 8 revision 2026-08-20).
         ".env.example",
@@ -568,6 +578,9 @@ describe("ksor init — scaffold contents (spec: emitted-tree contract)", () => 
         ".gitignore",
         "AGENTS.md",
         "CLAUDE.md",
+        // The MCP door as a portable container — no host named in it
+        // (decision 8 revision 2026-08-23).
+        "Dockerfile",
         "README.md",
         "instance.md",
         "knowledge",
@@ -578,6 +591,59 @@ describe("ksor init — scaffold contents (spec: emitted-tree contract)", () => 
         "vercel.json",
       ].sort(),
     );
+  });
+
+  // "Vendor-free is the ownership argument" — the emitted container is where
+  // that claim is cheapest to lose. A Dockerfile that grew one host-specific
+  // line would still deploy, still pass every other test, and quietly make the
+  // artifact unportable; the neutrality is only real while nothing in it knows
+  // where it runs. vercel.json POINTS AT this file rather than replacing it,
+  // which is what keeps the host a choice.
+  it("emits a container that names no host", () => {
+    const dir = workDir();
+    runInit(["my-sor"], dir);
+    const dockerfile = readFileSync(path.join(dir, "my-sor", "Dockerfile"), "utf8");
+
+    for (const vendor of ["vercel", "cloud run", "cloudrun", "fly.io", "heroku", "render.com"]) {
+      expect(
+        dockerfile
+          .toLowerCase()
+          .split("\n")
+          .filter((l) => !l.trimStart().startsWith("#"))
+          .join("\n"),
+      ).not.toContain(vendor);
+    }
+    // It must still be a runnable image rather than a comment file.
+    expect(dockerfile).toContain("FROM node:");
+    expect(dockerfile).toContain("ksor");
+    expect(dockerfile).toContain("serve");
+
+    // And the host config defers to it, so there is exactly one build recipe.
+    const vercel: unknown = JSON.parse(
+      readFileSync(path.join(dir, "my-sor", "vercel.json"), "utf8"),
+    );
+    expect(vercel).toMatchObject({
+      services: { door: { runtime: "container", entrypoint: "Dockerfile" } },
+    });
+  });
+
+  // The image serves; it does not publish, and it does not carry secrets. Both
+  // are governance properties, not build hygiene: a corpus copied in suggests
+  // the container reads it (it reads Postgres), and a baked .env publishes the
+  // DSN to anyone who can pull the image.
+  it("excludes secrets, the corpus, and the site from the image", () => {
+    const dir = workDir();
+    runInit(["my-sor"], dir);
+    const ignore = readFileSync(path.join(dir, "my-sor", ".dockerignore"), "utf8");
+    const lines = ignore.split("\n").map((l) => l.trim());
+
+    expect(lines).toContain(".env");
+    expect(lines).toContain("knowledge/");
+    expect(lines).toContain("system/");
+    expect(lines).toContain("node_modules/");
+    // The example is documentation, not a secret, and the .env* rule would
+    // otherwise take it — the same carve-out .gitignore makes.
+    expect(lines).toContain("!.env.example");
   });
 
   it("CLAUDE.md is a one-line pointer file, never a symlink", () => {

--- a/packages/ksor/src/init/materialize.ts
+++ b/packages/ksor/src/init/materialize.ts
@@ -21,6 +21,7 @@ const EMITTED_NAMES: ReadonlyMap<string, string> = new Map([
   // Same reason as .gitignore: npm pack is unreliable about leading-dot names,
   // so the template ships bare and init restores the dot.
   ["env.example", ".env.example"],
+  ["dockerignore", ".dockerignore"],
 ]);
 
 const TEXT_EXTENSIONS = new Set([

--- a/packages/ksor/src/tarball.integration.test.ts
+++ b/packages/ksor/src/tarball.integration.test.ts
@@ -47,9 +47,13 @@ const REQUIRED_IN_TARBALL = [
   "templates/scaffold/pnpm-lock.yaml",
   "templates/scaffold/instance.md",
   "templates/scaffold/vercel.json",
-  // Not ".gitignore": npm pack drops that name from every tarball, so the
-  // template ships bare and init renames it on emit.
+  // The container artifacts. Shipping these is what makes the served rung
+  // deployable anywhere rather than only where we happened to test.
+  "templates/scaffold/Dockerfile",
+  // Not ".gitignore"/".dockerignore": npm pack drops leading-dot names from
+  // the tarball, so these templates ship bare and init renames them on emit.
   "templates/scaffold/gitignore",
+  "templates/scaffold/dockerignore",
   "templates/scaffold/system/site/package.json",
   "templates/scaffold/.agents/skills/format-checker/check.mjs",
   "templates/scaffold/.claude/skills/format-checker/check.mjs",

--- a/packages/ksor/templates/scaffold/AGENTS.md
+++ b/packages/ksor/templates/scaffold/AGENTS.md
@@ -356,6 +356,35 @@ refuses rather than publish a document someone took down.
 behind that audience's own access control, never on a public host.
 Details in README → Deploying.
 
+### The MCP door is a container
+
+The other surface is a live process, so it ships as one. `Dockerfile` and
+`.dockerignore` are yours, at the repo root, and they name no host:
+
+```sh
+docker build -t my-record .
+docker run --rm -p 8080:80 --env-file .env my-record
+```
+
+That image runs on Cloud Run, Fly, Render, ECS, Kubernetes or a VPS unchanged.
+`vercel.json` declares BOTH surfaces — a `site` service built from
+`system/site/out/` and a `door` service pointing at that same `Dockerfile` —
+with rewrites putting the door on `/mcp`, `/health`, `/ready` and the
+`/.well-known/oauth-protected-resource` document, and the site on everything
+else. Two rules if you edit it: the `/(.*)` catch-all must stay LAST, and do
+not add a project-level `trailingSlash` — the site's Next config already sets
+it, and at project level it 308-redirects `POST /mcp`, which breaks the door.
+
+The image deliberately excludes `.env` (a baked DSN is published to anyone who
+can pull the image), `knowledge/` (the door reads Postgres, never the folder)
+and `system/` (the other surface).
+
+**Deploying does not publish.** A container that ingested on boot would pay the
+whole record's embedding cost on every cold start and need write credentials at
+runtime. So `pnpm refresh` is a DEPLOY step you run — from your machine or from
+CI — and a first deploy without it serves an empty record. Full walkthrough:
+`node_modules/@panaversity/ksor/docs/deploying.md` and `…/docs/ingesting.md`.
+
 ## Writing knowledge
 
 - One document per file under `knowledge/`; the path is the document's

--- a/packages/ksor/templates/scaffold/Dockerfile
+++ b/packages/ksor/templates/scaffold/Dockerfile
@@ -1,0 +1,36 @@
+# The MCP door, as an ordinary container.
+#
+# Nothing here names a host. It installs the pinned `@panaversity/ksor` from
+# package.json, listens on $PORT, and runs `ksor serve` — which is all Cloud Run,
+# Fly, Render, ECS, Kubernetes or a plain VPS asks for. `vercel.json` points AT
+# this file rather than replacing it, so the artifact stays portable and the host
+# stays a choice.
+#
+# Build and run it anywhere:
+#   docker build -t my-record .
+#   docker run --rm -p 8080:80 --env-file .env my-record
+#
+# This image serves; it does not publish. `ksor ingest` is a write plane that
+# runs from CI or your machine against the same database — see the deployment
+# guide in node_modules/@panaversity/ksor/docs/deploying.md.
+
+FROM node:24-alpine
+
+WORKDIR /app
+
+# Only the manifest first, so this layer caches until the ksor pin changes.
+COPY package.json ./
+RUN npm install --omit=dev --no-audit --no-fund
+
+# The record's identity and configuration. The CORPUS is deliberately absent:
+# the door serves from Postgres, and knowledge/ belongs to the build that
+# published it — see .dockerignore.
+COPY instance.md ./
+
+# Most container hosts inject PORT; 80 is a sane default when nothing does.
+ENV PORT=80
+EXPOSE 80
+
+# `ksor serve` refuses to boot unauthenticated on a public bind. That posture
+# belongs to the record, not to the host, so it travels inside the image.
+CMD ["node_modules/.bin/ksor", "serve", "--instance", "instance.md"]

--- a/packages/ksor/templates/scaffold/README.md
+++ b/packages/ksor/templates/scaffold/README.md
@@ -60,6 +60,43 @@ unauthenticated: a local run declares `KSOR_AUTH_DISABLED=1` (already in
 a public bind needs a configured SSO door instead. Any other operation is
 `pnpm exec ksor <verb>`.
 
+### Test the agent surface with an actual agent
+
+The MCP door is meant to be read by agents, so check it with one rather than
+with `curl`. With `pnpm serve` running, write `.mcp.json` at the repo root:
+
+```json
+{
+  "mcpServers": {
+    "test-record": {
+      "type": "http",
+      "url": "http://127.0.0.1:8080/mcp"
+    }
+  }
+}
+```
+
+Open a new session of your coding agent, confirm it lists the server, then ask
+it three questions **in this order** — the order is the test:
+
+1. Something the record covers, **phrased in words the document never uses**.
+   Retrieval is semantic, so this should still find it, and every answer should
+   arrive with a citation.
+2. Something **adjacent but not covered** — your record's own subject area, a
+   question it genuinely does not answer. It should decline.
+3. Something far outside the record. It should decline, and must not answer
+   from its own knowledge.
+
+Question 2 is the one that matters. Anything can answer questions it has the
+text for; refusing a plausible near-miss is the property that makes a system of
+record worth trusting, and it is the one that breaks quietly.
+
+**On a fresh record, 2 and 3 will not refuse — and that is honest, not broken.**
+The abstention gate is off until you measure a floor for this corpus, which the
+server says out loud at boot (`abstain OFF`) and in every search envelope
+(`gate: "off"`). Run `pnpm exec ksor calibrate --instance instance.md` first if
+you want to test refusal. Delete `.mcp.json`, or keep it — it holds no secret.
+
 Then talk to your coding agent — `AGENTS.md` carries the working rules, and
 the agent kit in `.agents/skills/` knows how to interview you
 (`intake-interview`), convert your source material (`add-sources`), and keep

--- a/packages/ksor/templates/scaffold/README.md
+++ b/packages/ksor/templates/scaffold/README.md
@@ -118,7 +118,9 @@ and anything that can serve files can serve it.
 - **Vercel** — connect the repository (or run `vercel`); the shipped
   `vercel.json` answers the setup interview: deploy from the repo root
   (never pin `system/site` as the root directory — the record lives
-  outside it), build with `pnpm build`, serve `system/site/out/`. If the
+  outside it), build with `pnpm build`, serve `system/site/out/`. It also
+  declares the MCP **door** as a second service built from the shipped
+  `Dockerfile`, so `/mcp` and the site share one domain. If the
   build image's pnpm predates the `packageManager` pin, set the
   `ENABLE_EXPERIMENTAL_COREPACK=1` build environment variable.
 **Once `instance.md` declares a `database:`, the BUILD needs the DSN too.**
@@ -142,6 +144,24 @@ writes "nothing denied" and exits 0.
   `user.github.io/repo`)? Build with `KSOR_BASE_PATH=/repo pnpm build`.
 - **Verify any deploy** the same way: the home page, one document page,
   and `/llms.txt` all load; nothing else is required.
+
+### The agent surface deploys separately
+
+The site is files; the MCP door is a process. `Dockerfile` and `.dockerignore`
+at the repo root build it, and they name no host — the same image runs on
+Cloud Run, Fly, Render, ECS, Kubernetes or a VPS:
+
+```sh
+docker build -t my-record .
+docker run --rm -p 8080:80 --env-file .env my-record
+```
+
+One thing surprises people: **deploying does not publish.** The door serves
+whatever generation is already in the database, so a first deploy with no
+`pnpm refresh` serves an empty record. Publishing is a step you run — from your
+machine or from CI — and it is deliberately not something a booting container
+does. The full walkthrough, including what a cold start costs and where ingest
+belongs, is in `node_modules/@panaversity/ksor/docs/deploying.md`.
 
 If `instance.md` declares `audiences:`, what you deploy is a **tier**.
 Plain `pnpm build` always builds the public tier — safe for any host.

--- a/packages/ksor/templates/scaffold/dockerignore
+++ b/packages/ksor/templates/scaffold/dockerignore
@@ -1,0 +1,26 @@
+# Keep the serving image to what serving needs.
+
+# Secrets. The image takes its configuration from the environment at RUN time;
+# baking a .env into a layer publishes it to anyone who can pull the image.
+.env
+.env.*
+!.env.example
+
+# The corpus. The door serves from Postgres — knowledge/ was published by
+# `ksor ingest` before this container ever started, and copying it in would
+# suggest the container reads it. It does not.
+knowledge/
+
+# The website. It is the OTHER surface, built and hosted separately.
+system/
+
+# Build and tooling noise.
+node_modules/
+.git/
+.github/
+.agents/
+.claude/
+.gemini/
+*.log
+.DS_Store
+.ksor-denylist.json

--- a/packages/ksor/templates/scaffold/pnpm-workspace.yaml
+++ b/packages/ksor/templates/scaffold/pnpm-workspace.yaml
@@ -19,17 +19,13 @@ minimumReleaseAgeExclude:
 # Dependency install scripts are denied by default. Flip an entry to true
 # only with a comment naming what breaks without it. pnpm 11 exits 1 on every
 # install until each build script is explicitly decided (found live:
-# fresh-scaffold pnpm dev, 2026-08-18). All four below are reviewed and stay
-# denied:
+# fresh-scaffold pnpm dev, 2026-08-18). Both below are reviewed and stay denied:
 #   esbuild, sharp — prebuilt platform binaries ship as optionalDependencies,
 #     so their install scripts are download fallbacks the site never needs.
-#   @google/genai, protobufjs — pulled in by the `@panaversity/ksor` serve
-#     tool. genai's flagged script is its own dev `prepare` (nothing the
-#     published tarball needs built); protobufjs's postinstall is a
-#     version-compat warning, nothing built. (Same review as the root
-#     workspace, 2026-08-19; serve works with both denied — verified live.)
+#
+# `@google/genai` and `protobufjs` were listed here too, as deps of the serve
+# tool. The embedding provider now speaks the vendor's REST API directly, so
+# neither package is installed at all and denying them described nothing.
 allowBuilds:
   esbuild: false
   sharp: false
-  "@google/genai": false
-  protobufjs: false

--- a/packages/ksor/templates/scaffold/vercel.json
+++ b/packages/ksor/templates/scaffold/vercel.json
@@ -1,8 +1,26 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "framework": null,
-  "installCommand": "pnpm install --no-frozen-lockfile",
-  "buildCommand": "pnpm build",
-  "outputDirectory": "system/site/out",
-  "trailingSlash": true
+  "services": {
+    "site": {
+      "root": ".",
+      "installCommand": "pnpm install --no-frozen-lockfile",
+      "buildCommand": "pnpm build",
+      "outputDirectory": "system/site/out"
+    },
+    "door": {
+      "root": ".",
+      "runtime": "container",
+      "entrypoint": "Dockerfile"
+    }
+  },
+  "rewrites": [
+    { "source": "/mcp(.*)", "destination": { "service": "door" } },
+    {
+      "source": "/.well-known/oauth-protected-resource(.*)",
+      "destination": { "service": "door" }
+    },
+    { "source": "/health", "destination": { "service": "door" } },
+    { "source": "/ready", "destination": { "service": "door" } },
+    { "source": "/(.*)", "destination": { "service": "site" } }
+  ]
 }

--- a/scripts/container-acceptance.mjs
+++ b/scripts/container-acceptance.mjs
@@ -233,12 +233,35 @@ try {
   });
   const structured = outline.result?.structuredContent;
   if (!structured) fail(`outline returned nothing: ${JSON.stringify(outline).slice(0, 400)}`);
-  const rendered = JSON.stringify(structured);
-  if (!rendered.includes("knowledge/")) {
-    fail(`the outline carries no record: ${rendered.slice(0, 400)}`);
+  const nodes = structured.nodes ?? [];
+  if (nodes.length === 0) {
+    fail(`the outline carries no record: ${JSON.stringify(structured).slice(0, 400)}`);
   }
-  console.log("outline: ok —", rendered.length, "bytes of governed record");
+  console.log(`outline: ${nodes.length} nodes, first "${nodes[0].title}"`);
 
+  // The guarantee, not merely a reply: a search must come back CITED. Provenance
+  // is what separates this from any other retrieval server, so it is what the
+  // container walk asserts — a stable_id and the generation that authorized it.
+  const search = await mcp({
+    jsonrpc: "2.0",
+    id: 3,
+    method: "tools/call",
+    params: { name: "search", arguments: { query: "what is a knowledge system of record", k: 3 } },
+  });
+  const found = search.result?.structuredContent;
+  if (!found) fail(`search returned nothing: ${JSON.stringify(search).slice(0, 400)}`);
+  const hits = found.hits ?? [];
+  if (hits.length === 0) fail(`search found nothing: ${JSON.stringify(found).slice(0, 400)}`);
+  for (const hit of hits) {
+    const provenance = hit.provenance ?? {};
+    if (!provenance.stable_id || provenance.generation === undefined) {
+      fail(`a hit came back UNCITED: ${JSON.stringify(hit).slice(0, 300)}`);
+    }
+  }
+  console.log(
+    `search: ${hits.length} cited hits, gate=${found.gate}, ` +
+      `first ${hits[0].provenance.stable_id} gen=${hits[0].provenance.generation}`,
+  );
   // 8. And the claim the whole job exists for.
   const body = emitted
     .split("\n")

--- a/scripts/container-acceptance.mjs
+++ b/scripts/container-acceptance.mjs
@@ -1,0 +1,215 @@
+/**
+ * The emitted container, proven WITHOUT a hosting vendor.
+ *
+ * `ksor init` now ships a Dockerfile, and the claim attached to it is that the
+ * served rung runs anywhere — "vendor-free is the ownership argument". A claim
+ * only checked by deploying to one vendor is a claim about that vendor. So this
+ * walks the artifact on plain Docker: scaffold, publish a generation, build the
+ * image, boot it, and ask it a question over MCP.
+ *
+ * It installs the LOCAL build rather than the published one (the tier rule paid
+ * for with shipped defects: the test must install the same tree the artifact
+ * installs). The Dockerfile is used as emitted, with ONE line inserted to bring
+ * the local tarball into the build context — and the insertion is asserted to be
+ * the only difference, so this can never quietly drift into testing a different
+ * recipe than adopters get.
+ */
+
+import { execFileSync } from "node:child_process";
+import { copyFileSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+const cli = path.join(repoRoot, "packages", "ksor", "dist", "cli.mjs");
+const DSN = process.env["KSOR_DB_URL"];
+const PORT = "8099";
+const IMAGE = "ksor-container-acceptance";
+
+if (!DSN) {
+  console.error("KSOR_DB_URL is required (this walk publishes a real generation)");
+  process.exit(1);
+}
+
+const work = mkdtempSync(path.join(tmpdir(), "ksor-container-"));
+const project = path.join(work, "demo");
+let container = "";
+
+function run(cmd, args, opts = {}) {
+  return execFileSync(cmd, args, { encoding: "utf8", stdio: "pipe", ...opts });
+}
+
+function ksor(args, env = {}) {
+  return run(process.execPath, [cli, ...args], {
+    cwd: project,
+    env: { ...process.env, ...env },
+  });
+}
+
+function fail(message) {
+  console.error(`FAIL: ${message}`);
+  cleanup();
+  process.exit(1);
+}
+
+function cleanup() {
+  if (container) {
+    try {
+      console.error(run("docker", ["logs", container]).slice(-4000));
+    } catch {
+      /* the container may never have started */
+    }
+    try {
+      run("docker", ["rm", "-f", container]);
+    } catch {
+      /* already gone */
+    }
+  }
+  rmSync(work, { recursive: true, force: true });
+}
+
+try {
+  // 1. Scaffold with the local CLI.
+  run(process.execPath, [cli, "init", "demo"], { cwd: work });
+
+  // 2. Point the record at the database. The scaffold ships the block
+  //    commented out, which is the adopter's first edit on this rung.
+  const instancePath = path.join(project, "instance.md");
+  const instance = readFileSync(instancePath, "utf8").replace(
+    "# database:\n#   dsn_env: KSOR_DB_URL",
+    "database:\n  dsn_env: KSOR_DB_URL",
+  );
+  if (!instance.includes("\ndatabase:\n")) fail("could not enable the database block");
+  writeFileSync(instancePath, instance);
+
+  // 3. Install the LOCAL build, not the published one.
+  const packed = run("npm", ["pack", "--pack-destination", project], {
+    cwd: path.join(repoRoot, "packages", "ksor"),
+  })
+    .trim()
+    .split("\n")
+    .at(-1);
+  copyFileSync(path.join(project, packed), path.join(project, "ksor-local.tgz"));
+  const pkgPath = path.join(project, "package.json");
+  const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+  pkg.dependencies["@panaversity/ksor"] = "file:./ksor-local.tgz";
+  writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
+
+  // 4. Publish a generation. This is a DEPLOY step, never something the
+  //    container does at boot — the whole point of the serve/ingest split.
+  ksor(["schema", "--instance", "instance.md", "--apply"]);
+  ksor(["grant", "--instance", "instance.md"]);
+  ksor(["ingest", "--instance", "instance.md", "--knowledge", "knowledge", "--flip"]);
+
+  // 5. Build the emitted Dockerfile, plus exactly one line for the tarball.
+  const emitted = readFileSync(path.join(project, "Dockerfile"), "utf8");
+  const INSERT = "COPY ksor-local.tgz ./\n";
+  const anchor = "RUN npm install";
+  if (!emitted.includes(anchor)) fail("the emitted Dockerfile no longer installs with npm");
+  const overlay = emitted.replace(anchor, INSERT + anchor);
+  if (overlay.replace(INSERT, "") !== emitted) fail("the overlay changed more than one line");
+  writeFileSync(path.join(project, "Dockerfile.citest"), overlay);
+
+  run("docker", ["build", "-f", "Dockerfile.citest", "-t", IMAGE, "."], {
+    cwd: project,
+    stdio: "inherit",
+  });
+
+  // 6. Boot it. --network host so the container reaches the Postgres service
+  //    the same way the ingest above did.
+  container = run("docker", [
+    "run",
+    "-d",
+    "--network",
+    "host",
+    "-e",
+    `PORT=${PORT}`,
+    "-e",
+    `KSOR_DB_URL=${DSN}`,
+    "-e",
+    `GEMINI_API_KEY=${process.env["GEMINI_API_KEY"] ?? ""}`,
+    "-e",
+    "KSOR_AUTH_DISABLED=1",
+    "-e",
+    "KSOR_SNAPSHOT_KEYS=k1=0123456789abcdef0123456789abcdef",
+    IMAGE,
+  ]).trim();
+
+  const base = `http://127.0.0.1:${PORT}`;
+  let health;
+  for (let attempt = 0; attempt < 60; attempt++) {
+    try {
+      const res = await fetch(`${base}/health`);
+      if (res.ok) {
+        health = await res.json();
+        break;
+      }
+    } catch {
+      /* not listening yet */
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  if (!health) fail(`the container never answered ${base}/health`);
+  console.log("health:", JSON.stringify(health));
+  if (health.corpus_id !== "demo") fail(`served the wrong corpus: ${health.corpus_id}`);
+
+  // 7. Ask it a real question over MCP.
+  const mcp = async (body) => {
+    const res = await fetch(`${base}/mcp`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+        "mcp-protocol-version": "2025-11-25",
+      },
+      body: JSON.stringify(body),
+    });
+    const text = await res.text();
+    const line = text.split("\n").find((l) => l.startsWith("data: ") || l.startsWith("{"));
+    if (!line) fail(`no JSON-RPC in the reply: ${text.slice(0, 300)}`);
+    return JSON.parse(line.replace(/^data: /, ""));
+  };
+
+  const init = await mcp({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+      protocolVersion: "2025-11-25",
+      capabilities: {},
+      clientInfo: { name: "container-acceptance", version: "1" },
+    },
+  });
+  if (init.result?.serverInfo?.name !== "ksor") {
+    fail(`initialize did not answer as ksor: ${JSON.stringify(init).slice(0, 300)}`);
+  }
+  console.log("initialize: ksor", init.result.serverInfo.version);
+
+  const outline = await mcp({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "tools/call",
+    params: { name: "outline", arguments: {} },
+  });
+  const structured = outline.result?.structuredContent;
+  if (!structured) fail(`outline returned nothing: ${JSON.stringify(outline).slice(0, 400)}`);
+  const rendered = JSON.stringify(structured);
+  if (!rendered.includes("knowledge/")) {
+    fail(`the outline carries no record: ${rendered.slice(0, 400)}`);
+  }
+  console.log("outline: ok —", rendered.length, "bytes of governed record");
+
+  // 8. And the claim the whole job exists for.
+  const body = emitted
+    .split("\n")
+    .filter((l) => !l.trimStart().startsWith("#"))
+    .join("\n")
+    .toLowerCase();
+  for (const vendor of ["vercel", "cloud run", "fly.io", "heroku", "aws", "azure"]) {
+    if (body.includes(vendor)) fail(`the emitted Dockerfile names a host: ${vendor}`);
+  }
+  console.log("\nthe emitted container serves the record, and names no host.");
+} finally {
+  cleanup();
+}

--- a/scripts/container-acceptance.mjs
+++ b/scripts/container-acceptance.mjs
@@ -56,9 +56,20 @@ function fail(message) {
 function cleanup() {
   if (container) {
     try {
-      console.error(run("docker", ["logs", container]).slice(-4000));
-    } catch {
-      /* the container may never have started */
+      // BOTH streams, through a shell: execFileSync returns stdout only, and
+      // the door writes its boot report — including every refusal — to stderr.
+      // Capturing stdout alone printed an empty string over a real failure.
+      console.error("--- container state ---");
+      console.error(
+        run("sh", [
+          "-c",
+          `docker inspect -f '{{.State.Status}} exit={{.State.ExitCode}}' ${container}`,
+        ]).trim(),
+      );
+      console.error("--- container logs ---");
+      console.error(run("sh", ["-c", `docker logs ${container} 2>&1`]).slice(-6000));
+    } catch (error) {
+      console.error(`could not read the container's logs: ${error.message}`);
     }
     try {
       run("docker", ["rm", "-f", container]);

--- a/scripts/container-acceptance.mjs
+++ b/scripts/container-acceptance.mjs
@@ -84,13 +84,34 @@ try {
   writeFileSync(instancePath, instance);
 
   // 3. Install the LOCAL build, not the published one.
-  const packed = run("npm", ["pack", "--pack-destination", project], {
+  //
+  //    PNPM pack, never npm pack. The manifest declares `"zod": "catalog:"`,
+  //    a pnpm-only protocol that pnpm RESOLVES to a concrete range when it
+  //    packs or publishes — so the registry serves `^4.4.3` and every consumer
+  //    is fine. `npm pack` copies the manifest verbatim, leaving `catalog:` in
+  //    the tarball, and the install then dies with EUNSUPPORTEDPROTOCOL. That
+  //    would be a test failing on its own packaging while the shipped artifact
+  //    was correct, which is the most expensive kind of red.
+  const packed = run("pnpm", ["pack", "--pack-destination", project], {
     cwd: path.join(repoRoot, "packages", "ksor"),
   })
     .trim()
     .split("\n")
-    .at(-1);
-  copyFileSync(path.join(project, packed), path.join(project, "ksor-local.tgz"));
+    .at(-1)
+    .trim();
+  copyFileSync(packed, path.join(project, "ksor-local.tgz"));
+
+  // The property that makes the line above correct, asserted rather than
+  // trusted: a pnpm-only protocol reaching the tarball would break every npm
+  // and yarn consumer of the published package.
+  const packedManifest = run("tar", ["-xzOf", "ksor-local.tgz", "package/package.json"], {
+    cwd: project,
+  });
+  const packedDeps = JSON.stringify(JSON.parse(packedManifest).dependencies ?? {});
+  if (packedDeps.includes("catalog:") || packedDeps.includes("workspace:")) {
+    fail(`the packed manifest carries an unresolved pnpm protocol: ${packedDeps}`);
+  }
+
   const pkgPath = path.join(project, "package.json");
   const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
   pkg.dependencies["@panaversity/ksor"] = "file:./ksor-local.tgz";

--- a/scripts/container-acceptance.mjs
+++ b/scripts/container-acceptance.mjs
@@ -163,6 +163,13 @@ try {
     `GEMINI_API_KEY=${process.env["GEMINI_API_KEY"] ?? ""}`,
     "-e",
     "KSOR_AUTH_DISABLED=1",
+    // A container sets $PORT, so the door binds 0.0.0.0 — a PUBLIC bind, where
+    // KSOR_AUTH_DISABLED alone is deliberately not enough ("the loopback-dev
+    // flag, not a licence to serve the corpus to the internet with no auth").
+    // This walk accepts that risk explicitly, exactly as a public deployment
+    // must. The refusal is the posture working: it is what this job first hit.
+    "-e",
+    "KSOR_ALLOW_PUBLIC_UNAUTHENTICATED=1",
     "-e",
     "KSOR_SNAPSHOT_KEYS=k1=0123456789abcdef0123456789abcdef",
     IMAGE,


### PR DESCRIPTION
## Problem

A KSoR has two surfaces and only one of them could be deployed. `ksor init`
emitted a `vercel.json` that built the static site and nothing else, so an
adopter who climbed to the served MCP rung — the surface that *is* the product —
had to invent a container recipe before they could put it anywhere.

That gap also hid three things nothing in the repo said out loud: the site build
needs `KSOR_DB_URL` once a `database:` block exists, `ksor serve` refuses to boot
unauthenticated, and **deploying does not publish** — a first deploy with no
ingest serves an empty record.

## Solution

`ksor init` now emits `Dockerfile` and `.dockerignore`, and `vercel.json`
declares both services behind one domain (`/mcp`, `/health`, `/ready` and the
RFC 9728 document to the door; everything else to the site).

The Dockerfile **names no host**. It installs the pinned `@panaversity/ksor`,
honours `$PORT`, and runs `ksor serve`, so the same image runs on Cloud Run, Fly,
Render, ECS, Kubernetes or a VPS. `vercel.json` points *at* that file rather than
replacing it, which is what keeps "vendor-free is the ownership argument" true in
the artifact and not only in the prose.

Adding two root files needed a **decision 8 revision** (the scaffold root set is
closed at birth), recorded in AGENTS.md alongside the `.env.example` precedent.

## Verified live, and the verification paid for itself

Deployed to a real Vercel project against Neon before any of it shipped. A
project-level `trailingSlash: true` — harmless while the config was static-only —
**308-redirected every door route, including `POST /mcp`**. Shipping the config
from reasoning alone would have broken the MCP endpoint of every adopter who
deployed it. Removed; the site's own Next config already sets it where it
belongs.

After the fix, on one domain: `/` and `/docs/…` serve the site, `/health` and
`/ready` answer from the door, and `POST /mcp` returns a real MCP `initialize`
plus cited hits from the active generation.

## Behavior

- **Two guards, not just a template.** One test asserts the emitted Dockerfile
  names no vendor and that `vercel.json` defers to it; another asserts the image
  excludes `.env`, `knowledge/` and `system/` — governance properties, not build
  hygiene (a baked DSN is published to anyone who can pull the image; a copied
  corpus implies the container reads it, and it never does).
- **A new CI job builds the emitted image, boots it against real Postgres and
  asks it a question over MCP** — plain Docker, no hosting vendor. It installs
  the *local* build and asserts its Dockerfile differs from the emitted one by
  exactly the line that brings the tarball in, so it can never drift into testing
  a different recipe than adopters get.
- **`docs/deploying.md`** — both surfaces onto a host, the configuration each
  needs, why the site build also needs the DSN, and what a cold start costs
  (measured: ~1.7s warm, ~9.1s cold, 81 documents / 6,963 chunks).
- **`docs/ingesting.md`** — the generation model, why serving does not publish,
  where ingest belongs (never inside the container: a 6,963-chunk first ingest
  measured ~50 minutes, an order of magnitude past any serverless timeout), and
  how the abstention gate gets turned on.
- **Scaffold `pnpm-workspace.yaml` drops the `@google/genai` and `protobufjs`
  build-script denials.** The provider speaks REST now (#54), so neither package
  is installed at all and the entries described a dependency we do not have.

## Not in scope

Docusaurus component support (#35) — the deferred `:::tip` / `<Quiz>` work. It
surfaced during this PR's live deploy, where a corpus carrying those directives
failed the site build; the door half deployed fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
