### PR TITLE
Record what multilingual would cost, before anyone builds it

### DIFF
--- a/research/i18n.md
+++ b/research/i18n.md
@@ -1,0 +1,441 @@
+---
+issue: https://github.com/panaversity/ksor/issues/36
+status: proposed
+last_updated: 2026-08-24
+---
+
+# Multilingual — what the shell gives, and what the record still has to answer
+
+Issue #36 asks where a record written in more than one language puts the second
+one. This file is the evidence behind that question, gathered before anything
+is built, so the answer is not re-derived a third time.
+
+**Nothing here is implemented, and nothing here is decided.** Translation
+touches decision 9's subject matter, so it goes back to the owner before code —
+AGENTS.md is explicit that work contradicting a decision stops. What this file
+records is the ground the decision would be made on.
+
+One thing was found while surveying and IS fixed, because it was a live defect
+rather than a translation feature: the site's search index pinned English
+tokenization, which made every non-Latin record silently unsearchable
+(PR #121). It is described in §1 because it is the cheapest possible evidence
+that the "any language they write in" claim was never tested.
+
+## 0. How this was established
+
+Every claim about Fumadocs and Next below was read out of the **installed
+16.14.5 source** or produced by **running it** — a real `next build` with i18n
+enabled, and the loader driven directly. None of it is recalled or taken from
+documentation, because 16.x is recent and the engine changed under it. Where a
+thing could not be verified it says so by name.
+
+Two adversarial passes were run over the findings and three candidate designs —
+one technical, one hunting governance leaks. Both found real errors in the
+research they were checking; those corrections are folded in below and marked
+where they reverse something.
+
+## 1. The defect that was already shipping
+
+`app/api/search/route.ts` passed `language: "english"` to `createFromSource`.
+
+Naming a language selects a **per-language splitter regex**, and English's is
+Latin-only. An Urdu or Chinese document indexed under it produces **zero
+tokens** and cannot be found — while its page renders, sits in the sidebar, and
+appears in `llms.txt`. Nothing goes red. Verified directly:
+`createTokenizer({language:'english'}).tokenize('کاروباری اداروں کے لیے')`
+returns `[]`.
+
+The pin bought nothing. Since fumadocs-core 16.14.0 the engine is **ZBSearch**,
+not Orama; zbsearch 4.0.0 disables stemming and installs empty stopwords by
+default, so `english` and `multilingual` return identical results on English
+text — including the same miss, where `recordings` does not find `recording`,
+under both. The comment above the option still pointed at the Orama docs.
+
+Two neighbours of the same shape, NOT fixed and deliberately left for the
+design:
+
+- `app/layout.tsx:24` hardcodes `<html lang="en">`. A one-liner, but it needs a
+  source of truth the record does not yet have.
+- PostgreSQL ships **no Urdu text-search configuration at all**, so an Urdu
+  record cannot declare a correct `retrieval.text_search_config` even as a
+  monolingual corpus. The declare-time refusal that already exists for `dim`
+  should catch this; today it does not.
+
+`language: "arabic"` is not a workaround for Urdu and is worse than useless:
+its alphabet stops at U+064A, so every Urdu-specific letter cuts words apart —
+`کام` (work) and `گام` (step) both tokenize to `["ام"]`. Indexing and querying
+mangle identically, so some exact-word queries still hit, which makes it look
+like it works while distinct words silently collapse together.
+
+## 2. What Fumadocs actually provides
+
+`defineI18n` carries exactly five fields: `languages`, `defaultLanguage`,
+`hideLocale`, `parser`, `fallbackLanguage`. Content is named `page.ur.mdx`
+(`parser: 'dot'`, the default) or `ur/page.mdx` (`parser: 'dir'`). `loader()`
+takes the config and `source.getPages(lang)` / `getPageTree(lang)` /
+`generateParams()` become locale-aware. Roughly 50 UI strings are translatable
+through `I18nProvider`.
+
+### It works under `output: "export"`, in one configuration
+
+Middleware is definitively not executed under static export — Next 16 renamed
+`middleware.ts` to `proxy.ts`, and the static-export guide lists Proxy,
+Rewrites, Redirects, Cookies and Headers as unsupported. Reading the installed
+middleware settles that it is **not required to render**: with
+`hideLocale: "never"` and a locale already in the path it returns a bare
+`NextResponse.next()`. Proved by building the real stack with `proxy.ts`
+deleted — both `out/en/docs/alpha/index.html` and `out/ur/docs/alpha/index.html`
+emitted correctly, with `trailingSlash: true` and `basePath` both behaving.
+
+This is the maintainer's own sanctioned path, not a workaround
+(fuma-nama/fumadocs#1785): _"You should remove the middleware and use
+traditional i18n routing for static export… you don't need a middleware if you
+don't hide the locale"_, and _"middleware.ts doesn't work in static export
+mode, `/` will always give 404"_.
+
+Four traps, each verified:
+
+- **`hideLocale` must stay `"never"`.** It is implemented purely as a
+  middleware rewrite, so under export it does not make default-language routes
+  prefix-free — it breaks every English link instead, silently.
+- **A dead `proxy.ts` builds clean.** The build succeeds and merely warns. A
+  scaffold could ship an inert proxy, pass CI and deploy. If i18n ever lands,
+  refusing that state is the `assertGovernanceServable` posture applied here.
+- **`/` is a 404.** `out/index.html` is never emitted. An explicit root page is
+  required; a `<meta http-equiv="refresh">` degrades to a visible link and is
+  more robust than `redirect()`.
+- **Every dynamic route needs its own `generateStaticParams`**, the root layout
+  and `(home)` included, or the build fails outright.
+
+What is lost without the middleware: Accept-Language negotiation, cookie locale
+persistence, and a working root. The first two are cheap to give up.
+
+### The behaviour that decides the shape
+
+**A missing translation silently serves the default language's bytes at the
+localized URL.** `makeStorage(lang, inherit)` copies the fallback locale's whole
+file map, so `getPage(['leave'],'ur')` returns the _English_ file's data at
+`/ur/docs/leave` with `locale:"ur"` — no 404, no marker in `page.data`. And
+`generateParams()` emits that route, so a static export **prerenders it as a
+real file**: an 81-document record with two languages emits 162 HTML files, 160
+of them English, on day one.
+
+`fallbackLanguage: null` converts this to a genuine 404 — the page is
+`undefined` and the route is never generated. For a governed record that is
+almost certainly the correct setting: absence becomes honest rather than papered
+over, and "is this document translated?" becomes answerable from the route table
+instead of by inspection.
+
+### The naming collision
+
+The dot parser reads the locale from the second-to-last segment, so the only
+spelling it recognises as a translated summary is `<doc>.summary.ur.md` — which
+`!**/*.summary.md` does not match. The other spelling, `<doc>.ur.summary.md`,
+_is_ excluded but parses its locale as `"summary"`. **No dotted naming satisfies
+both**, which makes `parser: 'dir'` the only convention that keeps locales and
+attachment suffixes out of one flat namespace.
+
+_Correction from the verify pass, worth recording because it changes the
+mechanism rather than the conclusion:_ the collection's exclusion is enforced by
+**tinyglobby** (file discovery), not picomatch. `picomatch(array)` is a plain OR
+over independently-compiled matchers, so negation entries do not subtract there;
+picomatch is reached only from fumadocs-mdx's dev watcher (`hasFile`). Dev and
+build can therefore disagree about a naming scheme, and the adopter's whole
+review loop is `pnpm dev`. One experiment before any convention is ratified.
+
+### Version
+
+The pinned 16.14.5 duplicates locale-only pages into every locale's tree
+(reproduced: `["index.mdx","leave.ur.mdx","leave.ur.mdx"]`; cause is
+`inherit.folders` copied by reference). The fix is in **16.15.0** — which is
+also a "Redesign source API" release; 16.15.1 changes how search reads
+structured data; 17.0.0 has since shipped. So "bump first" is a stage with its
+own two-shell conformance run, not a line in a risk register.
+
+## 3. Where the framework stops
+
+Translation has **no representation in the kernel at all** — no language column,
+no language parameter, no language-aware code path anywhere under
+`packages/content/` or `packages/content-gateway/`. Five constraints follow.
+
+### One database is one stemming
+
+`chunks.search_tsv` is a STORED generated column carrying one literal
+configuration (`schema.sql:143-148`); the renderer refuses unless it finds that
+token exactly once (`schema.ts:206-222`); a mismatch is a boot refusal. A second
+`corpus_id` or tenant does not help — `search_tsv` is a column on the shared
+`chunks` table. Decision 20 forbids escaping this by reimplementing the keyword
+arm in JS.
+
+Stock PostgreSQL 17 ships 29 configurations: `simple` plus 28 snowball.
+**Arabic and Hindi are present. Urdu is not.** The Arabic stemmer is wrong for
+Urdu (Indo-Aryan morphology, shared script only) and the Hindi one operates on
+Devanagari. The only honest declaration for an Urdu record today is `simple`.
+
+**Unproven and load-bearing:** whether
+`GENERATED ALWAYS AS (to_tsvector(<sibling regconfig column>, content)) STORED`
+is accepted at all. It should be — the two-argument `to_tsvector` is IMMUTABLE
+and a generated expression may reference a sibling column — but nobody has run
+it, and no Postgres was reachable while this was written. It is the first commit
+of any per-row design, before a line of seam is written.
+
+_Correction from the verify pass:_ PG17 **does** support
+`ALTER COLUMN … SET EXPRESSION AS`, so such a migration need not drop the column
+and silently take `idx_chunks_tsv` and every other dependent with it.
+
+### One calibrated floor cannot describe two languages
+
+`vector_floor` is one scalar per instance, calibrated over one pooled
+whole-record distribution against English-only out-of-corpus probes, applied as
+a single `topCosine < floor` (`abstain.ts:37-39`). A bilingual corpus produces
+two cosine regimes one number cannot separate. Issue #36 already says this: _"A
+floor calibrated on English queries is not a floor for Urdu queries."_
+
+**Unmeasured and decisive:** Google's published cross-lingual numbers are
+non-English-query → English-passage, never the reverse, and never at the
+1536-dimension MRL truncation ksor stores. Whether same-language and
+cross-language cosines occupy one regime is the measurement that everything
+about a shared vector space depends on. Urdu _is_ on the vendor's supported
+list, so this is the half that plausibly generalises — and the half nobody has
+tested.
+
+### A per-node takedown does not reach a translation
+
+`knowledge/policies/returns.ur.md` gets `stable_id: knowledge/policies/returns.ur`
+(`plain-tree.ts:337-354`) — a fully independent node with its own slug, its own
+MCP node, its own citation. `DENIED_CTE` seeds on an exact `stable_id` match and
+cascades only through `parent_id` (`takedown.ts:29-47`), so the only denial
+covering both is a `subtree` takedown on the whole enclosing section, which also
+withdraws every unrelated sibling. A mirror tree is worse: the Urdu node's parent
+chain never touches the English node at all. `assertGovernanceServable` will not
+warn, because the English id still resolves.
+
+This is decision 24's four-costume bug wearing a locale.
+
+### `MIN_CONTENT_CHARS` is issue #55 recurring for dense scripts
+
+The floor is a raw code-point count of 24 (`config.ts:33`), enforced identically
+at ingest and in the serving predicate — roughly 1.4x stricter for Urdu and ~4x
+stricter for CJK in information terms. Measured, whitespace-stripped code
+points: `退货期限为三十天` = 8, `返品は三十日以内です` = 10,
+`واپسی تیس دن میں ہوتی ہے` = 19, against an English control at 41. A complete
+Japanese policy sentence is labelled `nav` at ingest and refused by every
+retrieval arm.
+
+Decision 22 removed _length_ as the nav proxy but kept this one as the residual
+floor.
+
+_Two corrections from the verify pass:_ the SQL predicate interpolates the
+shared constant rather than hardcoding 24, so the number cannot drift between
+the two implementations — only the rule could, and `cpLen` and Postgres
+`length()` currently agree. And `CHUNK_POLICY` is at `v7`, while AGENTS.md
+decision 22 still records "v5 → v6"; that decision's own version note is stale.
+
+### The agent surface has no language, and cannot grow one locally
+
+`search` takes query + k; `read` takes slug + heading + budget; `outline` takes
+node + depth. The handlers are framework-owned by design (decision 23). With two
+languages in one record today, an agent sees both copies as separate `outline`
+rows distinguishable only by title, and one query returns whichever chunks rank
+— the vector arm may cross languages while the keyword arm systematically
+favours whichever language matches the stemmer.
+
+A second asymmetry surfaced here and deserves its own issue regardless of
+translation: **the door discloses no governance caveat at all.** `doc_status`
+and `superseded_by` are stored and rendered by the site — banner, sidebar chip,
+search-row caveat, `llms.txt` marker — and none of the three MCP output schemas
+carries them.
+
+Also unnamed anywhere in the tree: `gemini-embedding-2` has shipped, with an
+8,192-token input against 001's 2,048 and automatic normalization of truncated
+embeddings — which is the manual step `lib/embedding.ts` exists for. Relevant
+because `HARD_MAX_CHARS = 4000` at `CHARS_PER_TOKEN = 4` can exceed the 001
+limit for CJK, surfacing as failed chunks rather than as an error.
+
+## 4. Is a translation a document or an attachment?
+
+The fork everything hangs on, and it is genuinely contested.
+
+**Decision 24 forces it out of the attachment shape, through C13.** An
+attachment is refused if it declares _any_ frontmatter — as a class, not by
+allow-listing keys — precisely because it has no id to hang governance on. A
+translation of a governed policy must carry who translated it, whether anyone
+reviewed it, and what it was translated from. The attachment shape deletes
+exactly the governance critical rule 1 forbids weakening.
+
+Worse, the spec states the asymmetry itself: _"A summary is site-only. The door
+does not serve it."_ A translation as an attachment would render on the site and
+have **no MCP node at all** — so an agent asks in Urdu about a document the
+record demonstrably contains and receives an abstention. Product principle 5
+says abstention is a correct answer; it is not a correct answer here.
+
+**The case FOR the attachment reading is real** and is recorded rather than
+waved away: a translation is the one derivative where "may assert nothing its
+parent does not" is definitionally true, and it is the only shape where takedown
+and visibility inheritance are _structural_ rather than a second rule to keep in
+step.
+
+**But it is not an independent document either** — the derivation is
+load-bearing, and the repo already has the shape: `content_nodes.superseded_by`
+is a stable-id pointer from one node to another, read by one frontmatter module,
+written into the node row, and included in the corpus-change key. Decision 15's
+"column plus a seam" applied to a node-to-node relation.
+
+So the shape the recorded decisions force is `lang` + `translation_of` +
+`source_hash` columns, a `lib/language.ts` serving seam bound the way
+`takedown.ts` binds denial, and a `LANGUAGE_CASES` decision table under
+decision 18 — because the site and the door would otherwise implement one rule
+in two languages, which has drifted four separate times on visibility alone.
+
+Two subtleties the adversarial pass drew out and no candidate design carried:
+
+- **A governance state must be a row, not a rendering decision.** The site's
+  posture that "an undeclared key renders nothing" is right for a missing
+  `owner` on an original, which reads as a gap — and wrong for a missing
+  reviewer on a translation, which reads as an ordinary approved document. An
+  unreviewed machine translation would otherwise ship with impeccable
+  _inherited_ provenance, a citable `stable_id`, and no disclosure anywhere.
+  `reviewed_by IS NULL` has to be a positive state in the table.
+- **Decision 21 bites.** A `reviewed_by:` frontmatter line is a self-asserted
+  string wearing a schema — read, not verified. That decision's reversal clause
+  admits only an identity the tool can _verify_, and names a bearer token's
+  subject as qualifying. Which points somewhere none of the designs proposed: a
+  verified review is an act performed at the **door**, where a subject exists,
+  not a line in a file.
+
+## 5. Staleness — a wrong answer with perfect provenance
+
+The English source is edited; the translation is not. The site now serves, with
+a full citation and a resolved generation, a statement the record no longer
+makes. Product principle 6 anticipated this exactly: _"Provenance proves
+who-said-when; the expert judgment of whether a source is right is a separate
+mechanism — never sell one as the other."_
+
+**Abstention is the wrong mechanism**, and reaching for it would be a real
+error: abstention here is a measured cosine floor on the vector arm, calibrated
+per corpus. Content state is not what it measures. The correct kin is the
+takedown / audience serving seam — a rule, bound once, honoured by both
+surfaces.
+
+**The detector already exists.** `contentHash()` is sha256 over the
+CRLF-normalised body, persisted as `sources.content_hash NOT NULL`;
+`chunks.chunk_hash` is already "the carry-forward key"; `retrieval_log` records
+both. And `sameCorpus()` is the precedent for what "changed" must mean, because
+it was already corrected once for this class of bug: hashing the
+frontmatter-stripped body meant a `visibility:` change altered no compared byte,
+so the governance columns are now in the key (`build.ts:414-462`).
+
+Two traps found in every candidate design:
+
+- **Three frontmatter splitters, two already disagreeing with the kernel by
+  construction.** The kernel's regex consumes the closing fence's trailing
+  whitespace and tolerates a BOM and CRLF; the site's and the checker's do not,
+  and the site then reconstructs the body leaving `\n---\n` in it. For any
+  document with frontmatter the two sha256s differ, deterministically — so a
+  hash-based staleness rule would read permanently stale on one surface and
+  permanently fresh on the other, a decision-19 disagreement on a refusal. The
+  canonical leaf must export the **splitter**, not only the hash.
+- **Supersession changes no body byte.** A source marked `status: superseded`
+  leaves every body-hash mechanism reporting the translation _fresh_ while it
+  translates a withdrawn document — the state issue #36 itself calls "worse than
+  no translation".
+
+### Prior art
+
+MDN is the closest analogue and the strongest warning: it deleted most of its
+locales over stale machine translations. What it kept is the mechanism —
+`l10n.sourceCommit`, a frontmatter key holding the commit hash of the English
+source the translation was synchronised with, so the diff since that commit is
+computable. In-band, in the file, versioned with it. (Whether a linter enforces
+it could not be confirmed from primary sources.)
+
+That is the shape this repo's own constraints argue for too: reproducible
+builds, a value the door can return beside a citation, and decision 15's
+column-plus-seam.
+
+## 6. Candidate designs, and what the adversarial pass found
+
+Three were designed independently against different lenses, then attacked twice.
+**All three leaked**, and every leak was the same shape: site hides, door
+serves — decision 24's bug wearing a locale.
+
+| Design                 | Shape                                                                                 | Killed on                                                                                                                                                                                                                                                                                                                          |
+| ---------------------- | ------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Rendition**          | `<doc>.<lang>.md`, no stable id, source's governance                                  | `returns.summary.ur.md` matches no attachment suffix, so `isDoc` returns true and it **ingests as a node** while the site's glob excludes it. `planStage` also filters it on its own terms, so an `internal` document's translation reaches the public build                                                                       |
+| **Language column**    | `lang`/`translation_of` on `content_nodes`, mirror directories, one GUC-bound seam    | Its `DENIED_CTE` third arm is **invalid SQL** (two self-references in one recursive term). Governance inheritance is ingest-only, so the site still publishes an `internal` translation. Its migration silently resolves the `TextSearchConfigMismatch` refusal by re-stemming a published generation underneath its own citations |
+| **Seventh attachment** | `<doc>.translation.<lang>.md` as a tab, withholding itself when a hash stops matching | A glob cannot express a BCP-47 regex, so its two copies of the rule are **permanently mismatched**: every string in the gap (`returns.translation.francais.md`) is excluded by the site and ingested by the door                                                                                                                   |
+
+None of these is fatal to its approach — each leak has a fix. But together they
+are the strongest result in this research: **the naming convention is not the
+interesting decision, and neither is the framework.** The interesting decision is
+whether the rule that classifies a file lives in one place both surfaces read, or
+in four hand-typed copies of a glob and a regex that a table can pin but not
+reconcile.
+
+Three more gaps, none of them covered by any design:
+
+- **`KSOR_AUDIENCE` x language is unstated.** Both are per-build staging filters
+  over one directory, so the product is N_audiences x N_languages separate
+  exports. That seam already has a recorded history of failing _silently in the
+  success direction_ — 42 of 48 runs, 27 returning success with a third of the
+  record missing (docs/status.md, 0.0.22). Crossing two such filters needs the
+  positive control that fix got, stated per combination.
+- **Per-language output trees are not disjoint and cannot merge into one
+  deploy.** Next always writes to `out/`, and several artifacts sit at fixed
+  paths — one `out/api/search`, one `out/llms.txt`, one `out/llms-full.txt`,
+  one `.well-known` document. N per-language builds merged into one directory
+  means N-1 of each are silently overwritten. The audience seam does not have
+  this problem only because it does _not_ merge: a wider tier is a separate
+  deployment by rule.
+- **The two-shell obligation.** Decision 9's surface contract is asserted
+  against both shells, and the Docusaurus shell dropped i18n deliberately. Any
+  route shape or `llms.txt` change becomes a clause both shells must satisfy —
+  or the contract gains a Fumadocs-only exception, which weakens the swap seam
+  decision 9 exists to prove.
+
+## 7. What needs an owner decision
+
+1. **Is a second language a second KSoR project, or a second set of nodes in one
+   record?** `specs/ksor/init/spec.md:177` currently implies the former, and
+   one-regconfig-per-instance plus the `ksor://<instance>/<path>` URI scheme both
+   point that way. But that answer forks identity: the same policy gets two
+   `stable_id`s, two takedown rows, two generations — so a document withdrawn in
+   one language keeps serving in the other, which is the failure product
+   principle 3 exists to prevent and which issue #36 names in its own words.
+   Everything downstream hangs on this.
+
+2. **Decision 9's reversal clause was narrowed at ratification.** The candidate
+   text at `research/site-shell.md:160-162` read _"…or if multilingual i18n
+   becomes a near-term requirement it cannot meet."_ The ratified `AGENTS.md:245`
+   reads only _"Reversed if Fumadocs's static export or llms surface regresses
+   before the site slice ships."_ The one clause that would re-open the shell on
+   multilingual demand no longer exists. Working rule 6 says supersession is
+   visible; this wants a revision note either way, independent of whether
+   translation is ever built.
+
+3. **There is a live decision-18 violation on language today**, independent of
+   translation: the door's stemmer is declared per-record in `instance.md`, the
+   site's index had English hardcoded (PR #121), and `text_search_config` appears
+   nowhere under `packages/ksor/`. One rule, two surfaces, no table.
+
+### If it is built, the order that does not require the answer first
+
+1. **Run the two measurements.** Does the per-row `regconfig` generated column
+   apply? Do same-language and cross-language cosines occupy one regime at 1536
+   dimensions? Both are cheap, both can collapse a design, neither has been run.
+2. **Bump fumadocs to ≥ 16.15.0** as its own stage with a two-shell conformance
+   run — it is a source-API redesign, not a patch.
+3. **Land the rule as a REFUSAL, rendering nothing** — one canonical classifier,
+   its copies, its drift test, and `LANGUAGE_CASES`, red first against the leaks
+   in §6, all of which are reproducible against today's code.
+4. **Render it, then serve it** — site before door. A site that renders a
+   language the door cannot answer is a decision-19 conversation; a door that
+   answers a language the site cannot render is not.
+
+### What would reverse the whole thing
+
+If the answer to "who reads this?" is _two audiences who never cite each other's
+documents_ — a public English site and an internal Urdu one — then two separate
+projects is honest and correct, and none of §3 through §6 is worth building.
+That is the cheapest outcome available here and it should be ruled out
+deliberately rather than by omission.


### PR DESCRIPTION
Closes nothing. Feeds #36.

## Problem

Issue #36 asks where a record written in more than one language puts the second one. It has been deferred three times — `research/site-shell.md`, `research/scaffold-structure.md:119`, `specs/ksor/init/spec.md:177` — and only **once** with reasoning attached. So the evidence keeps being re-derived, and the last time it was derived it decided the site shell.

## Solution

`research/i18n.md` — the evidence, gathered before anything is built.

**Nothing here is implemented and nothing is decided.** Translation touches decision 9's subject matter, so it goes back to the owner before code. The file records the ground that decision would be made on, and names what would reverse the whole thing: if the two languages serve audiences who never cite each other's documents, two separate projects is honest and correct, and none of §3–§6 is worth building.

## What it found

**The framework question was the easy one.** Fumadocs i18n works under `output: "export"` in exactly one configuration — `hideLocale: "never"`, no proxy, `/` needs an explicit root page — and it is the maintainer's own sanctioned path, not a workaround. Four traps are recorded, each verified by building the real stack.

**The kernel has no answer at all.** No language column, no language parameter, no language-aware code path:

- one stemming per database, in a `STORED` generated column, with a boot refusal on change — and stock Postgres 17 ships **no Urdu configuration at all**
- one `vector_floor`, calibrated over one pooled distribution against English-only probes
- a per-node takedown does not reach a translation, and `assertGovernanceServable` will not warn
- `MIN_CONTENT_CHARS` is a raw code-point count, ~4x stricter for CJK — issue #55 recurring
- the MCP tools have no language input, and the handlers are framework-owned by design

**Three candidate designs were built and attacked twice. All three leaked** — every one the same shape, site hides while the door serves, which is decision 24's bug wearing a locale. That is the strongest result in the file: the naming convention is not the interesting decision, and neither is the framework. The interesting decision is whether the rule that classifies a file lives in one place both surfaces read.

## Method

Every claim about Fumadocs and Next was read out of the installed 16.14.5 source or produced by running it — a real `next build` with i18n enabled, and the loader driven directly. Where something could not be verified, the file says so by name (the per-row `regconfig` generated column, and cross-lingual cosine behaviour at 1536 dimensions — both named as measurements to run first, because either can collapse a design).

Corrections an adversarial pass made to this research are folded in and marked, including two that reverse it: the exclusion glob is enforced by tinyglobby rather than picomatch, and PG17 supports `ALTER COLUMN … SET EXPRESSION AS`.

## Two things surfaced that are independent of translation

- **Decision 9's reversal clause was narrowed at ratification.** The candidate text at `research/site-shell.md:160-162` read *"…or if multilingual i18n becomes a near-term requirement it cannot meet."* `AGENTS.md:245` ships without it, so nothing re-opens the shell on multilingual demand. Working rule 6 says supersession is visible — this wants a revision note either way.
- **The MCP door discloses no governance caveat at all.** `doc_status` and `superseded_by` are stored and rendered by the site — banner, sidebar chip, search-row caveat, `llms.txt` marker — and none of the three MCP output schemas carries them. Worth its own issue.

Related: #121 fixes the one live defect found while surveying.

## Not in scope

No changesets — `research/` is outside `packages/ksor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DaZDawqHyZRJAXfE6MSm7i