### PR TITLE
Document how to keep people out of the site

### DIFF
--- a/.changeset/trim-shell-revision.md
+++ b/.changeset/trim-shell-revision.md
@@ -16,3 +16,16 @@ unblocked. That last one is the reason it stays.
 But coding principle 1 applies to this file too — context is liability, and
 AGENTS.md loads every session. The narrative half was 90 words explaining why
 the proof had been valuable, which the commit already records.
+
+Also documents the thing that was missing entirely: **how to keep people out of
+the site.** The door's auth had four recipes; the site had nothing, and the
+most common requirement — "everyone signs in before reading anything" — is also
+the easiest, needs no ksor change, and was written down nowhere.
+
+Three shapes, separated because they had been muddled: a host-level gate in
+front of the origin (protects every byte, holds against `curl`, and makes a
+site sign-in button redundant rather than complementary); per-audience builds
+for a restricted subset (enforcement by absence, already built); and the
+per-request case, which a static export cannot express and which issue #130
+records rather than implements. Plus what does not work — hiding rendered
+content behind a browser check, which presents rather than protects.

--- a/.changeset/trim-shell-revision.md
+++ b/.changeset/trim-shell-revision.md
@@ -1,0 +1,18 @@
+---
+"@panaversity/ksor": patch
+---
+
+Trim the shell-retirement revision in AGENTS.md from 222 words to 129, keeping
+what an agent must act on and moving the reasoning to the commit that carried
+it.
+
+Working rule 6 requires a reversed decision to keep its entry and gain a
+revision note, so removing it is not available — and it is not irrelevant
+either: without it an agent looks for a deleted directory with no explanation,
+or restores two-shell assertions thinking they were lost by accident, or reads
+decision 9, sees no obstacle, and treats dropping `output: "export"` as
+unblocked. That last one is the reason it stays.
+
+But coding principle 1 applies to this file too — context is liability, and
+AGENTS.md loads every session. The narrative half was 90 words explaining why
+the proof had been valuable, which the commit already records.

--- a/.changeset/trim-shell-revision.md
+++ b/.changeset/trim-shell-revision.md
@@ -29,3 +29,15 @@ for a restricted subset (enforcement by absence, already built); and the
 per-request case, which a static export cannot express and which issue #130
 records rather than implements. Plus what does not work — hiding rendered
 content behind a browser check, which presents rather than protects.
+
+The per-request case gets three answers rather than a deferral: **read through
+the door** (already applies audience scope per request and logs an actor per
+read — per-person governance with an audit trail a static site cannot have),
+**split the record** (content needing per-person confidentiality inside one tier
+usually belongs in its own record), or **fork the site**, which an adopter owns
+outright under decision 4.
+
+The fork is offered with what it costs stated: ksor's guarantee is enforcement
+by ABSENCE, asserted against a positive control; a request-time filter is a
+different guarantee and becomes the adopter's to test. A filter that is bypassed
+serves the document; an absent file cannot be.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,30 +248,18 @@ reverse it, and a reversed decision keeps its entry with a revision note.
    recipe and one shell-agnostic conformance suite runs the surface
    contract against both shells in CI. `ksor init` still emits Fumadocs,
    always; no selector was added._ _Revision 2026-08-24 (owner): the
-   second shell is RETIRED — `workbench/shells/docusaurus/` is deleted and
-   the conformance suite runs one shell. The proof did its job: it was
-   built to answer "is the shell really a slot, or is the contract just a
-   description of what Fumadocs happens to do", and it answered by keeping
-   the surface contract honest through the visibility model, attachments
-   and the staging lock. What it costs now exceeds that. Every surface the
-   record grows — quizzes, decks, slides, code tabs — has to be built
-   twice or the suite goes red, and the second build is one nobody ships:
-   `ksor init` has always emitted Fumadocs and never offered a selector.
-   Maintaining a shell no adopter runs, to prove a property no adopter
-   exercises, is the "code is liability" test failing. The surface
-   contract survives unchanged and is still asserted — against one
-   implementation, which is what the other clauses of this decision
-   (adopter ownership of `system/site`, future registry-distributed
-   shells) always intended to carry. Restored by an adopter actually
-   swapping a shell, which would make the property live again rather than
-   hypothetical; the recipe lives in git history until then.
-
-   _One consequence, recorded because it is now cheaper and must stay
-   deliberate: this removes the strongest objection to reversing the
-   `output: "export"` clause, since a Docusaurus shell could never satisfy
-   a Next-server contract. That reversal is still an owner decision and
-   still contradicts `specs/ksor/visibility/spec.md`, which refuses
-   per-request filtering by name. Site auth does not authorize it._
+   second shell is RETIRED — `workbench/shells/docusaurus/` deleted, the
+   conformance suites run one. Every surface the record grew had to be built
+   twice to keep it green, for a shell no adopter runs (`ksor init` has always
+   emitted Fumadocs, no selector). The five-clause surface contract is
+   unchanged and still asserted against one implementation; both suites keep
+   their `.each(SHELLS)` shape so adding a shell back needs no restructuring.
+   Restored by an adopter actually swapping one; the recipe is in git history.
+   **Consequence to hold onto:** this removes the structural objection to
+   reversing the `output: "export"` clause, since a Docusaurus shell could
+   never satisfy a Next-server contract. That reversal is now CHEAPER, not
+   decided — it still contradicts `specs/ksor/visibility/spec.md`, and site
+   auth does not authorize it (issue #130)._
 
 10. **Scaffold templates are MIT-0** (owner, 2026-08-18): init's output
     lands in the adopter's proprietary repo free of attribution

--- a/packages/ksor/docs/authorization.md
+++ b/packages/ksor/docs/authorization.md
@@ -32,8 +32,11 @@ Read this before spending an afternoon on a provider's console.
 **It protects the MCP door, not the website.** Everything on this page is a
 bearer token on `POST /mcp`. Your static site is a separate surface, served by
 whatever hosts it, and configuring auth here leaves it exactly as public as it
-was. If people must not read the record at all, the site needs its own access
-control — or must not be published.
+was. Keeping people out of the SITE is a different mechanism and is not on this
+page — see "Keeping people out of the site" in
+[deploying.md](./deploying.md), which covers the three shapes: a host-level gate
+in front of everything, per-audience builds for a restricted subset, and why the
+per-request case needs a decision first.
 
 **It is one gate, not per-user rules.** The door checks that a token was signed
 by the issuer you named and audienced at this record. It reads no scopes, no

--- a/packages/ksor/docs/deploying.md
+++ b/packages/ksor/docs/deploying.md
@@ -286,12 +286,35 @@ Plain `pnpm build` is always the public tier, so the safe thing is the default.
 
 ### "Different readers see different documents, decided per request"
 
-A static export cannot do this: `pnpm build` writes every published document into
-`system/site/out/` and the host serves what it is asked for. Doing it properly
-means the site stops being static, which is a decision with real cost — issue
-#130 records it, along with what would justify reopening it.
+Two supported answers, and a third that is yours.
 
-Until then, the honest shapes are the two above.
+**Read through the door instead.** This is the one ksor is built for. The MCP
+surface already applies the audience scope **per request** and writes a
+`retrieval_log` row carrying the actor for every read — per-person governance
+with an audit trail, which a static site cannot have at any price. If the
+requirement is "who read what, and were they allowed to", that is the door, not
+the website.
+
+**Or split the record.** Content needing per-person confidentiality inside one
+tier is usually content that belongs in its own record, with its own gate. That
+is what the audience model and the second-record design anticipate.
+
+**Or fork the site — you already own it.** `system/site` is yours outright
+(decision 4). Nothing stops you removing `output: "export"` and filtering per
+request in your own repository. ksor's contract is unaffected; this is a
+directory you own, changed the way you want it.
+
+What you take on if you do:
+
+> ksor's guarantee is **enforcement by absence** — a restricted document is
+> never written into the artifact, and a conformance suite asserts that against
+> a positive control that proves the check is not blind. A request-time filter
+> is a **different** guarantee, and it becomes yours to test, because those
+> suites will no longer be testing it for you. A filter that is bypassed serves
+> the document; an absent file cannot be.
+
+That is the whole trade. It is a reasonable thing to do with your eyes open, and
+a bad thing to drift into because a login button suggested it.
 
 ### What does NOT work
 

--- a/packages/ksor/docs/deploying.md
+++ b/packages/ksor/docs/deploying.md
@@ -246,6 +246,61 @@ a row) and reaches the site at its next build (it reads a file), so a site built
 without the DSN would keep publishing what the door already refuses. Set
 `KSOR_DB_URL` on the site build as well as on the door.
 
+## Keeping people out of the site
+
+The door has auth ([authorization.md](./authorization.md)). The **site** is
+static files, so it has none — and the way to protect it is not to add code, it
+is to put something in front of it.
+
+Three requirements, three different answers. Pick the row you actually have.
+
+### "Everyone must sign in before reading anything"
+
+**Put a gate in front of the origin.** Nothing in ksor changes, and it protects
+every byte — HTML, `llms.txt`, images, the search index — because the request
+never reaches the files.
+
+| host          | what to turn on                                                                                      |
+| ------------- | ---------------------------------------------------------------------------------------------------- |
+| Vercel        | Deployment Protection (password, or SSO on paid plans)                                               |
+| Cloudflare    | Cloudflare Access in front of the deployment                                                         |
+| anything else | an authenticating reverse proxy — nginx with `auth_request`, oauth2-proxy, Caddy with `forward_auth` |
+
+This is the strongest gate available to a static site, and the only one that
+holds against `curl`. It is coarse — whole deployment, all or nothing — which is
+exactly right when the answer is "this record is internal".
+
+**A sign-in button on the site is not an alternative to this.** The gate has
+already authenticated the reader before a page renders; a second login inside it
+would ask the same person to sign in twice, and on its own would protect
+nothing.
+
+### "Some documents are restricted, most are not"
+
+**Build per audience.** `KSOR_AUDIENCE=<tier> pnpm build` stages only what that
+tier may see, so restricted documents are **never written into the artifact** —
+enforcement by absence, which is the only kind a static host can honour. Publish
+the public artifact openly and the wider one behind the gate above.
+
+Plain `pnpm build` is always the public tier, so the safe thing is the default.
+
+### "Different readers see different documents, decided per request"
+
+A static export cannot do this: `pnpm build` writes every published document into
+`system/site/out/` and the host serves what it is asked for. Doing it properly
+means the site stops being static, which is a decision with real cost — issue
+#130 records it, along with what would justify reopening it.
+
+Until then, the honest shapes are the two above.
+
+### What does NOT work
+
+**Hiding rendered content behind a signed-in check in the browser.** If the page
+was built with the content in it, the content is in the response before any
+JavaScript runs — `curl` and every crawler see it. A component that blurs or
+collapses it is presenting, not protecting. If you build one, say so in its own
+comment, or the next reader will take it for a gate.
+
 ## Authorization, or the deliberate absence of it
 
 `ksor serve` **refuses to boot unauthenticated on a public bind.** There is no


### PR DESCRIPTION
Two things, both from the same observation: **the door had four auth recipes and the site had none.**

## The gap

The most common requirement — *"everyone signs in before reading anything"* — is also the **easiest**, needs **no ksor change at all**, and was documented nowhere.

Three shapes, separated because this conversation kept muddling them:

| requirement | static export? | mechanism | ksor change |
|---|---|---|---|
| everything behind login | ✅ | host gate in front of the origin | **none** |
| some documents restricted | ✅ | per-audience builds | **none — already built** |
| per-reader, per-request | ❌ | drop static export | issue #130 |

The host gate is the strongest protection available to a static site and the only one that holds against `curl` — the request never reaches the files, so it covers HTML, `llms.txt`, images and the search index alike. Vercel Deployment Protection, Cloudflare Access, or any authenticating reverse proxy.

## The consequence that matters for the open auth question

**With a host gate in place, a site sign-in button is redundant, not complementary.** The reader was already authenticated before a page rendered; a second login inside the gate asks the same person to sign in twice and protects nothing on its own.

That is worth knowing before building sign-in for protection reasons.

## And the thing that looks like a gate and isn't

Hiding rendered content behind a browser check. If the page was built with the content in it, the content is in the response before any JavaScript runs. The doc says so, and says that if someone builds one anyway it must declare itself as presentation in its own comment.

## Also in this PR

Trims the shell-retirement revision in `AGENTS.md` from **222 words to 129**.

Working rule 6 requires the note to exist — without it an agent finds a deleted directory with no explanation, or restores two-shell assertions, or reads decision 9, sees no obstacle, and treats dropping `output: "export"` as unblocked. That last one is why it stays.

But coding principle 1 applies to this file too, and it loads every session. What went was 90 words arguing why the proof had been valuable — which the commit that retired it already carries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)