### PR TITLE
Search the record in the language it is written in

### DIFF
--- a/.changeset/lucky-hounds-smile.md
+++ b/.changeset/lucky-hounds-smile.md
@@ -1,0 +1,28 @@
+---
+"@panaversity/ksor": patch
+---
+
+Search the record in the language it is written in.
+
+The scaffolded site pinned its search index to English tokenization. That is a
+per-language splitter regex, and English's is Latin-only — so an Urdu, Chinese,
+Japanese or Korean document indexed to **zero tokens** and could not be found,
+while its page still rendered, still appeared in the sidebar, and still appeared
+in `llms.txt`. Nothing went red. A record written in a non-Latin script was
+published complete and silently unsearchable, which broke ksor's own claim to
+hold "plain markdown, in any language you write in".
+
+The pin bought nothing in exchange. Since fumadocs-core 16.14.0 the engine is
+ZBSearch, which disables stemming and installs empty stopwords by default, so
+`english` and `multilingual` return identical results on English text —
+including the same miss (`recordings` does not find `recording`) under both.
+
+The option is removed, so the engine keeps its own `multilingual` default and
+segments every script. Existing English records are unaffected apart from a
+small index-size change: the multilingual segmenter splits hyphenated
+identifiers that the English splitter kept whole, which grows the exported index
+by roughly 2% on a technical corpus.
+
+Restoring stemming for any language remains available and is a separate,
+deliberate change — it needs a stemmer dependency and the same tokenizer handed
+to the browser, not a one-word option.

--- a/packages/ksor/src/search-language.integration.test.ts
+++ b/packages/ksor/src/search-language.integration.test.ts
@@ -1,0 +1,66 @@
+/**
+ * The search index must not pin a tokenizer language.
+ *
+ * The engine's default is `multilingual`, which segments with `Intl.Segmenter`
+ * and indexes every script. Naming a language selects a per-language splitter
+ * regex instead, and `english`'s is Latin-only — so an Urdu or Chinese document
+ * indexed under it produces ZERO tokens and cannot be found, while its page
+ * still renders, still sits in the sidebar and still appears in llms.txt.
+ * Nothing goes red. That is the "silent weakness" the record's invariants
+ * forbid, and it broke the product's own claim to hold "plain markdown, in any
+ * language they write in" for every non-Latin record.
+ *
+ * This asserts the SHIPPED BYTES, which is what a regression would look like:
+ * the option is re-added for a perceived English win it does not buy (since
+ * fumadocs-core 16.14.0 the engine is ZBSearch, which disables stemming and
+ * ships empty stopwords by default, so `english` and `multilingual` return
+ * identical results on English text).
+ *
+ * What it deliberately does NOT claim: that a non-Latin document is findable.
+ * That is a behavioural fact about the built index and belongs in the
+ * KSOR_E2E tier, which installs the real tree — see scaffold-e2e.
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const ROUTE = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "templates",
+  "scaffold",
+  "system",
+  "site",
+  "app",
+  "api",
+  "search",
+  "route.ts",
+);
+
+describe("the scaffolded search index", () => {
+  const source = readFileSync(ROUTE, "utf8");
+
+  it("names no tokenizer language, so every script indexes", () => {
+    // Matches `language:` as an option key only — the word appears in this
+    // file's own explanation of why the option is absent, and that prose must
+    // not be what keeps the test green.
+    const pinned = /^\s*language\s*:/m.exec(source);
+    expect(
+      pinned?.[0] ?? null,
+      "a named language selects a per-script splitter: a Latin-only one indexes " +
+        "an Urdu or Chinese document to zero tokens, silently. Leave the engine " +
+        "on its `multilingual` default.",
+    ).toBeNull();
+  });
+
+  it("still exports the static index the dialog downloads", () => {
+    // The option was removed, not the route: `staticGET` is what prerenders the
+    // JSON the client-side dialog fetches, and dropping it would take search out
+    // of a static export entirely.
+    expect(source).toMatch(/staticGET:\s*GET/);
+    expect(source).toMatch(/createFromSource\(\s*source\s*\)/);
+  });
+});

--- a/packages/ksor/templates/scaffold/system/site/app/api/search/route.ts
+++ b/packages/ksor/templates/scaffold/system/site/app/api/search/route.ts
@@ -5,7 +5,18 @@ import { createFromSource } from "fumadocs-core/search/server";
 // search dialog downloads and queries client-side (see app/layout.tsx).
 export const revalidate = false;
 
-export const { staticGET: GET } = createFromSource(source, {
-  // https://docs.orama.com/docs/orama-js/supported-languages
-  language: "english",
-});
+// NO `language:` option, deliberately. The engine's own default is
+// `multilingual`, which segments with `Intl.Segmenter` and indexes every script;
+// naming a language selects a per-language splitter regex instead. `english`'s
+// is Latin-only, so an Urdu or Chinese document indexed under it produces ZERO
+// tokens and is unreachable by search — while its page still renders, still sits
+// in the sidebar and still appears in llms.txt. Nothing goes red. That silently
+// broke the record's own claim to hold "plain markdown, in any language they
+// write in" (found by reading the shipped tokenizer, 2026-08-24).
+//
+// It bought nothing in exchange: since fumadocs-core 16.14.0 the engine is
+// ZBSearch, which disables stemming and ships empty stopwords by default, so
+// `english` and `multilingual` return identical results on English text.
+// Restoring stemming is a separate, larger decision — it needs a stemmer
+// dependency AND the same tokenizer handed to the browser through `initDB`.
+export const { staticGET: GET } = createFromSource(source);


### PR DESCRIPTION
## Problem

The scaffolded site pinned its search index to English tokenization:

```ts
export const { staticGET: GET } = createFromSource(source, {
  // https://docs.orama.com/docs/orama-js/supported-languages
  language: "english",
});
```

Naming a language selects a **per-language splitter regex**, and English's is Latin-only. So an Urdu, Chinese, Japanese or Korean document indexed to **zero tokens** and could not be found — while its page still rendered, still sat in the sidebar, and still appeared in `llms.txt`. Nothing went red.

A record written in a non-Latin script was therefore published complete and silently unsearchable. That is the "silent weakness" the product invariants forbid, and it made this claim false for every such record:

> Out of the box the owner is meant to touch knowledge only — plain markdown, **in any language they write in**. (AGENTS.md:61, README.md:65)

Verified directly against the pinned engine: `createTokenizer({language:'english'}).tokenize('کاروباری اداروں کے لیے')` returns `[]`.

## Why the pin bought nothing

Since fumadocs-core 16.14.0 the engine is **ZBSearch**, not Orama. zbsearch 4.0.0 disables stemming and installs empty stopwords by default, so `english` and `multilingual` return **identical** results on English text — including the same miss, where `recordings` does not find `recording`, under both.

The comment above the option still pointed at the Orama docs, which have not described this engine since 16.14.0.

## Solution

Remove the option. The engine keeps its own `multilingual` default, which segments with `Intl.Segmenter` and indexes every script.

## Behaviour

- **Non-Latin records become searchable.** This is the whole point.
- **English records are unaffected in results**, per the stemming note above.
- **The exported index grows by roughly 2%** on a technical corpus — the multilingual segmenter splits hyphenated identifiers the English splitter kept whole (`ksor-gateway-floor-missing` → four tokens instead of one). Stated rather than hidden, because it is a real cost.

Restoring stemming for any language remains available and is a separate, deliberate change: it needs a stemmer dependency *and* the same tokenizer handed to the browser through `initDB`, not a one-word option.

## Test

`packages/ksor/src/search-language.integration.test.ts` asserts the shipped bytes name no tokenizer language, and that `staticGET` survived the edit.

Watched failing first against the pre-fix route — both assertions red for the right reasons (pinned language found; `createFromSource` still carried an options argument).

It deliberately does **not** claim a non-Latin document is findable. That is a behavioural fact about the built index and belongs in the `KSOR_E2E` tier, which installs the real tree — noted in the test's own header as follow-up.

## Not in scope

`app/layout.tsx:24` still hardcodes `<html lang="en">`. It is a one-liner, but it needs a source of truth the record does not yet have, so it belongs with the i18n design rather than here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DaZDawqHyZRJAXfE6MSm7i