### PR TITLE
Get the registration file into the container image

### DIFF
--- a/.changeset/gateway-reaches-the-image.md
+++ b/.changeset/gateway-reaches-the-image.md
@@ -1,0 +1,21 @@
+---
+"@panaversity/ksor": patch
+---
+
+Fix the container serving the DEFAULT tool surface while the repository said
+otherwise.
+
+`.dockerignore` excluded all of `system/` — correct when that directory held only
+the website, and wrong the moment the door's own registration moved into
+`system/gateways/`. The file never reached the image, so a record that had
+renamed its tools, dropped one, or written what it covers was deployed serving
+none of it. Nothing went red: the door booted, `/health` was green, searches
+returned cited hits, and only `tools/list` betrayed it.
+
+It now excludes `system/site/`, and the Dockerfile copies the project rather than
+naming files one at a time — which is how the door came to ship without the very
+file that shapes its tool surface.
+
+The container acceptance job now writes a customized registration before building
+the image and asserts the served tool is the one that file names. Found by
+deploying and looking at `tools/list`, which is the only thing that would have.

--- a/packages/ksor/src/init.integration.test.ts
+++ b/packages/ksor/src/init.integration.test.ts
@@ -639,7 +639,11 @@ describe("ksor init — scaffold contents (spec: emitted-tree contract)", () => 
 
     expect(lines).toContain(".env");
     expect(lines).toContain("knowledge/");
-    expect(lines).toContain("system/");
+    // The SITE, not all of system/: system/gateways/ carries the door's own
+    // registration and must reach the image. Excluding it shipped a container
+    // that served the default tool surface while the repo said otherwise.
+    expect(lines).toContain("system/site/");
+    expect(lines).not.toContain("system/");
     expect(lines).toContain("node_modules/");
     // The example is documentation, not a secret, and the .env* rule would
     // otherwise take it — the same carve-out .gitignore makes.

--- a/packages/ksor/templates/scaffold/Dockerfile
+++ b/packages/ksor/templates/scaffold/Dockerfile
@@ -22,10 +22,12 @@ WORKDIR /app
 COPY package.json ./
 RUN npm install --omit=dev --no-audit --no-fund
 
-# The record's identity and configuration. The CORPUS is deliberately absent:
-# the door serves from Postgres, and knowledge/ belongs to the build that
-# published it — see .dockerignore.
-COPY instance.md ./
+# The record's identity, configuration, and its MCP registration
+# (system/gateways/). What is deliberately ABSENT is decided in .dockerignore —
+# the corpus, the website and every secret — rather than by listing files here:
+# naming them one at a time is how the door came to ship without the very file
+# that shapes its tool surface (found live).
+COPY . ./
 
 # Most container hosts inject PORT; 80 is a sane default when nothing does.
 ENV PORT=80

--- a/packages/ksor/templates/scaffold/dockerignore
+++ b/packages/ksor/templates/scaffold/dockerignore
@@ -11,8 +11,11 @@
 # suggest the container reads it. It does not.
 knowledge/
 
-# The website. It is the OTHER surface, built and hosted separately.
-system/
+# The website — the OTHER surface, built and hosted separately. NOT all of
+# system/: system/gateways/ holds this door's own registration, and excluding
+# it made the container silently serve the default tool surface while the
+# repository said otherwise (found live).
+system/site/
 
 # Build and tooling noise.
 node_modules/

--- a/scripts/container-acceptance.mjs
+++ b/scripts/container-acceptance.mjs
@@ -242,10 +242,16 @@ try {
       clientInfo: { name: "container-acceptance", version: "1" },
     },
   });
-  if (init.result?.serverInfo?.name !== "ksor") {
-    fail(`initialize did not answer as ksor: ${JSON.stringify(init).slice(0, 300)}`);
+  // The server NAME comes from the registration file, so this is already the
+  // first evidence that the file reached the image: "ksor" would mean it did not.
+  const served = init.result?.serverInfo;
+  if (served?.name !== "acceptance") {
+    fail(
+      `initialize answered as ${JSON.stringify(served?.name)} — the registration file did ` +
+        `not reach the image, so the door fell back to the compiled default`,
+    );
   }
-  console.log("initialize: ksor", init.result.serverInfo.version);
+  console.log(`initialize: ${served.name} ${served.version} — from the registration file`);
 
   // The tool the REGISTRATION FILE names — not the default. If system/gateways/
   // never reached the image, this is "search" and the assertion says so.

--- a/scripts/container-acceptance.mjs
+++ b/scripts/container-acceptance.mjs
@@ -134,6 +134,28 @@ try {
   ksor(["grant", "--instance", "instance.md"]);
   ksor(["ingest", "--instance", "instance.md", "--knowledge", "knowledge", "--flip"]);
 
+  // 4b. Customize the tool surface, so the walk proves the registration file
+  //     actually REACHES the image. It did not once: .dockerignore excluded all
+  //     of system/, the door fell back to the compiled default, and every test
+  //     stayed green because none of them looked at the served tool names.
+  writeFileSync(
+    path.join(project, "system", "gateways", "content.ts"),
+    "import { FLOOR, McpServer, READ_ONLY, SEARCH_OUTPUT, composeInstructions, searchHandler, z }\n" +
+      '  from "@panaversity/ksor/gateway";\n' +
+      "export default function buildGateway(ctx, version) {\n" +
+      '  const server = new McpServer({ name: "acceptance", version },\n' +
+      "    { instructions: composeInstructions(ctx.instance.instructions) });\n" +
+      '  server.registerTool("search_the_record", {\n' +
+      '    title: "Search",\n' +
+      "    description: `Acceptance corpus.\\n\\n${FLOOR.search}`,\n" +
+      "    inputSchema: z.object({ query: z.string(), k: z.number().int().min(1).max(50).default(2) }),\n" +
+      "    outputSchema: SEARCH_OUTPUT,\n" +
+      "    annotations: READ_ONLY,\n" +
+      "  }, searchHandler(ctx));\n" +
+      "  return server;\n" +
+      "}\n",
+  );
+
   // 5. Build the emitted Dockerfile, plus exactly one line for the tarball.
   const emitted = readFileSync(path.join(project, "Dockerfile"), "utf8");
   const INSERT = "COPY ksor-local.tgz ./\n";
@@ -225,19 +247,17 @@ try {
   }
   console.log("initialize: ksor", init.result.serverInfo.version);
 
-  const outline = await mcp({
-    jsonrpc: "2.0",
-    id: 2,
-    method: "tools/call",
-    params: { name: "outline", arguments: {} },
-  });
-  const structured = outline.result?.structuredContent;
-  if (!structured) fail(`outline returned nothing: ${JSON.stringify(outline).slice(0, 400)}`);
-  const nodes = structured.nodes ?? [];
-  if (nodes.length === 0) {
-    fail(`the outline carries no record: ${JSON.stringify(structured).slice(0, 400)}`);
+  // The tool the REGISTRATION FILE names — not the default. If system/gateways/
+  // never reached the image, this is "search" and the assertion says so.
+  const listed = await mcp({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} });
+  const names = (listed.result?.tools ?? []).map((t) => t.name);
+  if (names.length !== 1 || names[0] !== "search_the_record") {
+    fail(
+      `the container served ${JSON.stringify(names)} — the registration file did not reach ` +
+        `the image, so the door fell back to the compiled default`,
+    );
   }
-  console.log(`outline: ${nodes.length} nodes, first "${nodes[0].title}"`);
+  console.log(`tools/list: ${JSON.stringify(names)} — the registration reached the image`);
 
   // The guarantee, not merely a reply: a search must come back CITED. Provenance
   // is what separates this from any other retrieval server, so it is what the
@@ -246,12 +266,17 @@ try {
     jsonrpc: "2.0",
     id: 3,
     method: "tools/call",
-    params: { name: "search", arguments: { query: "what is a knowledge system of record", k: 3 } },
+    params: {
+      name: "search_the_record",
+      arguments: { query: "what is a knowledge system of record" },
+    },
   });
   const found = search.result?.structuredContent;
   if (!found) fail(`search returned nothing: ${JSON.stringify(search).slice(0, 400)}`);
   const hits = found.hits ?? [];
   if (hits.length === 0) fail(`search found nothing: ${JSON.stringify(found).slice(0, 400)}`);
+  // The file's own default is k=2; nothing asked for a count, so the file decided.
+  if (hits.length > 2) fail(`the file's k=2 default was ignored: ${hits.length} hits`);
   for (const hit of hits) {
     const provenance = hit.provenance ?? {};
     if (!provenance.stable_id || provenance.generation === undefined) {
@@ -259,9 +284,10 @@ try {
     }
   }
   console.log(
-    `search: ${hits.length} cited hits, gate=${found.gate}, ` +
+    `search: ${hits.length} cited hits (file default k=2), gate=${found.gate}, ` +
       `first ${hits[0].provenance.stable_id} gen=${hits[0].provenance.generation}`,
   );
+
   // 8. And the claim the whole job exists for.
   const body = emitted
     .split("\n")


### PR DESCRIPTION
## Problem

A deployed container served the **default** tool surface while the repository said
otherwise. A record that had renamed its tools, dropped one, or written what it
covers deployed with none of it applied.

`.dockerignore` excluded all of `system/` — correct when that directory held only
the website, and wrong the moment the door's own registration moved into
`system/gateways/` (#106). The `Dockerfile` also copied only `package.json` and
`instance.md`, so even without the ignore rule the file would not have arrived.

Two changes that were each correct alone.

**Nothing went red.** The door booted, `/health` was green, searches returned
cited hits with real provenance. The only symptom was `tools/list` showing
`["search","outline","read"]` for a project whose registration named
`search_the_book` and served one tool.

## Solution

- `.dockerignore` excludes `system/site/`, not `system/`.
- The `Dockerfile` copies the project and lets `.dockerignore` decide what is
  excluded, rather than naming files one at a time — which is exactly how the door
  came to ship without the file that shapes its surface.

## Behavior

The container acceptance job now writes a **customized** registration before
building the image, and asserts:

- the served tool is `search_the_record` — the name that file gives it. If the
  registration does not reach the image this reads `["search","outline","read"]`
  and the failure says so.
- the file's own `k: 2` default is honoured when the caller asks for no count.
- hits still come back cited, with `stable_id` and `generation`.

`init.integration.test.ts` pins `system/site/` and asserts `system/` is *not*
excluded.

Found by deploying 0.0.24 live and reading `tools/list` — the only thing that
would have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
