### PR TITLE
Name what enters the image, because .dockerignore is not universal

### DIFF
--- a/.changeset/dockerfile-names-what-it-copies.md
+++ b/.changeset/dockerfile-names-what-it-copies.md
@@ -1,0 +1,20 @@
+---
+"@panaversity/ksor": patch
+---
+
+The emitted `Dockerfile` names the files it copies instead of `COPY . ./`.
+
+**A `.dockerignore` is not honoured by every build host.** Vercel's container
+builder ignores it, so `COPY . ./` swept in `node_modules` and the built site —
+about a gigabyte — and the deploy failed with the registry rejecting the push as
+`PAYLOAD_TOO_LARGE`. The error arrives from the host and says nothing about the
+file that caused it.
+
+Naming what enters the image is the only form portable across build hosts. The
+`.dockerignore` stays as defence in depth for builders that do respect it, but it
+is no longer what bounds the image.
+
+The risk of naming files is forgetting one — which is exactly how the registration
+file came to be missing from the image two releases ago. That is covered: the
+container acceptance job boots the built image and asserts it serves the tools the
+registration names, so a forgotten file fails there rather than at a deploy.

--- a/packages/ksor/src/tarball.integration.test.ts
+++ b/packages/ksor/src/tarball.integration.test.ts
@@ -123,7 +123,14 @@ describe("published tarball", () => {
     const staged = path.join(workDir(), "pkg");
     cpSync(pkgDir, staged, {
       recursive: true,
-      filter: (src) => path.basename(src) !== "node_modules",
+      // Also skip the init suite's fake installs. They are created and removed
+      // INSIDE packages/ksor while vitest runs files in parallel, so a copy that
+      // walks into one mid-teardown fails ENOENT — the residual half of the
+      // 2026-08-18 flake, seen again 2026-08-23.
+      filter: (src) => {
+        const base = path.basename(src);
+        return base !== "node_modules" && !base.startsWith("ksor-fakeinstall-");
+      },
     });
     const probe = path.join(staged, "templates", "scaffold", "system", "site", "probe.tsbuildinfo");
     writeFileSync(probe, "transient\n");

--- a/packages/ksor/templates/scaffold/Dockerfile
+++ b/packages/ksor/templates/scaffold/Dockerfile
@@ -22,12 +22,16 @@ WORKDIR /app
 COPY package.json ./
 RUN npm install --omit=dev --no-audit --no-fund
 
-# The record's identity, configuration, and its MCP registration
-# (system/gateways/). What is deliberately ABSENT is decided in .dockerignore —
-# the corpus, the website and every secret — rather than by listing files here:
-# naming them one at a time is how the door came to ship without the very file
-# that shapes its tool surface (found live).
-COPY . ./
+# The record's identity and configuration, and this door's own MCP registration.
+#
+# NAMED, not `COPY . ./`. A .dockerignore is not honoured by every builder —
+# Vercel's is not, and `COPY . ./` there swept in node_modules and the built
+# site, producing a registry push rejected as PAYLOAD_TOO_LARGE (found live).
+# Naming what enters the image is the only form that is portable across build
+# hosts. The risk of naming things is forgetting one; that is covered by a test
+# which boots the built image and asserts it serves the tools this file names.
+COPY instance.md ./
+COPY system/gateways/ ./system/gateways/
 
 # Most container hosts inject PORT; 80 is a sane default when nothing does.
 ENV PORT=80

--- a/packages/ksor/templates/scaffold/dockerignore
+++ b/packages/ksor/templates/scaffold/dockerignore
@@ -1,5 +1,10 @@
 # DENY EVERYTHING, then allow exactly what the door needs.
 #
+# Defence in depth, NOT the bound. The Dockerfile names the files it copies,
+# because a .dockerignore is not honoured by every build host — Vercel's is
+# not. This file protects local `docker build` and every builder that does
+# respect it; the Dockerfile protects the rest.
+#
 # The inverse — listing what to exclude — cannot bound the image, because it can
 # only exclude what someone thought of. A build output, a cache, a backup
 # directory or a vendored dependency in the project root all end up inside, and


### PR DESCRIPTION
## Problem

The emitted `Dockerfile` used `COPY . ./` and relied on `.dockerignore` to bound
the image. **Vercel's container builder does not honour `.dockerignore`**, so the
copy swept in everything.

Measured on the failing project: `node_modules` **496 MB**, `system/` **643 MB**.
The deploy died with the container registry rejecting the push:

```
StatusCode: 413, "Request Entity Too Large ... PAYLOAD_TOO_LARGE"
```

An error that arrives from the host and says nothing about the cause.

## Solution

Name the files:

```dockerfile
COPY package.json ./
RUN npm install --omit=dev --no-audit --no-fund
COPY instance.md ./
COPY system/gateways/ ./system/gateways/
```

Verified: the same project deploys successfully with this form.

`.dockerignore` keeps its deny-all shape as defence in depth for builders that do
respect it — and its comment now says so, rather than claiming to be what bounds
the image.

## On reversing my own previous change

The last change moved to `COPY . ./` reasoning that "naming files one at a time is
how the door came to ship without the very file that shapes its tool surface."
That worry was right; the remedy was wrong. The remedy is the **container
acceptance test**, which boots the built image and asserts it serves the tools the
registration names — a forgotten file fails there, not at someone's deploy.

## Live state

Deployed and verified on the fixed form:

- `tools/list` → `["search_the_book"]`, **5,500 bytes** against the default surface's
  11,960 — ~1,615 tokens saved every session
- the record's `covers` prose first, framework floor intact
- the file's `k: 3` honoured; hits cited with `stable_id` and `generation`

🤖 Generated with [Claude Code](https://claude.com/claude-code)