### PR TITLE
Bound the container image with a deny-all manifest

### DIFF
--- a/.changeset/bound-the-image.md
+++ b/.changeset/bound-the-image.md
@@ -1,0 +1,21 @@
+---
+"@panaversity/ksor": patch
+---
+
+Bound the container image: `.dockerignore` now denies everything and allows only
+what the door needs.
+
+The previous shape listed what to exclude, which cannot bound an image — it can
+only exclude what someone thought of. A build output, a cache, a vendored
+dependency or a backup directory in the project root all rode in, and the failure
+arrived as a container registry rejecting the push (`PAYLOAD_TOO_LARGE`) rather
+than as anything about the file that was added.
+
+Now: `*`, then `!package.json`, `!instance.md`, and `system/gateways/` — this
+door's own MCP registration. Everything else stays out, including the corpus (the
+door serves from Postgres), the website (a separately hosted surface), and every
+`.env` (a DSN baked into a layer is published to anyone who can pull the image).
+
+The container acceptance job now reports the built image's size and fails past a
+ceiling, so an allow-list that stops bounding it goes red here rather than at
+someone's deploy.

--- a/packages/ksor/src/init.integration.test.ts
+++ b/packages/ksor/src/init.integration.test.ts
@@ -631,23 +631,33 @@ describe("ksor init — scaffold contents (spec: emitted-tree contract)", () => 
   // are governance properties, not build hygiene: a corpus copied in suggests
   // the container reads it (it reads Postgres), and a baked .env publishes the
   // DSN to anyone who can pull the image.
-  it("excludes secrets, the corpus, and the site from the image", () => {
+  it("ships a deny-all image manifest that admits only what the door needs", () => {
     const dir = workDir();
     runInit(["my-sor"], dir);
     const ignore = readFileSync(path.join(dir, "my-sor", ".dockerignore"), "utf8");
-    const lines = ignore.split("\n").map((l) => l.trim());
+    // Directives only — the file is mostly comments explaining each choice.
+    const lines = ignore
+      .split("\n")
+      .map((l) => l.trim())
+      .filter((l) => l !== "" && !l.startsWith("#"));
 
-    expect(lines).toContain(".env");
-    expect(lines).toContain("knowledge/");
-    // The SITE, not all of system/: system/gateways/ carries the door's own
-    // registration and must reach the image. Excluding it shipped a container
-    // that served the default tool surface while the repo said otherwise.
-    expect(lines).toContain("system/site/");
-    expect(lines).not.toContain("system/");
-    expect(lines).toContain("node_modules/");
-    // The example is documentation, not a secret, and the .env* rule would
-    // otherwise take it — the same carve-out .gitignore makes.
-    expect(lines).toContain("!.env.example");
+    // DENY-ALL, then allow. An exclude-list can only exclude what someone
+    // thought of; a build output or a backup directory in the project root then
+    // rides into the image and the failure surfaces as a registry rejecting the
+    // push (found live). The allow-list bounds it regardless of what is lying
+    // around.
+    expect(lines[0]).toBe("*");
+    expect(lines).toContain("!package.json");
+    expect(lines).toContain("!instance.md");
+    // The door's own registration must reach the image, or the container serves
+    // the default surface while the repository says otherwise.
+    expect(lines).toContain("!system");
+    expect(lines).toContain("system/*");
+    expect(lines).toContain("!system/gateways");
+    // And the things that must NOT: nothing re-admits them.
+    for (const never of ["!.env", "!knowledge", "!system/site", "!node_modules"]) {
+      expect(lines, `${never} must never be allowed back in`).not.toContain(never);
+    }
   });
 
   it("CLAUDE.md is a one-line pointer file, never a symlink", () => {

--- a/packages/ksor/templates/scaffold/dockerignore
+++ b/packages/ksor/templates/scaffold/dockerignore
@@ -1,29 +1,32 @@
-# Keep the serving image to what serving needs.
+# DENY EVERYTHING, then allow exactly what the door needs.
+#
+# The inverse — listing what to exclude — cannot bound the image, because it can
+# only exclude what someone thought of. A build output, a cache, a backup
+# directory or a vendored dependency in the project root all end up inside, and
+# the failure arrives as a registry rejecting the push rather than as anything
+# about the file you added (found live: PAYLOAD_TOO_LARGE).
+#
+# So: nothing ships unless it is named here.
+*
 
-# Secrets. The image takes its configuration from the environment at RUN time;
-# baking a .env into a layer publishes it to anyone who can pull the image.
-.env
-.env.*
-!.env.example
+# The manifest, which pins @panaversity/ksor and is what `npm install` reads.
+!package.json
 
-# The corpus. The door serves from Postgres — knowledge/ was published by
-# `ksor ingest` before this container ever started, and copying it in would
-# suggest the container reads it. It does not.
-knowledge/
+# The record's identity and configuration. Its prose is the MCP server's
+# instructions, so the door genuinely needs the file.
+!instance.md
 
-# The website — the OTHER surface, built and hosted separately. NOT all of
-# system/: system/gateways/ holds this door's own registration, and excluding
-# it made the container silently serve the default tool surface while the
-# repository said otherwise (found live).
-system/site/
+# This door's own MCP registration — what its tools are called, what it says it
+# covers, and which of them exist. Excluding it makes the container serve the
+# default surface while your repository says otherwise.
+!system
+system/*
+!system/gateways
 
-# Build and tooling noise.
-node_modules/
-.git/
-.github/
-.agents/
-.claude/
-.gemini/
-*.log
-.DS_Store
-.ksor-denylist.json
+# Deliberately NOT here, and each for a reason:
+#   .env          configuration arrives from the environment at run time; a DSN
+#                 baked into a layer is published to anyone who can pull it.
+#   knowledge/    the door serves from Postgres. Copying the corpus in would
+#                 suggest the container reads it, and it never does.
+#   system/site/  the other surface, built and hosted separately.
+#   node_modules/ installed inside the image, from the manifest above.

--- a/scripts/container-acceptance.mjs
+++ b/scripts/container-acceptance.mjs
@@ -165,6 +165,17 @@ try {
   if (overlay.replace(INSERT, "") !== emitted) fail("the overlay changed more than one line");
   writeFileSync(path.join(project, "Dockerfile.citest"), overlay);
 
+  // The emitted .dockerignore DENIES everything not explicitly allowed, which
+  // correctly excludes the local tarball this walk injects. Allow it for the
+  // test build only — appended to the scaffold's copy in a temp directory, so
+  // the shipped file is untouched and `init.integration.test.ts` still asserts
+  // the real one. If this line ever fails to help, the deny-all changed shape.
+  const ignorePath = path.join(project, ".dockerignore");
+  writeFileSync(
+    ignorePath,
+    `${readFileSync(ignorePath, "utf8")}\n# CI only: the locally packed build under test.\n!ksor-local.tgz\n`,
+  );
+
   run("docker", ["build", "-f", "Dockerfile.citest", "-t", IMAGE, "."], {
     cwd: project,
     stdio: "inherit",

--- a/scripts/container-acceptance.mjs
+++ b/scripts/container-acceptance.mjs
@@ -170,6 +170,23 @@ try {
     stdio: "inherit",
   });
 
+  // An image the registry refuses is a failure that arrives from the HOST, long
+  // after the change that caused it — a build output or a backup directory in
+  // the project root riding in through a permissive .dockerignore (found live:
+  // PAYLOAD_TOO_LARGE). The allow-list is what bounds this; the number is a
+  // tripwire on the allow-list, not a performance target.
+  const sizeBytes = Number(
+    run("docker", ["image", "inspect", IMAGE, "--format", "{{.Size}}"]).trim(),
+  );
+  const sizeMb = Math.round(sizeBytes / 1_000_000);
+  console.log(`image: ${sizeMb} MB`);
+  if (sizeMb > 400) {
+    fail(
+      `the image is ${sizeMb} MB. Something in the project root is riding in — ` +
+        "check .dockerignore still denies everything it does not explicitly allow",
+    );
+  }
+
   // 6. Boot it. --network host so the container reaches the Postgres service
   //    the same way the ingest above did.
   container = run("docker", [


### PR DESCRIPTION
## Problem

`COPY . ./` plus an exclude-list cannot bound an image — an exclude-list only
excludes what someone thought of. A built site, a cache, a vendored dependency or
a backup directory in the project root all ride in.

The failure arrives from the **host**, not from this repo: a container registry
rejecting the push with `PAYLOAD_TOO_LARGE`, long after whatever was added.
Found live deploying 0.0.25.

## Solution

`.dockerignore` denies everything, then allows exactly what the door needs:

```
*
!package.json
!instance.md
!system
system/*
!system/gateways
```

The corpus stays out (the door serves from Postgres), the website stays out (a
separately hosted surface), every `.env` stays out (a DSN in a layer is published
to anyone who can pull the image) — each with the reason written beside it.

## Behavior

- `init.integration.test.ts` asserts the deny-all shape: `*` is the first
  directive, the three allows are present, and nothing re-admits `.env`,
  `knowledge`, `system/site` or `node_modules`.
- The container acceptance job reports the built image size and **fails past a
  ceiling**, so an allow-list that stops bounding it goes red in CI rather than at
  someone's deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)