### PR TITLE
Add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 # KSoR
 
 **The authoritative knowledge infrastructure for AI-native organizations.**
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/panaversity/ksor)
 
 A **Knowledge System of Record (KSoR)** turns an organization's governed knowledge into infrastructure that humans, AI agents, and software can reliably operate from.
 


### PR DESCRIPTION
Added a badge for DeepWiki to the README.

Its a good to add deepwiki for KSOR as user can review and ask questions or any confusion with deepwiki agent. Actually, it helped me a lot to learn deep about the project and the repo by chatting with agent

Btw, I am giaic student (in quarter 4)