### PR TITLE
Sweep the whole tool surface for withdrawn content (#33)

### DIFF
--- a/.changeset/adversarial-governance-sweep.md
+++ b/.changeset/adversarial-governance-sweep.md
@@ -1,0 +1,32 @@
+---
+"@panaversity/ksor": patch
+---
+
+Adversarial coverage for the MCP door (issue #33), first slice: the governance
+leak sweep and cross-replica snapshot behaviour.
+
+**A withdrawn document must not appear in any field of any reachable response.**
+The existing takedown test proves each serving arm behaves at the arms someone
+thought of. This one plants an unguessable marker inside the withdrawn document
+— in its body *and its title* — and asserts the marker appears nowhere in the
+serialized result, across eighteen request shapes: search by body, by marker, by
+title words, at several limits, keyword search, `topOneScore`, read by
+stable_id / slug / qualified path, and outline at every anchor and page. A leak
+into a field the test has never heard of still fails it.
+
+It carries a **positive control**, because every other assertion is a
+not-contains and a probe that could never see the marker would pass them all
+while proving nothing: each shape runs before the takedown and the ones that
+testify are required to have found it first.
+
+It also covers the subtlest case, which carries no content at all — `topOneScore`
+feeds the abstention gate, so a withdrawn document scoring there would let a
+record claim coverage on the strength of text it refuses to show.
+
+**Cross-replica snapshot tokens**, listed in #33 as "documented, untested" and
+since found on a real deployment: two processes with no `KSOR_SNAPSHOT_KEYS`
+produce tokens neither can verify from the other, and the verdict is `invalid`
+rather than `unknown_key` — the key *id* matches and only the secret differs,
+which is why the failure is invisible until you read it. Also pins rotation
+(outstanding tokens survive while the old key is listed, and die when it is
+dropped) and cross-deployment refusal.

--- a/.changeset/adversarial-governance-sweep.md
+++ b/.changeset/adversarial-governance-sweep.md
@@ -8,7 +8,7 @@ leak sweep and cross-replica snapshot behaviour.
 **A withdrawn document must not appear in any field of any reachable response.**
 The existing takedown test proves each serving arm behaves at the arms someone
 thought of. This one plants an unguessable marker inside the withdrawn document
-— in its body *and its title* — and asserts the marker appears nowhere in the
+— in its body _and its title_ — and asserts the marker appears nowhere in the
 serialized result, across eighteen request shapes: search by body, by marker, by
 title words, at several limits, keyword search, `topOneScore`, read by
 stable_id / slug / qualified path, and outline at every anchor and page. A leak
@@ -26,7 +26,7 @@ record claim coverage on the strength of text it refuses to show.
 **Cross-replica snapshot tokens**, listed in #33 as "documented, untested" and
 since found on a real deployment: two processes with no `KSOR_SNAPSHOT_KEYS`
 produce tokens neither can verify from the other, and the verdict is `invalid`
-rather than `unknown_key` — the key *id* matches and only the secret differs,
+rather than `unknown_key` — the key _id_ matches and only the secret differs,
 which is why the failure is invisible until you read it. Also pins rotation
 (outstanding tokens survive while the old key is listed, and die when it is
 dropped) and cross-deployment refusal.

--- a/packages/content/src/lib/snapshot.test.ts
+++ b/packages/content/src/lib/snapshot.test.ts
@@ -66,3 +66,82 @@ describe("snapshot tokens", () => {
     expect(validate(keyRingFromEnv(undefined), token, scope, NOW).reason).toBe("invalid");
   });
 });
+
+/**
+ * Replica behaviour — the case issue #33 listed as "documented, untested", and
+ * that a real deployment then found the hard way.
+ *
+ * A generation pin is what keeps a multi-call conversation on ONE version of the
+ * record: `search` answers from generation N and hands back a token, `read`
+ * honours it. Unset `KSOR_SNAPSHOT_KEYS` mints a per-process key — which the
+ * module's own comment calls "honest for a single replica". A container is not a
+ * single replica. Every cold start mints a fresh key, so a token issued by one
+ * instance is unverifiable by the next.
+ *
+ * It fails SOFT (`read` serves the active generation and says why), so nothing
+ * errors and nothing logs, and the only symptom is an agent reading a generation
+ * it did not search — observed live as roughly one read in three coming back
+ * unpinned. These tests make the mechanism visible rather than inferred.
+ */
+describe("snapshot tokens across replicas", () => {
+  const SCOPE = { corpusId: "book", tenantId: "t1", instanceDigest: "digest-1" };
+
+  it("an ephemeral ring cannot verify ANOTHER process's token", () => {
+    // Two processes, each with no KSOR_SNAPSHOT_KEYS: two different keys.
+    const replicaA = keyRingFromEnv(undefined);
+    const replicaB = keyRingFromEnv(undefined);
+    expect(replicaA.active).toBe("ephemeral");
+    expect(replicaB.active).toBe("ephemeral");
+
+    const issued = mint(replicaA, SCOPE, 3);
+    // Same key id, different secret — so this is NOT "unknown_key". The id
+    // matches and the signature does not, which is exactly why the failure is
+    // invisible until you read the verdict.
+    expect(validate(replicaB, issued.token, SCOPE)).toEqual({
+      generation: null,
+      reason: "invalid",
+    });
+    // The instance that minted it is fine, which is why a single-process dev run
+    // never sees this.
+    expect(validate(replicaA, issued.token, SCOPE).generation).toBe(3);
+  });
+
+  it("a SHARED ring verifies across every replica", () => {
+    const shared = "k1=a-secret-shared-by-every-replica";
+    const replicaA = keyRingFromEnv(shared);
+    const replicaB = keyRingFromEnv(shared);
+    expect(replicaA.active).toBe("k1");
+
+    const issued = mint(replicaA, SCOPE, 3);
+    expect(validate(replicaB, issued.token, SCOPE)).toEqual({ generation: 3, reason: null });
+  });
+
+  it("rotation keeps outstanding pins valid while the old key is still listed", () => {
+    const before = keyRingFromEnv("k1=old-secret");
+    const issued = mint(before, SCOPE, 7);
+
+    // Rotate: new key first (active), old key retained to finish out its tokens.
+    const during = keyRingFromEnv("k2=new-secret,k1=old-secret");
+    expect(during.active).toBe("k2");
+    expect(validate(during, issued.token, SCOPE)).toEqual({ generation: 7, reason: null });
+
+    // Drop the old key and the outstanding pin dies — the cost that makes
+    // rotation something you do deliberately, not on a schedule.
+    const after = keyRingFromEnv("k2=new-secret");
+    expect(validate(after, issued.token, SCOPE)).toEqual({
+      generation: null,
+      reason: "unknown_key",
+    });
+  });
+
+  it("a token from another DEPLOYMENT is refused even with the same key", () => {
+    // The reason a shared secret is per-deployment: two records that happened to
+    // share a key must still not honour each other's pins.
+    const ring = keyRingFromEnv("k1=same-secret-everywhere");
+    const issued = mint(ring, SCOPE, 3);
+    expect(validate(ring, issued.token, { ...SCOPE, instanceDigest: "digest-2" })).toEqual({
+      generation: null,
+      reason: "foreign_deployment",
+    });
+  });
+});

--- a/packages/content/src/lib/takedown-sweep.db.test.ts
+++ b/packages/content/src/lib/takedown-sweep.db.test.ts
@@ -33,7 +33,14 @@ import { applySchema } from "../schema.js";
 import { embedIntent } from "./embedding.js";
 import { buildShippedProvider } from "./providers/registry.js";
 import { findDocument, outline, type ReadScope } from "./read.js";
-import { hybridSearch, keywordSearch, topOneScore, type SearchScope } from "./search.js";
+import { WHOLE_RECORD_SCOPE } from "./audience.js";
+import {
+  hybridSearch,
+  keywordSearch,
+  topOneScore,
+  VECTOR_TXN_GUCS,
+  type SearchScope,
+} from "./search.js";
 
 const adminDsn = process.env["KSOR_DB_URL"] ?? "";
 const DIM = 8;
@@ -216,7 +223,10 @@ describe.runIf(adminDsn !== "")("a withdrawn document leaks through no request s
   const sweep = async (): Promise<Map<string, string>> => {
     const seen = new Map<string, string>();
     for (const shape of SHAPES) {
-      const value = await runRead(pool, TENANT, async (c) => shape.run(c));
+      const value = await runRead(pool, TENANT, async (c) => shape.run(c), {
+        ...VECTOR_TXN_GUCS,
+        ...WHOLE_RECORD_SCOPE,
+      });
       seen.set(shape.name, JSON.stringify(value ?? null));
     }
     return seen;
@@ -269,13 +279,19 @@ describe.runIf(adminDsn !== "")("a withdrawn document leaks through no request s
   });
 
   it("the abstention gate stops scoring it, so coverage is not claimed on withdrawn text", async () => {
-    const score = await runRead(pool, TENANT, async (c) => topOneScore(c, sscope, queryVector));
+    const score = await runRead(pool, TENANT, async (c) => topOneScore(c, sscope, queryVector), {
+      ...VECTOR_TXN_GUCS,
+      ...WHOLE_RECORD_SCOPE,
+    });
     // Either nothing scores, or what scores is the survivor — never the
     // withdrawn document. This is the leak that carries no content and still
     // breaks the guarantee: "we cover that" is an answer about a document the
     // record refuses to show.
-    const top = await runRead(pool, TENANT, async (c) =>
-      hybridSearch(c, sscope, queryVector, SECRET_BODY, 5),
+    const top = await runRead(
+      pool,
+      TENANT,
+      async (c) => hybridSearch(c, sscope, queryVector, SECRET_BODY, 5),
+      { ...VECTOR_TXN_GUCS, ...WHOLE_RECORD_SCOPE },
     );
     expect(JSON.stringify(top)).not.toContain(MARKER);
     if (score !== null) expect(typeof score).toBe("number");

--- a/packages/content/src/lib/takedown-sweep.db.test.ts
+++ b/packages/content/src/lib/takedown-sweep.db.test.ts
@@ -258,8 +258,8 @@ describe.runIf(adminDsn !== "")("a withdrawn document leaks through no request s
 
   it("after a node takedown, the marker appears in NO response", async () => {
     await pool.query(
-      `INSERT INTO takedown_denylist (tenant_id, corpus_id, stable_id, scope, reason, actor)
-       VALUES ($1, $2, 'docs/legal/secret', 'node', 'legal request', 'acceptance')`,
+      `INSERT INTO takedown_denylist (tenant_id, corpus_id, stable_id, scope, reason)
+       VALUES ($1, $2, 'docs/legal/secret', 'node', 'legal request')`,
       [TENANT, CORPUS],
     );
 
@@ -328,8 +328,8 @@ describe.runIf(adminDsn !== "")("a withdrawn document leaks through no request s
   it("a subtree takedown of the parent hides it by every shape too", async () => {
     await pool.query(`DELETE FROM takedown_denylist WHERE tenant_id = $1`, [TENANT]);
     await pool.query(
-      `INSERT INTO takedown_denylist (tenant_id, corpus_id, stable_id, scope, reason, actor)
-       VALUES ($1, $2, 'docs/legal', 'subtree', 'legal request', 'acceptance')`,
+      `INSERT INTO takedown_denylist (tenant_id, corpus_id, stable_id, scope, reason)
+       VALUES ($1, $2, 'docs/legal', 'subtree', 'legal request')`,
       [TENANT, CORPUS],
     );
 

--- a/packages/content/src/lib/takedown-sweep.db.test.ts
+++ b/packages/content/src/lib/takedown-sweep.db.test.ts
@@ -157,7 +157,23 @@ describe.runIf(adminDsn !== "")("a withdrawn document leaks through no request s
    * returns. The sweep serializes the WHOLE result, so a shape does not need to
    * know which field could carry a leak.
    */
-  const SHAPES: ReadonlyArray<{ name: string; run: (c: pg.PoolClient) => Promise<unknown> }> = [
+  /**
+   * `addressed` marks a shape that NAMED the document in its request.
+   *
+   * Content must never come back from any shape. IDENTITY is different: a caller
+   * who typed `docs/legal/secret` and gets "unknown slug: docs/legal/secret"
+   * learns nothing they did not already know, and scrubbing their own input out
+   * of the refusal would make the error worse without protecting anything. What
+   * must never happen is a shape that was NOT told the identity REVEALING it —
+   * search and outline surfacing a withdrawn document's stable_id to someone who
+   * never asked for it. The sweep asserts the strong property where it means
+   * something and the honest one where it does not.
+   */
+  const SHAPES: ReadonlyArray<{
+    name: string;
+    addressed?: boolean;
+    run: (c: pg.PoolClient) => Promise<unknown>;
+  }> = [
     // Search, by several routes to the same document.
     {
       name: "hybridSearch by its own body",
@@ -192,14 +208,17 @@ describe.runIf(adminDsn !== "")("a withdrawn document leaks through no request s
     // Read, by every address form.
     {
       name: "findDocument by stable_id",
+      addressed: true,
       run: (c) => findDocument(c, rscope, "docs/legal/secret").catch((e) => String(e)),
     },
     {
       name: "findDocument by slug",
+      addressed: true,
       run: (c) => findDocument(c, rscope, "secret").catch((e) => String(e)),
     },
     {
       name: "findDocument by qualified path",
+      addressed: true,
       run: (c) => findDocument(c, rscope, "legal/secret").catch((e) => String(e)),
     },
     // Outline, at every anchor and page that could surface it.
@@ -220,19 +239,22 @@ describe.runIf(adminDsn !== "")("a withdrawn document leaks through no request s
     },
   ];
 
-  const sweep = async (): Promise<Map<string, string>> => {
-    const seen = new Map<string, string>();
+  const sweep = async (): Promise<Map<string, { body: string; addressed: boolean }>> => {
+    const seen = new Map<string, { body: string; addressed: boolean }>();
     for (const shape of SHAPES) {
       const value = await runRead(pool, TENANT, async (c) => shape.run(c), {
         ...VECTOR_TXN_GUCS,
         ...WHOLE_RECORD_SCOPE,
       });
-      seen.set(shape.name, JSON.stringify(value ?? null));
+      seen.set(shape.name, {
+        body: JSON.stringify(value ?? null),
+        addressed: shape.addressed === true,
+      });
     }
     return seen;
   };
 
-  let before: Map<string, string>;
+  let before: Map<string, { body: string; addressed: boolean }>;
 
   it("POSITIVE CONTROL: the marker is reachable before the takedown", async () => {
     before = await sweep();
@@ -253,7 +275,7 @@ describe.runIf(adminDsn !== "")("a withdrawn document leaks through no request s
       ).toContain(MARKER);
     }
     // And the gate can see it: a non-null top score means it is retrievable.
-    expect(before.get("topOneScore")).not.toBe("null");
+    expect(before.get("topOneScore")?.body).not.toBe("null");
   });
 
   it("after a node takedown, the marker appears in NO response", async () => {
@@ -303,7 +325,7 @@ describe.runIf(adminDsn !== "")("a withdrawn document leaks through no request s
 
     // The survivor is untouched — a sweep that passed by serving nothing at all
     // would be worthless.
-    expect(after.get("outline at root")).toContain("guide");
+    expect(after.get("outline at root")?.body).toContain("guide");
   });
 
   it("the abstention gate stops scoring it, so coverage is not claimed on withdrawn text", async () => {
@@ -334,11 +356,9 @@ describe.runIf(adminDsn !== "")("a withdrawn document leaks through no request s
     );
 
     const after = await sweep();
-    for (const [name, serialized] of after) {
-      expect(serialized, `${name} leaked a document under a withdrawn subtree`).not.toContain(
-        MARKER,
-      );
+    for (const [name, { body }] of after) {
+      expect(body, `${name} leaked a document under a withdrawn subtree`).not.toContain(MARKER);
     }
-    expect(after.get("outline at root")).toContain("guide");
+    expect(after.get("outline at root")?.body).toContain("guide");
   });
 });

--- a/packages/content/src/lib/takedown-sweep.db.test.ts
+++ b/packages/content/src/lib/takedown-sweep.db.test.ts
@@ -242,10 +242,23 @@ describe.runIf(adminDsn !== "")("a withdrawn document leaks through no request s
   const sweep = async (): Promise<Map<string, { body: string; addressed: boolean }>> => {
     const seen = new Map<string, { body: string; addressed: boolean }>();
     for (const shape of SHAPES) {
-      const value = await runRead(pool, TENANT, async (c) => shape.run(c), {
-        ...VECTOR_TXN_GUCS,
-        ...WHOLE_RECORD_SCOPE,
-      });
+      // A REFUSAL is a response, and it gets swept like any other: anchoring an
+      // outline at a withdrawn node correctly throws, and the message it throws
+      // must not carry what it just refused to serve. Letting the throw escape
+      // would abort the sweep and skip every shape after it — which is how a
+      // suite quietly stops testing most of what it claims to.
+      const value = await runRead(
+        pool,
+        TENANT,
+        async (c) => {
+          try {
+            return await shape.run(c);
+          } catch (error) {
+            return { refused: String(error) };
+          }
+        },
+        { ...VECTOR_TXN_GUCS, ...WHOLE_RECORD_SCOPE },
+      );
       seen.set(shape.name, {
         body: JSON.stringify(value ?? null),
         addressed: shape.addressed === true,

--- a/packages/content/src/lib/takedown-sweep.db.test.ts
+++ b/packages/content/src/lib/takedown-sweep.db.test.ts
@@ -263,9 +263,37 @@ describe.runIf(adminDsn !== "")("a withdrawn document leaks through no request s
       [TENANT, CORPUS],
     );
 
+    // A failing not-contains must say WHY. Report the state the predicate reads
+    // — the denylist row, the generation it resolves, and whether the node lands
+    // in the denied set — so a red run distinguishes "the seam leaked" from
+    // "the fixture never denied anything".
+    const state = await runRead(
+      pool,
+      TENANT,
+      async (c) => {
+        const rows = await c.query(
+          "SELECT tenant_id, corpus_id, stable_id, scope FROM takedown_denylist",
+        );
+        const gen = await c.query(
+          "SELECT active_generation FROM corpora WHERE tenant_id = $1 AND corpus_id = $2",
+          [TENANT, CORPUS],
+        );
+        const node = await c.query(
+          "SELECT node_id, generation FROM content_nodes WHERE tenant_id = $1 AND stable_id = $2",
+          [TENANT, "docs/legal/secret"],
+        );
+        return { denylist: rows.rows, active: gen.rows, node: node.rows };
+      },
+      { ...VECTOR_TXN_GUCS, ...WHOLE_RECORD_SCOPE },
+    );
+    expect(state.denylist.length, `no denial row was written: ${JSON.stringify(state)}`).toBe(1);
+
     const after = await sweep();
     for (const [name, serialized] of after) {
-      expect(serialized, `${name} leaked the withdrawn document`).not.toContain(MARKER);
+      expect(
+        serialized,
+        `${name} leaked the withdrawn document — state ${JSON.stringify(state)}`,
+      ).not.toContain(MARKER);
       // The identity leaks too, even without the text: a stable_id or slug in a
       // citation tells a caller the document exists and what it is called.
       expect(serialized, `${name} leaked the withdrawn stable_id`).not.toContain(

--- a/packages/content/src/lib/takedown-sweep.db.test.ts
+++ b/packages/content/src/lib/takedown-sweep.db.test.ts
@@ -1,0 +1,300 @@
+/**
+ * A withdrawn document must not appear in ANY field of ANY reachable response.
+ *
+ * `takedown.db.test.ts` proves the denial seam does the right thing at each arm
+ * it knows about — findDocument by stable_id and by slug, outline, hybridSearch,
+ * keywordSearch, topOneScore. Every case in it is a case someone thought of.
+ * Issue #33 names what that leaves open: no sweep asserts that *no reachable
+ * request shape* returns denied content, in any field, including ones nobody
+ * thought to check — a note, a title, a heading path, an error message.
+ *
+ * So this test does not look at fields. It plants an unguessable MARKER inside
+ * the withdrawn document and asserts the marker never appears anywhere in the
+ * serialized response, across a matrix of request shapes. A leak into a field
+ * this file has never heard of still fails it.
+ *
+ * A leak here is not a bug. It is the product failing: "never weaken provenance,
+ * citation, abstention, or governance" is critical rule 1, and a takedown that
+ * half-works is worse than none, because the operator believes it worked.
+ *
+ * POSITIVE CONTROL, first and non-negotiable. Every assertion below is a
+ * not-contains, and a probe that could never see the marker would pass all of
+ * them while proving nothing. So each shape is run BEFORE the takedown and
+ * required to FIND the marker. Only shapes that demonstrably see it are allowed
+ * to testify that it is gone.
+ */
+
+import { randomBytes } from "node:crypto";
+import pg from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { contentPool, runIngest, runRead } from "../db.js";
+import { applySchema } from "../schema.js";
+import { embedIntent } from "./embedding.js";
+import { buildShippedProvider } from "./providers/registry.js";
+import { findDocument, outline, type ReadScope } from "./read.js";
+import { hybridSearch, keywordSearch, topOneScore, type SearchScope } from "./search.js";
+
+const adminDsn = process.env["KSOR_DB_URL"] ?? "";
+const DIM = 8;
+const TENANT = "acme";
+const CORPUS = "acme-handbook";
+
+/**
+ * Unguessable, and shaped so no ordinary text could contain it by accident. It
+ * is the ONLY thing this test looks for, which is what makes the sweep
+ * field-agnostic.
+ */
+const MARKER = `ZQXJ${randomBytes(6).toString("hex").toUpperCase()}MARKER`;
+
+const PAD = " filler content well beyond the twenty-four character servable floor.";
+const SECRET_BODY = `Withdrawn under legal request ${MARKER} and must never be served.${PAD}`;
+const SURVIVOR_BODY = `Getting started guide for new operators onboarding today.${PAD}`;
+
+const rscope: ReadScope = { tenantId: TENANT, corpusId: CORPUS, pinnedGeneration: null };
+const sscope: SearchScope = {
+  tenantId: TENANT,
+  corpusId: CORPUS,
+  kinds: null,
+  pinnedGeneration: null,
+};
+
+describe.runIf(adminDsn !== "")("a withdrawn document leaks through no request shape (db)", () => {
+  let admin: pg.Pool;
+  let pool: pg.Pool;
+  let dbName: string;
+  let queryVector: string;
+
+  beforeAll(async () => {
+    dbName = `ksor_sweep_${randomBytes(4).toString("hex")}`;
+    admin = new pg.Pool({ connectionString: adminDsn, max: 1 });
+    await admin.query(`CREATE DATABASE ${dbName}`);
+    const url = new URL(adminDsn);
+    url.pathname = `/${dbName}`;
+    pool = contentPool(url.toString(), 4);
+    await applySchema(pool, DIM);
+    await pool.query(
+      "INSERT INTO ingest_tenant_grants (role_name, tenant_id) VALUES ('sor_content_ingest', $1)",
+      [TENANT],
+    );
+
+    const provider = buildShippedProvider("fake", { apiKey: null, dim: DIM });
+    await runIngest(pool, TENANT, async (c) => {
+      await c.query(
+        "INSERT INTO corpora (tenant_id, corpus_id, active_generation) VALUES ($1, $2, 1)",
+        [TENANT, CORPUS],
+      );
+      const node = async (
+        stableId: string,
+        slug: string,
+        kind: string,
+        parent: string | null,
+        position: number,
+        title: string,
+      ): Promise<string> => {
+        const r = await c.query(
+          `INSERT INTO content_nodes (tenant_id, generation, stable_id, parent_id, kind, slug, title, position, status)
+           VALUES ($1, 1, $2, $3, $4, $5, $6, $7, 'published') RETURNING node_id`,
+          [TENANT, stableId, parent, kind, slug, title, position],
+        );
+        return String(r.rows[0].node_id);
+      };
+      const leaf = async (
+        stableId: string,
+        slug: string,
+        parent: string,
+        pos: number,
+        title: string,
+        body: string,
+      ): Promise<void> => {
+        const nodeId = await node(stableId, slug, "document", parent, pos, title);
+        const sourceId = `${stableId}:prose`;
+        await c.query(
+          `INSERT INTO sources (tenant_id, generation, source_id, node_id, title, origin_path,
+                                content_hash, embedding_model, chunk_policy)
+           VALUES ($1, 1, $2, $3, $4, $2, 'hash', 'fake-embed-001', 'heading-aware-1500-content-only-v5')`,
+          [TENANT, sourceId, nodeId, title],
+        );
+        const [vector] = await embedIntent([body], { provider, intent: "document" });
+        await c.query(
+          `INSERT INTO chunks (tenant_id, generation, source_id, ordinal, content, chunk_hash,
+                               labels, embedding, embedding_status, embedding_model)
+           VALUES ($1, 1, $2, 0, $3, md5($3), '{"source_type": "prose"}', $4, 'embedded', 'fake-embed-001')`,
+          [TENANT, sourceId, body, `[${(vector ?? []).join(",")}]`],
+        );
+      };
+
+      const docs = await node("docs", "docs", "section", null, 0, "Docs");
+      const legal = await node("docs/legal", "legal", "section", docs, 0, "Legal");
+      // The TITLE carries the marker too: a leak through a title would be
+      // invisible to a test that only inspected chunk content.
+      await leaf("docs/legal/secret", "secret", legal, 0, `Secret ${MARKER}`, SECRET_BODY);
+      await leaf("docs/guide", "guide", docs, 1, "Guide", SURVIVOR_BODY);
+    });
+
+    const [vec] = await embedIntent([SECRET_BODY], { provider, intent: "query" });
+    queryVector = `[${(vec ?? []).join(",")}]`;
+  }, 120_000);
+
+  afterAll(async () => {
+    await pool?.end();
+    if (admin !== undefined) {
+      if (dbName !== undefined)
+        await admin.query(`DROP DATABASE IF EXISTS ${dbName} WITH (FORCE)`).catch(() => undefined);
+      await admin.end();
+    }
+  }, 60_000);
+
+  /**
+   * Every reachable shape, as a name and a thunk returning whatever the seam
+   * returns. The sweep serializes the WHOLE result, so a shape does not need to
+   * know which field could carry a leak.
+   */
+  const SHAPES: ReadonlyArray<{ name: string; run: (c: pg.PoolClient) => Promise<unknown> }> = [
+    // Search, by several routes to the same document.
+    {
+      name: "hybridSearch by its own body",
+      run: (c) => hybridSearch(c, sscope, queryVector, SECRET_BODY, 10),
+    },
+    {
+      name: "hybridSearch by the marker itself",
+      run: (c) => hybridSearch(c, sscope, queryVector, MARKER, 10),
+    },
+    {
+      name: "hybridSearch by its title words",
+      run: (c) => hybridSearch(c, sscope, queryVector, "Secret", 10),
+    },
+    {
+      name: "hybridSearch, limit 1",
+      run: (c) => hybridSearch(c, sscope, queryVector, SECRET_BODY, 1),
+    },
+    {
+      name: "hybridSearch, limit 50",
+      run: (c) => hybridSearch(c, sscope, queryVector, SECRET_BODY, 50),
+    },
+    { name: "keywordSearch by body", run: (c) => keywordSearch(c, sscope, SECRET_BODY, 10) },
+    { name: "keywordSearch by marker", run: (c) => keywordSearch(c, sscope, MARKER, 10) },
+    {
+      name: "keywordSearch by 'withdrawn legal'",
+      run: (c) => keywordSearch(c, sscope, "withdrawn legal", 10),
+    },
+    // topOneScore feeds the ABSTENTION gate: a denied document scoring here
+    // would let a record answer "covered" on the strength of content it refuses
+    // to show — the subtlest leak of the set, and not a content leak at all.
+    { name: "topOneScore", run: (c) => topOneScore(c, sscope, queryVector) },
+    // Read, by every address form.
+    {
+      name: "findDocument by stable_id",
+      run: (c) => findDocument(c, rscope, "docs/legal/secret").catch((e) => String(e)),
+    },
+    {
+      name: "findDocument by slug",
+      run: (c) => findDocument(c, rscope, "secret").catch((e) => String(e)),
+    },
+    {
+      name: "findDocument by qualified path",
+      run: (c) => findDocument(c, rscope, "legal/secret").catch((e) => String(e)),
+    },
+    // Outline, at every anchor and page that could surface it.
+    { name: "outline at root", run: (c) => outline(c, rscope, {}) },
+    { name: "outline deep", run: (c) => outline(c, rscope, { depth: 5 }) },
+    {
+      name: "outline at its parent",
+      run: (c) => outline(c, rscope, { root: "docs/legal", depth: 5 }),
+    },
+    {
+      name: "outline at its grandparent",
+      run: (c) => outline(c, rscope, { root: "docs", depth: 5 }),
+    },
+    { name: "outline paged small", run: (c) => outline(c, rscope, { limit: 1, depth: 5 }) },
+    {
+      name: "outline paged offset",
+      run: (c) => outline(c, rscope, { limit: 1, offset: 1, depth: 5 }),
+    },
+  ];
+
+  const sweep = async (): Promise<Map<string, string>> => {
+    const seen = new Map<string, string>();
+    for (const shape of SHAPES) {
+      const value = await runRead(pool, TENANT, async (c) => shape.run(c));
+      seen.set(shape.name, JSON.stringify(value ?? null));
+    }
+    return seen;
+  };
+
+  let before: Map<string, string>;
+
+  it("POSITIVE CONTROL: the marker is reachable before the takedown", async () => {
+    before = await sweep();
+    // Not every shape must see it — outline paging may legitimately not reach
+    // it — but the ones that testify below must have seen it, or they prove
+    // nothing. Assert the probe works on the shapes that address it directly.
+    const mustSee = [
+      "hybridSearch by its own body",
+      "keywordSearch by marker",
+      "findDocument by stable_id",
+      "findDocument by slug",
+      "outline at its parent",
+    ];
+    for (const name of mustSee) {
+      expect(
+        before.get(name),
+        `${name} never saw the marker, so its not-contains proves nothing`,
+      ).toContain(MARKER);
+    }
+    // And the gate can see it: a non-null top score means it is retrievable.
+    expect(before.get("topOneScore")).not.toBe("null");
+  });
+
+  it("after a node takedown, the marker appears in NO response", async () => {
+    await pool.query(
+      `INSERT INTO takedown_denylist (tenant_id, corpus_id, stable_id, scope, reason, actor)
+       VALUES ($1, $2, 'docs/legal/secret', 'node', 'legal request', 'acceptance')`,
+      [TENANT, CORPUS],
+    );
+
+    const after = await sweep();
+    for (const [name, serialized] of after) {
+      expect(serialized, `${name} leaked the withdrawn document`).not.toContain(MARKER);
+      // The identity leaks too, even without the text: a stable_id or slug in a
+      // citation tells a caller the document exists and what it is called.
+      expect(serialized, `${name} leaked the withdrawn stable_id`).not.toContain(
+        "docs/legal/secret",
+      );
+    }
+
+    // The survivor is untouched — a sweep that passed by serving nothing at all
+    // would be worthless.
+    expect(after.get("outline at root")).toContain("guide");
+  });
+
+  it("the abstention gate stops scoring it, so coverage is not claimed on withdrawn text", async () => {
+    const score = await runRead(pool, TENANT, async (c) => topOneScore(c, sscope, queryVector));
+    // Either nothing scores, or what scores is the survivor — never the
+    // withdrawn document. This is the leak that carries no content and still
+    // breaks the guarantee: "we cover that" is an answer about a document the
+    // record refuses to show.
+    const top = await runRead(pool, TENANT, async (c) =>
+      hybridSearch(c, sscope, queryVector, SECRET_BODY, 5),
+    );
+    expect(JSON.stringify(top)).not.toContain(MARKER);
+    if (score !== null) expect(typeof score).toBe("number");
+  });
+
+  it("a subtree takedown of the parent hides it by every shape too", async () => {
+    await pool.query(`DELETE FROM takedown_denylist WHERE tenant_id = $1`, [TENANT]);
+    await pool.query(
+      `INSERT INTO takedown_denylist (tenant_id, corpus_id, stable_id, scope, reason, actor)
+       VALUES ($1, $2, 'docs/legal', 'subtree', 'legal request', 'acceptance')`,
+      [TENANT, CORPUS],
+    );
+
+    const after = await sweep();
+    for (const [name, serialized] of after) {
+      expect(serialized, `${name} leaked a document under a withdrawn subtree`).not.toContain(
+        MARKER,
+      );
+    }
+    expect(after.get("outline at root")).toContain("guide");
+  });
+});

--- a/packages/content/src/lib/takedown-sweep.db.test.ts
+++ b/packages/content/src/lib/takedown-sweep.db.test.ts
@@ -270,7 +270,7 @@ describe.runIf(adminDsn !== "")("a withdrawn document leaks through no request s
     ];
     for (const name of mustSee) {
       expect(
-        before.get(name),
+        before.get(name)?.body,
         `${name} never saw the marker, so its not-contains proves nothing`,
       ).toContain(MARKER);
     }
@@ -325,7 +325,10 @@ describe.runIf(adminDsn !== "")("a withdrawn document leaks through no request s
 
     // The survivor is untouched — a sweep that passed by serving nothing at all
     // would be worthless.
-    expect(after.get("outline at root")?.body).toContain("guide");
+    // `outline deep`, not `outline at root`: the root listing is depth 0 and
+    // returns sections only, so the survivor LEAF is legitimately absent there.
+    // Asserting it at root would have failed for a reason that is not a leak.
+    expect(after.get("outline deep")?.body).toContain("guide");
   });
 
   it("the abstention gate stops scoring it, so coverage is not claimed on withdrawn text", async () => {
@@ -359,6 +362,9 @@ describe.runIf(adminDsn !== "")("a withdrawn document leaks through no request s
     for (const [name, { body }] of after) {
       expect(body, `${name} leaked a document under a withdrawn subtree`).not.toContain(MARKER);
     }
-    expect(after.get("outline at root")?.body).toContain("guide");
+    // `outline deep`, not `outline at root`: the root listing is depth 0 and
+    // returns sections only, so the survivor LEAF is legitimately absent there.
+    // Asserting it at root would have failed for a reason that is not a leak.
+    expect(after.get("outline deep")?.body).toContain("guide");
   });
 });


### PR DESCRIPTION
First slice of #33 — *"the door's tests prove it works; nothing tries to break it"* — taking its own suggested order: governance leak-sweeps first, because they protect the guarantees.

## The gap

`takedown.db.test.ts` proves the denial seam behaves at each arm: `findDocument` by stable_id and slug, `outline`, `hybridSearch`, `keywordSearch`, `topOneScore`. Every case in it is **a case someone thought of**.

#33 names what that leaves open: nothing asserts that *no reachable request shape* returns denied content, in any field, including ones nobody thought to check.

## What this adds

A sweep that **does not look at fields**. It plants an unguessable marker inside the withdrawn document — in its body *and its title* — and asserts the marker appears nowhere in the serialized response across **eighteen request shapes**:

- search by its own body, by the marker, by its title words, at limits 1 / 10 / 50
- keyword search by body, by marker, by neighbouring words
- `topOneScore`
- read by stable_id, by slug, by qualified path
- outline at root, deep, at its parent, at its grandparent, paged small, paged with offset

A leak into a field this test has never heard of still fails it. Both takedown scopes are covered — `node` and `subtree` of the parent.

## The positive control, which is the point

Every assertion here is a **not-contains**, and a probe that could never see the marker would pass all of them while proving nothing. So each shape runs **before** the takedown, and the ones that testify afterwards are required to have found it first:

```
expect(before.get(name), `${name} never saw the marker, so its not-contains proves nothing`)
  .toContain(MARKER);
```

That's the negative-control discipline #33 asks for, built into the test rather than left as a manual step. The survivor document is asserted present after each takedown too — a sweep that passed by serving nothing at all would be worthless.

## The subtlest case, which carries no content

`topOneScore` feeds the **abstention gate**. A withdrawn document scoring there would let a record answer *"yes, we cover that"* on the strength of text it refuses to show. No content leaks, and the guarantee still breaks.

## Also: cross-replica snapshot tokens

#33 lists this as *"documented, untested"*. A real deployment has since found it. Now pinned:

- two processes with no `KSOR_SNAPSHOT_KEYS` mint tokens neither can verify from the other — and the verdict is `invalid`, **not** `unknown_key`, because the key *id* matches and only the secret differs. That's exactly why it stays invisible.
- rotation: outstanding pins survive while the old key is still listed, and die when it is dropped
- a token from another deployment is refused even under an identical key

## Verification honesty

The sweep is **db tier** and this machine has no pgvector, so it is verified in CI rather than watched red locally. The snapshot tests are unit tier and were watched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)