### PR TITLE
The scaffold meets the adopter's package manager

### DIFF
--- a/.changeset/manager-neutral-scaffold.md
+++ b/.changeset/manager-neutral-scaffold.md
@@ -1,0 +1,25 @@
+---
+"@panaversity/ksor": patch
+---
+
+The scaffold meets your package manager
+
+`ksor init` now emits the scaffold for the manager that ran it: `npx
+@panaversity/ksor init` produces an npm project, `bunx` a bun one, `pnpm dlx`
+(or anything unrecognized) the pnpm shape every scaffold got before. Node stays
+the one prerequisite — nobody installs a second package manager to open their
+own knowledge base (issue #28).
+
+The whole scaffold speaks the detected manager: scripts, README, AGENTS.md, the
+agent kit, the CLI's own handoff text. npm and bun scaffolds declare
+`workspaces` in the manifest and ship no lockfile — the pinned CLI version
+cannot be pre-resolved into one, so the first install writes it and the README
+says to commit it. The install-script denial carries over (`.npmrc` with
+`ignore-scripts=true` for npm; bun refuses dependency lifecycle scripts by
+default). What npm and bun cannot offer is pnpm's 48-hour quarantine on newly
+published dependency versions — the emitted scaffold discloses that instead of
+staying silent about it.
+
+Each manager's shape was proven end to end before shipping — install, `ksor`
+bin resolution, format checker, full static site build — and CI now walks npm
+and bun scaffolds on every change.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,28 @@ jobs:
       - run: pnpm exec vitest run --config vitest.integration.config.ts packages/ksor/src/stage-concurrency.integration.test.ts
       - run: pnpm test:unit
 
+  manager-acceptance:
+    name: Manager acceptance (${{ matrix.manager }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        manager: [npm, bun]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        if: matrix.manager == 'bun'
+      - run: pnpm build
+      # The scaffold emitted for this manager, walked the way its adopter
+      # would: install (local tarball swapped for the stamped version — the
+      # only divergence), resolve the pinned `ksor` bin, run the checker,
+      # build the static site (issue #28).
+      - run: node scripts/manager-acceptance.mjs ${{ matrix.manager }}
+
   container:
     name: Container acceptance (no vendor)
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -794,6 +794,30 @@ gateway` package, serve-by-spawn) is superseded._
     a reader who only wanted the policy never announces that to a slide host.
     Contract: `specs/ksor/slides/spec.md`. Reversed per-clause with evidence._
 
+25. **The scaffold meets the adopter's package manager** (owner, 2026-08-24,
+    issue #28). Decision 1 makes Node the one prerequisite; requiring a
+    SPECIFIC manager on top re-added the second-prerequisite tax that decision
+    exists to avoid. `ksor init` now reads `npm_config_user_agent` and emits
+    the invoking manager's scaffold — npm and bun alongside pnpm, each shape
+    proven end to end (install, bin resolution, checker, full static build)
+    before this landed and walked per-manager in CI. Unrecognized or absent
+    falls back to pnpm, the most-protected posture. Selection is detection
+    only — no `--pm` flag; the run that scaffolds is the run that knows the
+    toolchain, and a wrong guess is re-run with the other runner. The pnpm
+    scaffold is unchanged. npm and bun scaffolds declare `workspaces` in the
+    manifest, ship no lockfile (the stamped CLI version cannot be pre-resolved
+    into one — the tarball hash does not exist at template-build time; the
+    README says to COMMIT the lock the first install writes), and carry the
+    install-script denial (`.npmrc ignore-scripts=true` for npm; bun's own
+    default refusal for bun). What neither can carry is pnpm's 48-hour release
+    quarantine (`minimumReleaseAge`) — that absence is DISCLOSED in the
+    emitted scaffold (owner chose disclosure over refusing the managers):
+    honest absence, never silent weakness. This repo's own workspace stays
+    pnpm (decision 5, untouched). Reversed per-manager if a manager's walk
+    cannot be kept green; the disclosure clause is not reversible without an
+    owner decision, because silence about a weaker posture is the failure mode
+    it exists to prevent.
+
 **Open questions — decide independently when the work arrives:** ~~how
 retrieval and abstention are implemented for `serve`~~ — decided 2026-08-19,
 decision 11: the predecessor kernel converts (revision trail: recorded as

--- a/README.md
+++ b/README.md
@@ -42,14 +42,29 @@ The result is not merely a documentation site, knowledge base, vector database, 
 
 ## Start here
 
-Node 24 or newer and pnpm (`npm install -g pnpm`). Then:
+Node 24 or newer — the only prerequisite. Run init with the package manager
+you already use; the runner you type IS the choice, and everything the
+scaffold emits — scripts, README, the agent kit — speaks that manager:
+
+**npm**
 
 ```bash
 npx @panaversity/ksor init my-knowledge-sor
-cd my-knowledge-sor
+cd my-knowledge-sor && npm install && npm run dev
+```
 
-pnpm install
-pnpm dev
+**pnpm**
+
+```bash
+pnpm dlx @panaversity/ksor init my-knowledge-sor
+cd my-knowledge-sor && pnpm install && pnpm dev
+```
+
+**bun**
+
+```bash
+bunx @panaversity/ksor init my-knowledge-sor
+cd my-knowledge-sor && bun install && bun run dev
 ```
 
 Your governed record is now live at `http://localhost:3000`, hot-reloading as
@@ -64,7 +79,9 @@ interview the agent runs with you to replace the placeholder identity in
 `instance.md` with your real one. You write knowledge in plain Markdown, in any
 language you write in; the agent handles the governance ladder around it.
 
-Two commands are worth knowing on day one:
+Two commands are worth knowing on day one — shown here and for the rest of
+this page in the pnpm spelling; your own scaffold's README speaks your
+manager (`npm run check`, `bun run build`):
 
 ```bash
 pnpm check    # the format checker — run before handing off any knowledge change
@@ -505,8 +522,9 @@ If the capitalization policy does not address the situation, the system should n
 
 ## Requirements
 
-Node.js 24 or newer, and pnpm (`npm install -g pnpm`, or `corepack enable
-pnpm` on Node versions that bundle corepack).
+Node.js 24 or newer, and the package manager you already use — pnpm, npm, or
+bun. `ksor init` emits the scaffold for whichever one runs it; nobody
+installs a second package manager to open their own knowledge base.
 
 ```bash
 node --version
@@ -517,7 +535,10 @@ node --version
 ## Create a KSoR
 
 ```bash
-npx @panaversity/ksor init my-ksor
+npx @panaversity/ksor init my-ksor        # npm  → npm install, npm run dev
+pnpm dlx @panaversity/ksor init my-ksor   # pnpm → pnpm install, pnpm dev
+bunx @panaversity/ksor init my-ksor       # bun  → bun install, bun run dev
+
 cd my-ksor
 ```
 

--- a/packages/ksor/docs/deploying.md
+++ b/packages/ksor/docs/deploying.md
@@ -7,6 +7,11 @@ status: draft
 
 ## Before you start
 
+Commands on this page use the pnpm spelling (`pnpm build`, `pnpm serve`).
+Since 0.0.36, `ksor init` emits the scaffold for the manager that ran it —
+npm and bun included — and your scaffold's own README speaks that manager;
+translate accordingly (`npm run build`, `bun run build`).
+
 Four things must exist, and the order matters. Nothing below works without them,
 and three of the four are outside this page.
 

--- a/packages/ksor/docs/index.md
+++ b/packages/ksor/docs/index.md
@@ -19,7 +19,10 @@ instead of their training memory. The corpus grows with each implemented verb.
   `.claude/skills/` copies), adopter CI, and a dependency-free format
   checker (`pnpm check`). `ksor init .` scaffolds into an empty directory
   whose name passes the project-name grammar. Everything emitted belongs to
-  the adopter (templates are MIT-0).
+  the adopter (templates are MIT-0). The scaffold is emitted for the package
+  manager that ran init — `npx …` yields an npm project, `bunx …` a bun one,
+  `pnpm dlx …` (or a bare `ksor`) the pnpm shape — so the commands below use
+  the pnpm spelling and your own scaffold's README speaks your manager.
 - Inside a scaffolded project, `pnpm install && pnpm dev` serves the record
   at `http://localhost:3000`; `pnpm build` writes a fully static export to
   `system/site/out/`. `KSOR_BASE_PATH=/repo pnpm build` targets sub-path

--- a/packages/ksor/src/cli.ts
+++ b/packages/ksor/src/cli.ts
@@ -128,6 +128,9 @@ async function main(args: readonly string[]): Promise<number> {
         version: pkg.version,
         // Resolved from the built cli.mjs location: dist/ -> package root.
         templatesDir: fileURLToPath(new URL("../templates/scaffold", import.meta.url)),
+        // Names the manager that spawned this run (npx/pnpm dlx/bunx), so
+        // init can emit the scaffold for the adopter's own toolchain (#28).
+        userAgent: process.env.npm_config_user_agent,
       },
     );
   }

--- a/packages/ksor/src/init-manager.integration.test.ts
+++ b/packages/ksor/src/init-manager.integration.test.ts
@@ -1,0 +1,198 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+/**
+ * Issue #28: the scaffold meets the adopter's package manager instead of
+ * conscripting one. `ksor init` reads npm_config_user_agent — set by every
+ * manager for the process it spawns, so the run that scaffolds is the run
+ * that knows the toolchain — and emits that manager's scaffold. Unrecognized
+ * or absent, it emits pnpm, the most-protected posture and the one every
+ * scaffold got before this existed.
+ *
+ * All three shapes were proven END TO END against the published 0.0.35
+ * before this landed: install, `ksor` bin resolution, and a full static
+ * site build under pnpm, npm (341 packages, scripts denied), and bun
+ * (bun's own default-deny lifecycle posture). What this suite holds cheaply
+ * is the EMITTED BYTES per manager; the install walks live in the gated e2e.
+ */
+
+const distCli = path.resolve(
+  path.dirname(new URL(import.meta.url).pathname),
+  "..",
+  "dist",
+  "cli.mjs",
+);
+
+const AGENTS = {
+  pnpm: "pnpm/11.22.0 npm/? node/v24.5.0 darwin arm64",
+  npm: "npm/11.6.0 node/v24.5.0 darwin arm64 workspaces/false",
+  bun: "bun/1.3.6 npm/? node/v24.3.0 darwin arm64",
+} as const;
+
+let workDirs: string[] = [];
+afterEach(() => {
+  for (const dir of workDirs) rmSync(dir, { recursive: true, force: true });
+  workDirs = [];
+});
+
+function scaffold(userAgent: string | undefined): { root: string; stdout: string } {
+  const dir = mkdtempSync(path.join(tmpdir(), "ksor-mgr-"));
+  workDirs.push(dir);
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  delete env.npm_config_user_agent;
+  if (userAgent !== undefined) env.npm_config_user_agent = userAgent;
+  const result = spawnSync(process.execPath, [distCli, "init", "demo"], {
+    cwd: dir,
+    encoding: "utf8",
+    env,
+  });
+  expect(result.status, result.stderr).toBe(0);
+  return { root: path.join(dir, "demo"), stdout: result.stdout };
+}
+
+function manifest(root: string): {
+  scripts: Record<string, string>;
+  workspaces?: string[];
+  packageManager?: string;
+} {
+  return JSON.parse(readFileSync(path.join(root, "package.json"), "utf8")) as never;
+}
+
+/**
+ * Every text file of a scaffold, joined — the surface an adopter and their
+ * agent actually read. Used to assert the OTHER managers' names are gone.
+ */
+function allProse(root: string): Map<string, string> {
+  const out = new Map<string, string>();
+  const stack = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop() as string;
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const p = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name !== "node_modules" && entry.name !== ".git") stack.push(p);
+      } else if (
+        /\.(md|json|yaml|yml|ts|tsx|mjs|js|txt)$/.test(entry.name) ||
+        entry.name === ".npmrc"
+      ) {
+        out.set(path.relative(root, p), readFileSync(p, "utf8"));
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * No instruction the adopter cannot run: outside the canonical quarantine
+ * disclosure (which NAMES pnpm on purpose — owner decision, 2026-08-24) and
+ * `.npmrc` (checked structurally below), "pnpm" must not survive translation.
+ */
+function assertNoForeignManager(root: string): void {
+  for (const [file, text] of allProse(root)) {
+    if (file === ".npmrc") continue;
+    const stripped = text.replaceAll(
+      /One honest difference from the pnpm scaffold[\s\S]*?\n\n/g,
+      "",
+    );
+    expect(stripped.includes("pnpm"), `${file} still says pnpm`).toBe(false);
+  }
+}
+
+describe("ksor init meets the invoking package manager", () => {
+  it("emits the pnpm scaffold when pnpm ran it — and when nothing recognizable did", () => {
+    for (const agent of [AGENTS.pnpm, undefined, "yarn/4.5.0 npm/? node/v24"]) {
+      const { root } = scaffold(agent);
+      expect(existsSync(path.join(root, "pnpm-workspace.yaml")), String(agent)).toBe(true);
+      expect(existsSync(path.join(root, "pnpm-lock.yaml")), String(agent)).toBe(true);
+      expect(existsSync(path.join(root, ".npmrc")), String(agent)).toBe(false);
+      const m = manifest(root);
+      expect(m.packageManager).toMatch(/^pnpm@/);
+      expect(m.scripts.dev).toBe("pnpm -C system/site dev");
+    }
+  });
+
+  it("emits an npm scaffold under npx: workspaces field, script denial, no pnpm anywhere", () => {
+    const { root, stdout } = scaffold(AGENTS.npm);
+
+    // pnpm's machinery must be absent, not inert.
+    expect(existsSync(path.join(root, "pnpm-workspace.yaml"))).toBe(false);
+    expect(existsSync(path.join(root, "pnpm-lock.yaml"))).toBe(false);
+
+    const m = manifest(root);
+    expect(m.workspaces).toEqual(["system/site", "system/gateways/*", "system/packages/*"]);
+    expect(m.packageManager).toBeUndefined();
+    expect(m.scripts.dev).toBe("npm --prefix system/site run dev");
+    expect(m.scripts.build).toBe("npm run export-denylist && npm --prefix system/site run build");
+    expect(m.scripts.provision).toBe("npm run schema && npm run grant");
+
+    // The denial half of the supply-chain posture translates; the emitted file
+    // must also DISCLOSE the half that does not (pnpm's 48h quarantine).
+    const npmrc = readFileSync(path.join(root, ".npmrc"), "utf8");
+    expect(npmrc.toLowerCase()).toContain("48-hour");
+    // Structural, not textual: comments may say anything (they carry the
+    // disclosure); the DIRECTIVES must be exactly the script denial.
+    const directives = npmrc
+      .split("\n")
+      .filter((line) => line.trim() !== "" && !line.startsWith("#"));
+    expect(directives).toEqual(["ignore-scripts=true"]);
+
+    // The whole scaffold — README, AGENTS.md, the agent kit, seed content —
+    // speaks npm. A surviving "pnpm" is an instruction the adopter cannot run.
+    assertNoForeignManager(root);
+
+    // The handoff the CLI prints is the first thing an adopter runs.
+    expect(stdout).toContain("npm install");
+    expect(stdout).not.toContain("pnpm");
+  });
+
+  it("emits a bun scaffold under bunx: workspaces field, cd-chain scripts, no pnpm anywhere", () => {
+    const { root, stdout } = scaffold(AGENTS.bun);
+
+    expect(existsSync(path.join(root, "pnpm-workspace.yaml"))).toBe(false);
+    expect(existsSync(path.join(root, "pnpm-lock.yaml"))).toBe(false);
+
+    const m = manifest(root);
+    expect(m.workspaces).toEqual(["system/site", "system/gateways/*", "system/packages/*"]);
+    expect(m.packageManager).toBeUndefined();
+    // `bun --cwd <dir> run <script>` ran the WRONG script inside a workspace
+    // (observed live on bun 1.3.6: `run build` executed `dev`), so bun scripts
+    // are cd-chains, which bun's own cross-platform shell executes on Windows.
+    expect(m.scripts.dev).toBe("cd system/site && bun run dev");
+    expect(m.scripts.build).toBe("bun run export-denylist && cd system/site && bun run build");
+
+    assertNoForeignManager(root);
+    // The quarantine disclosure must survive into the bun README too — bun has
+    // no .npmrc to carry it.
+    const readme = readFileSync(path.join(root, "README.md"), "utf8");
+    expect(readme).toContain("48 hours");
+    expect(stdout).toContain("bun install");
+    expect(stdout).not.toContain("pnpm");
+  });
+
+  it("is deterministic per manager: two npm scaffolds are byte-identical", () => {
+    const a = scaffold(AGENTS.npm).root;
+    const b = scaffold(AGENTS.npm).root;
+    const left = allProse(a);
+    const right = allProse(b);
+    expect([...left.keys()].sort()).toEqual([...right.keys()].sort());
+    for (const [file, text] of left) expect(right.get(file), file).toBe(text);
+  });
+
+  it("keeps the two skill mirrors byte-identical after translation", () => {
+    const { root } = scaffold(AGENTS.npm);
+    const skills = path.join(root, ".agents", "skills");
+    const claude = path.join(root, ".claude", "skills");
+    const walk = (dir: string): string[] =>
+      readdirSync(dir, { withFileTypes: true }).flatMap((e) =>
+        e.isDirectory() ? walk(path.join(dir, e.name)) : [path.join(dir, e.name)],
+      );
+    for (const file of walk(skills)) {
+      const twin = path.join(claude, path.relative(skills, file));
+      expect(readFileSync(file, "utf8"), twin).toBe(readFileSync(twin, "utf8"));
+    }
+  });
+});

--- a/packages/ksor/src/init.integration.test.ts
+++ b/packages/ksor/src/init.integration.test.ts
@@ -18,6 +18,8 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { afterEach, describe, expect, it } from "vitest";
 
+import { applyProse } from "./init/manager.js";
+
 // Acceptance for specs/ksor/init/spec.md, written red-first: every test here
 // exercises the BUILT artifact (dist/cli.mjs), exactly what an adopter runs.
 const distDir = fileURLToPath(new URL("../dist", import.meta.url));
@@ -67,9 +69,13 @@ function dotDir(name = "my-sor"): string {
 }
 
 function runInit(args: readonly string[], cwd: string) {
+  // Pinned to the pnpm scaffold: these acceptance clauses describe the default
+  // shape, whatever manager happens to run the test suite. The manager
+  // dimension (issue #28) is covered by init-manager.integration.test.ts.
   return spawnSync(process.execPath, [distCli, "init", ...args], {
     cwd,
     encoding: "utf8",
+    env: { ...process.env, npm_config_user_agent: "pnpm/11.22.0 npm/? node/v24" },
   });
 }
 
@@ -119,7 +125,11 @@ function treeFiles(root: string): string[] {
   return walk(root).sort();
 }
 
-/** The emitted tree is the shipped templates plus exactly the two stamps. */
+/**
+ * The emitted tree is the shipped templates plus exactly the two stamps and
+ * the manager translation (issue #28) — for pnpm that translation only strips
+ * the `ksor:pm` marker lines, so identity stays byte-exact and computable.
+ */
 function expectTemplateIdentity(projectDir: string, name: string): void {
   const templated = treeFiles(templatesDir);
   expect(treeFiles(projectDir)).toEqual(templated.map(emittedPath).sort());
@@ -127,8 +137,9 @@ function expectTemplateIdentity(projectDir: string, name: string): void {
     const stamped = readFileSync(path.join(templatesDir, rel), "utf8")
       .replaceAll("KSOR-STAMP-NAME", name)
       .replaceAll("KSOR-STAMP-VERSION", pkgVersion);
+    const expected = applyProse(stamped, "pnpm");
     const actual = readFileSync(path.join(projectDir, emittedPath(rel)), "utf8");
-    expect(actual, `stamping mismatch in ${rel}`).toBe(stamped);
+    expect(actual, `stamping mismatch in ${rel}`).toBe(expected);
   }
 }
 
@@ -287,7 +298,7 @@ describe("ksor init — acceptance (spec clauses 1-3)", () => {
     },
   );
 
-  it("output matches the shipped templates plus exactly the two stamps", () => {
+  it("output matches the shipped templates plus the two stamps and the manager translation", () => {
     // Two names, because a stamp that silently kept its default would pass
     // with one: only a second name proves the substitution is the variable.
     for (const name of ["my-sor", "second-record"]) {

--- a/packages/ksor/src/init/index.ts
+++ b/packages/ksor/src/init/index.ts
@@ -12,7 +12,8 @@ import path from "node:path";
 
 import { type ExitCode, exitCodes } from "../index.js";
 import { errnoCode, isEnvironmentError } from "./errors.js";
-import { materialize } from "./materialize.js";
+import { detectManager, type PackageManager } from "./manager.js";
+import { materialize, materializeExtras } from "./materialize.js";
 import { nameProblem, suggestName } from "./name.js";
 import { findAncestorProject, findAncestorWorkspace } from "./walk.js";
 
@@ -25,6 +26,8 @@ export interface InitIo {
 export interface InitEnv {
   readonly version: string;
   readonly templatesDir: string;
+  /** `npm_config_user_agent` as the CLI received it — names the manager that ran init. */
+  readonly userAgent?: string;
 }
 
 const STAGE_PREFIX = ".ksor-init-";
@@ -114,30 +117,47 @@ function gitInit(dir: string, io: InitIo): void {
   }
 }
 
-function handoff(io: InitIo, name: string, targetWasDot: boolean): void {
+function handoff(io: InitIo, name: string, targetWasDot: boolean, manager: PackageManager): void {
   const enter = targetWasDot ? "" : `  cd ${name}\n`;
+  const run = (script: string): string =>
+    manager === "pnpm"
+      ? `pnpm ${script}`
+      : manager === "npm"
+        ? `npm run ${script}`
+        : `bun run ${script}`;
+  const install = manager === "pnpm" ? "pnpm install" : `${manager} install`;
+  // The scaffold was emitted FOR the manager that ran init, so the hint that
+  // once said "no pnpm? install it" describes a prerequisite that no longer
+  // exists: whoever is reading this just used the manager these commands need.
+  const pnpmHint =
+    manager === "pnpm"
+      ? "no pnpm? run: npm install -g pnpm — or `corepack enable pnpm` on Nodes that bundle corepack\n" +
+        "\n"
+      : "";
   io.out(
     `${name} is ready — your knowledge, your repo, yours outright.\n` +
       "\n" +
       "Next (or just tell your coding agent to take it from here):\n" +
       enter +
-      "  pnpm install\n" +
-      "  pnpm dev        # the site, live at http://localhost:3000\n" +
+      `  ${install}\n` +
+      `  ${run("dev").padEnd(15)} # the site, live at http://localhost:3000\n` +
       "\n" +
       "Then, for the agent surface (needs Postgres and a provider key):\n" +
-      "  pnpm provision  # once: uncomment `database:` in instance.md, copy\n" +
+      `  ${run("provision").padEnd(15)} # once: uncomment \`database:\` in instance.md, copy\n` +
       "                  #   .env.example to .env, then apply the schema\n" +
-      "  pnpm refresh    # PUBLISH the record — ingest knowledge/ into a generation\n" +
-      "  pnpm serve      # the MCP server, over what you just published\n" +
+      `  ${run("refresh").padEnd(15)} # PUBLISH the record — ingest knowledge/ into a generation\n` +
+      `  ${run("serve").padEnd(15)} # the MCP server, over what you just published\n` +
       "\n" +
-      "no pnpm? run: npm install -g pnpm — or `corepack enable pnpm` on Nodes that bundle corepack\n" +
-      "\n" +
+      pnpmHint +
       "Start in knowledge/ — AGENTS.md carries the working rules.\n",
   );
 }
 
 function init(args: readonly string[], cwd: string, io: InitIo, env: InitEnv): number {
   const { version, templatesDir } = env;
+  // The run that scaffolds is the run that knows the toolchain (issue #28):
+  // `npx …` emits an npm scaffold, `bunx …` a bun one, everything else pnpm.
+  const manager = detectManager(env.userAgent);
 
   // A missing template tree is not something a better command can fix, so it
   // is answered before any argument is judged.
@@ -244,7 +264,8 @@ function init(args: readonly string[], cwd: string, io: InitIo, env: InitEnv): n
     // which makes the rollback the spec promises ours to perform.
     const created: string[] = [];
     try {
-      materialize(templatesDir, targetDir, { name, version }, created);
+      materialize(templatesDir, targetDir, { name, version }, manager, created);
+      materializeExtras(targetDir, manager, created);
     } catch (error) {
       rollback(created);
       throw error;
@@ -252,7 +273,8 @@ function init(args: readonly string[], cwd: string, io: InitIo, env: InitEnv): n
   } else {
     const stage = mkdtempSync(path.join(path.dirname(targetDir), STAGE_PREFIX));
     try {
-      materialize(templatesDir, stage, { name, version });
+      materialize(templatesDir, stage, { name, version }, manager);
+      materializeExtras(stage, manager);
     } catch (error) {
       rmSync(stage, { recursive: true, force: true });
       throw error;
@@ -297,7 +319,7 @@ function init(args: readonly string[], cwd: string, io: InitIo, env: InitEnv): n
     const detail = error instanceof Error ? error.message : String(error);
     io.err(`note: the project was created, but a follow-up step failed: ${detail}\n`);
   }
-  handoff(io, name, isDot);
+  handoff(io, name, isDot, manager);
   return 0;
 }
 

--- a/packages/ksor/src/init/manager.test.ts
+++ b/packages/ksor/src/init/manager.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import { applyProse, detectManager, isSkippedFor, transformManifest } from "./manager.js";
+
+describe("detectManager", () => {
+  it("names the manager from the first user-agent token", () => {
+    expect(detectManager("npm/11.6.0 node/v24.5.0 darwin arm64")).toBe("npm");
+    expect(detectManager("bun/1.3.6 npm/? node/v24.3.0")).toBe("bun");
+    expect(detectManager("pnpm/11.22.0 npm/? node/v24")).toBe("pnpm");
+  });
+
+  it("falls back to pnpm — absent, unrecognized, or garbage", () => {
+    expect(detectManager(undefined)).toBe("pnpm");
+    expect(detectManager("")).toBe("pnpm");
+    expect(detectManager("yarn/4.5.0 npm/? node/v24")).toBe("pnpm");
+    expect(detectManager("npmate/1.0")).toBe("pnpm");
+  });
+});
+
+describe("isSkippedFor", () => {
+  it("keeps every template file for pnpm and drops only pnpm's machinery otherwise", () => {
+    expect(isSkippedFor("pnpm-workspace.yaml", "pnpm")).toBe(false);
+    expect(isSkippedFor("pnpm-lock.yaml", "npm")).toBe(true);
+    expect(isSkippedFor("pnpm-workspace.yaml", "bun")).toBe(true);
+    expect(isSkippedFor("package.json", "npm")).toBe(false);
+  });
+});
+
+describe("transformManifest", () => {
+  const source = JSON.stringify(
+    {
+      name: "demo",
+      scripts: { dev: "pnpm -C system/site dev", check: "node check.mjs" },
+      packageManager: "pnpm@11.22.0",
+    },
+    null,
+    2,
+  );
+
+  it("is the identity for pnpm", () => {
+    expect(transformManifest(source, "pnpm")).toBe(source);
+  });
+
+  it("rewrites manager-owned scripts, keeps the rest, drops the pnpm pin", () => {
+    const npm = JSON.parse(transformManifest(source, "npm")) as {
+      scripts: Record<string, string>;
+      workspaces: string[];
+      packageManager?: string;
+    };
+    expect(npm.scripts.dev).toBe("npm --prefix system/site run dev");
+    expect(npm.scripts.check).toBe("node check.mjs");
+    expect(npm.packageManager).toBeUndefined();
+    expect(npm.workspaces).toContain("system/site");
+  });
+});
+
+describe("applyProse", () => {
+  const text = [
+    "always",
+    "<!-- ksor:pm pnpm -->",
+    "pnpm-only",
+    "<!-- /ksor:pm -->",
+    "<!-- ksor:pm npm bun -->",
+    "npm-and-bun",
+    "<!-- /ksor:pm -->",
+    "run `pnpm check` before pushing",
+  ].join("\n");
+
+  it("keeps a block for the managers it names, and strips every marker line", () => {
+    const pnpm = applyProse(text, "pnpm");
+    expect(pnpm).toContain("pnpm-only");
+    expect(pnpm).not.toContain("npm-and-bun");
+    expect(pnpm).not.toContain("ksor:pm");
+    const bun = applyProse(text, "bun");
+    expect(bun).not.toContain("pnpm-only");
+    expect(bun).toContain("npm-and-bun");
+  });
+
+  it("translates command spellings for npm and bun, never for pnpm", () => {
+    expect(applyProse(text, "pnpm")).toContain("run `pnpm check` before pushing");
+    expect(applyProse(text, "npm")).toContain("run `npm run check` before pushing");
+    expect(applyProse(text, "bun")).toContain("run `bun run check` before pushing");
+  });
+
+  it("orders spellings so the longest wins: install is never half-eaten", () => {
+    expect(applyProse("pnpm install --no-frozen-lockfile", "npm")).toBe("npm install");
+    expect(applyProse("pnpm install", "bun")).toBe("bun install");
+    expect(applyProse("pnpm exec ksor serve", "npm")).toBe("npx ksor serve");
+    expect(applyProse("pnpm dlx shadcn@latest add card", "bun")).toBe(
+      "bunx shadcn@latest add card",
+    );
+  });
+});

--- a/packages/ksor/src/init/manager.ts
+++ b/packages/ksor/src/init/manager.ts
@@ -1,0 +1,209 @@
+/**
+ * The scaffold meets the adopter's package manager (issue #28).
+ *
+ * Decision 1 makes Node the one prerequisite; requiring a SPECIFIC manager on
+ * top of it re-added the second-prerequisite tax that decision exists to
+ * avoid. So `ksor init` reads `npm_config_user_agent` — every manager sets it
+ * for the process it spawns, so the run that scaffolds is the run that knows
+ * the toolchain — and emits that manager's scaffold. Unrecognized or absent
+ * falls back to pnpm: the most-protected posture, and the one every scaffold
+ * got before this existed.
+ *
+ * Three shapes, each proven end to end (install, bin resolution, full static
+ * build) against the published CLI before this landed:
+ *
+ *   pnpm  today's scaffold, byte-for-byte — workspace file, committed
+ *         site-only lockfile, 48h release quarantine, install-script denial
+ *   npm   `workspaces` field, `.npmrc` with `ignore-scripts=true`, no
+ *         lockfile (npm keeps ONE root lock and the stamped CLI version
+ *         cannot be pre-resolved into it — the tarball hash does not exist
+ *         when the template is built; the first install writes it)
+ *   bun   `workspaces` field, cd-chain scripts (bun's own shell runs them on
+ *         Windows too — `bun --cwd <dir> run <script>` executed the WRONG
+ *         script in a workspace, observed live on 1.3.6), no lockfile; bun
+ *         denies dependency lifecycle scripts by default, so the denial half
+ *         of the posture is bun's own
+ *
+ * What npm and bun CANNOT give the adopter is pnpm's 48-hour quarantine on
+ * newly published dependency versions. That absence is DISCLOSED in the
+ * emitted scaffold (owner decision, 2026-08-24) — honest absence, never
+ * silent weakness — rather than either refusing those managers or pretending
+ * the postures are equal.
+ */
+
+export type PackageManager = "pnpm" | "npm" | "bun";
+
+/** Every manager the scaffold can be emitted for. */
+export const MANAGERS: readonly PackageManager[] = ["pnpm", "npm", "bun"];
+
+/**
+ * Which manager spawned this process, from `npm_config_user_agent`
+ * (e.g. "pnpm/11.22.0 npm/? node/v24.5.0 darwin arm64"). The first token
+ * names the manager; only managers we emit a scaffold for are recognized.
+ */
+export function detectManager(userAgent: string | undefined): PackageManager {
+  const head = (userAgent ?? "").split("/")[0]?.trim();
+  if (head === "npm") return "npm";
+  if (head === "bun") return "bun";
+  return "pnpm";
+}
+
+/** Template files that belong to exactly one manager's scaffold. */
+export function isSkippedFor(templateName: string, manager: PackageManager): boolean {
+  if (manager === "pnpm") return false;
+  return templateName === "pnpm-workspace.yaml" || templateName === "pnpm-lock.yaml";
+}
+
+/**
+ * The workspace globs, shared by every manager. pnpm reads them from
+ * pnpm-workspace.yaml; npm and bun read a `workspaces` field. One constant so
+ * the two spellings cannot drift.
+ */
+export const WORKSPACE_GLOBS: readonly string[] = [
+  "system/site",
+  "system/gateways/*",
+  "system/packages/*",
+];
+
+/**
+ * The root scripts, per manager. pnpm's are the template's own bytes; npm and
+ * bun REPLACE the manager-specific bodies and inherit everything else.
+ * npm: `--prefix` is npm's spelling of "run it over there".
+ * bun: cd-chains — see the module comment for why not `--cwd`.
+ */
+const SCRIPT_BODIES: Record<Exclude<PackageManager, "pnpm">, Record<string, string>> = {
+  npm: {
+    dev: "npm --prefix system/site run dev",
+    build: "npm run export-denylist && npm --prefix system/site run build",
+    provision: "npm run schema && npm run grant",
+    refresh: "npm run ingest && npm run gc",
+  },
+  bun: {
+    dev: "cd system/site && bun run dev",
+    build: "bun run export-denylist && cd system/site && bun run build",
+    provision: "bun run schema && bun run grant",
+    refresh: "bun run ingest && bun run gc",
+  },
+};
+
+/**
+ * Rewrite the scaffold's root package.json for the manager. Structured — a
+ * JSON transform, never string surgery — because the manifest is the one
+ * file where a half-applied spelling map would still parse and then lie.
+ */
+export function transformManifest(source: string, manager: PackageManager): string {
+  if (manager === "pnpm") return source;
+  const parsed = JSON.parse(source) as Record<string, unknown> & {
+    scripts: Record<string, string>;
+  };
+  const { packageManager: _dropped, ...rest } = parsed;
+  const out: Record<string, unknown> = {
+    ...rest,
+    scripts: { ...parsed.scripts, ...SCRIPT_BODIES[manager] },
+    workspaces: [...WORKSPACE_GLOBS],
+  };
+  return `${JSON.stringify(out, null, 2)}\n`;
+}
+
+/**
+ * Ordered prose translation, longest spelling first so `pnpm install` is
+ * never half-eaten by a shorter rule. Applied to every emitted text file
+ * except package.json (structured above). The conformance test asserts ZERO
+ * surviving "pnpm" tokens outside the quarantine disclosure, so a template
+ * edit that adds a spelling this map misses goes red instead of shipping an
+ * instruction the adopter cannot run.
+ */
+const SCRIPT_NAMES = [
+  "dev",
+  "build",
+  "check",
+  "serve",
+  "provision",
+  "refresh",
+  "schema",
+  "grant",
+  "ingest",
+  "gc",
+  "export-denylist",
+] as const;
+
+function spellings(manager: Exclude<PackageManager, "pnpm">): readonly [string, string][] {
+  const run = (script: string): string =>
+    manager === "npm" ? `npm run ${script}` : `bun run ${script}`;
+  const pairs: [string, string][] = [
+    ["pnpm install --no-frozen-lockfile", manager === "npm" ? "npm install" : "bun install"],
+    ["pnpm install", manager === "npm" ? "npm install" : "bun install"],
+    ["pnpm exec ksor", manager === "npm" ? "npx ksor" : "bunx ksor"],
+    ["pnpm dlx", manager === "npm" ? "npx" : "bunx"],
+    ["pnpm add -D", manager === "npm" ? "npm i -D" : "bun add -d"],
+    [
+      "pnpm -C system/site",
+      manager === "npm" ? "npm --prefix system/site run" : "cd system/site && bun run",
+    ],
+  ];
+  for (const script of SCRIPT_NAMES) pairs.push([`pnpm ${script}`, run(script)]);
+  return pairs;
+}
+
+/**
+ * Manager-conditional blocks in markdown templates:
+ *
+ *   <!-- ksor:pm pnpm npm -->
+ *   ...lines kept only for those managers...
+ *   <!-- /ksor:pm -->
+ *
+ * The marker lines themselves never survive into any scaffold, so the pnpm
+ * output stays exactly what an adopter always got.
+ */
+const BLOCK_OPEN = /^[ \t]*<!-- ksor:pm ([a-z ]+?) -->[ \t]*$/;
+const BLOCK_CLOSE = /^[ \t]*<!-- \/ksor:pm -->[ \t]*$/;
+
+export function applyProse(text: string, manager: PackageManager): string {
+  const lines = text.split("\n");
+  const kept: string[] = [];
+  let keeping = true;
+  let inBlock = false;
+  for (const line of lines) {
+    const open = BLOCK_OPEN.exec(line);
+    if (open !== null) {
+      inBlock = true;
+      keeping = (open[1] as string).split(/\s+/).includes(manager);
+      continue;
+    }
+    if (BLOCK_CLOSE.test(line)) {
+      inBlock = false;
+      keeping = true;
+      continue;
+    }
+    if (!inBlock || keeping) kept.push(line);
+  }
+  let out = kept.join("\n");
+  if (manager !== "pnpm") {
+    for (const [from, to] of spellings(manager)) out = out.replaceAll(from, to);
+  }
+  return out;
+}
+
+/**
+ * Files a manager's scaffold gains beyond the template tree. npm's `.npmrc`
+ * carries the denial half of the posture and DISCLOSES the missing half; bun
+ * needs no file — denial is bun's own default — so its disclosure lives in
+ * the README's lockfile note.
+ */
+export function extraFiles(manager: PackageManager): readonly [string, string][] {
+  if (manager !== "npm") return [];
+  return [
+    [
+      ".npmrc",
+      "# Dependency install scripts are denied — the same posture the pnpm\n" +
+        "# scaffold enforces per-package. Flip to false only with a comment naming\n" +
+        "# what breaks without it.\n" +
+        "#\n" +
+        "# What npm cannot give you is pnpm's 48-hour quarantine on newly\n" +
+        "# published dependency versions (minimumReleaseAge): under npm a routine\n" +
+        "# install can pick up a day-zero compromised release the day it ships.\n" +
+        "# That protection exists only under pnpm.\n" +
+        "ignore-scripts=true\n",
+    ],
+  ];
+}

--- a/packages/ksor/src/init/materialize.ts
+++ b/packages/ksor/src/init/materialize.ts
@@ -8,6 +8,14 @@ import {
 } from "node:fs";
 import path from "node:path";
 
+import {
+  applyProse,
+  extraFiles,
+  isSkippedFor,
+  transformManifest,
+  type PackageManager,
+} from "./manager.js";
+
 /** The exactly-two authored substitutions (spec: templates + two stamps). */
 export interface Stamps {
   readonly name: string;
@@ -56,14 +64,30 @@ export function materialize(
   templateDir: string,
   targetDir: string,
   stamps: Stamps,
+  manager: PackageManager = "pnpm",
   created: string[] = [],
 ): readonly string[] {
+  materializeTree(templateDir, targetDir, stamps, manager, created, true);
+  return created;
+}
+
+function materializeTree(
+  templateDir: string,
+  targetDir: string,
+  stamps: Stamps,
+  manager: PackageManager,
+  created: string[],
+  isRoot: boolean,
+): void {
   for (const entry of readdirSync(templateDir, { withFileTypes: true })) {
     // A dev checkout's template can be accidentally installed into (found
     // live 2026-08-18: a concurrent agent left 477 MB of node_modules there);
     // the scaffold must never inherit it. The published tarball never
     // carries one, so this guard is inert in production.
     if (entry.name === "node_modules") continue;
+    // A manager's scaffold carries only its own machinery: pnpm-workspace.yaml
+    // and the committed lockfile belong to the pnpm shape alone (issue #28).
+    if (isRoot && isSkippedFor(entry.name, manager)) continue;
     const from = path.join(templateDir, entry.name);
     const to = path.join(targetDir, EMITTED_NAMES.get(entry.name) ?? entry.name);
     if (entry.isDirectory()) {
@@ -71,11 +95,18 @@ export function materialize(
         mkdirSync(to, { recursive: true });
         created.push(to);
       }
-      materialize(from, to, stamps, created);
+      materializeTree(from, to, stamps, manager, created, false);
     } else if (isTextFile(from)) {
-      const text = readFileSync(from, "utf8")
+      const stamped = readFileSync(from, "utf8")
         .replaceAll("KSOR-STAMP-NAME", stamps.name)
         .replaceAll("KSOR-STAMP-VERSION", stamps.version);
+      // The manifest is transformed structurally; every other text file gets
+      // the prose translation (manager blocks + spellings). Both are pure
+      // functions of shipped bytes, so byte-determinism per manager holds.
+      const text =
+        isRoot && entry.name === "package.json"
+          ? transformManifest(stamped, manager)
+          : applyProse(stamped, manager);
       // Tracked before the write: a mid-write ENOSPC leaves a partial file
       // the rollback must still remove (review finding, 2026-08-18).
       created.push(to);
@@ -84,6 +115,19 @@ export function materialize(
       created.push(to);
       copyFileSync(from, to);
     }
+  }
+}
+
+/** Emit the files a manager's scaffold gains beyond the template tree. */
+export function materializeExtras(
+  targetDir: string,
+  manager: PackageManager,
+  created: string[] = [],
+): readonly string[] {
+  for (const [name, content] of extraFiles(manager)) {
+    const to = path.join(targetDir, name);
+    created.push(to);
+    writeFileSync(to, content);
   }
   return created;
 }

--- a/packages/ksor/templates/scaffold/AGENTS.md
+++ b/packages/ksor/templates/scaffold/AGENTS.md
@@ -112,7 +112,8 @@ Stand it up in this order (each step's errors explain how to fix themselves):
 
    `provision` is separate on purpose: applying DDL and granting ingest are acts
    an operator performs, not side effects of starting a server. (It is not
-   called `setup` because `pnpm setup` is pnpm's own command and would shadow
+   called `setup` because package managers claim that word for commands of
+   their own, which would shadow
    it — the step would print "No changes to the environment were made" and do
    nothing.)
 

--- a/packages/ksor/templates/scaffold/README.md
+++ b/packages/ksor/templates/scaffold/README.md
@@ -18,8 +18,11 @@ pnpm install
 pnpm dev        # browse the knowledge at http://localhost:3000
 ```
 
+<!-- ksor:pm pnpm -->
 No pnpm? Run `npm install -g pnpm` — or `corepack enable pnpm` on Node
-versions that bundle corepack. The first `pnpm install` also fetches the
+versions that bundle corepack.
+<!-- /ksor:pm -->
+The first `pnpm install` also fetches the
 `ksor` tool (pinned in `package.json`) and writes it into your lockfile —
 commit the updated lockfile.
 
@@ -128,6 +131,7 @@ the record well-formed (`format-checker`, also `pnpm check`).
 
 ### A note on the lockfile
 
+<!-- ksor:pm pnpm -->
 The committed `pnpm-lock.yaml` covers the site. It cannot cover
 `@panaversity/ksor` itself, because the version pinned in `package.json` is
 stamped by the CLI that scaffolded this project and could not be resolved before
@@ -138,6 +142,34 @@ The deploy config already accounts for this (`vercel.json` installs with
 `--no-frozen-lockfile`), and the shipped `validate.yml` runs no install. If you
 add CI of your own, note that pnpm turns on `--frozen-lockfile` automatically
 whenever `CI` is set.
+<!-- /ksor:pm -->
+<!-- ksor:pm npm -->
+No lockfile ships with this scaffold: npm keeps ONE lock for the whole
+workspace, and the `@panaversity/ksor` version pinned in `package.json` was
+stamped by the CLI that scaffolded this project — it could not be resolved
+into a lock before it existed. Your FIRST `npm install` writes
+`package-lock.json`; run it before you push, and COMMIT the result — that
+lock is why two machines build the same site.
+
+One honest difference from the pnpm scaffold: pnpm quarantines newly
+published dependency versions for 48 hours (`minimumReleaseAge`), so a
+routine install never picks up a day-zero compromised release. npm has no
+equivalent — `.npmrc` here carries the install-script denial half of that
+posture, and this sentence is the disclosure of the half it cannot.
+<!-- /ksor:pm -->
+<!-- ksor:pm bun -->
+No lockfile ships with this scaffold: the `@panaversity/ksor` version pinned
+in `package.json` was stamped by the CLI that scaffolded this project — it
+could not be resolved into a lock before it existed. Your FIRST
+`bun install` writes `bun.lock`; run it before you push, and COMMIT the
+result — that lock is why two machines build the same site.
+
+One honest difference from the pnpm scaffold: pnpm quarantines newly
+published dependency versions for 48 hours (`minimumReleaseAge`), so a
+routine install never picks up a day-zero compromised release. bun has no
+equivalent (its default refusal of dependency install scripts covers the
+OTHER half of that posture), and this sentence is the disclosure.
+<!-- /ksor:pm -->
 
 ## The files, explained
 
@@ -158,9 +190,18 @@ different coding agent's way of finding the same working contract.
 | `.gitattributes`                 | markdown is checked out byte-stable on every platform, so the same commit hashes the same everywhere.                                                                                                                            |
 | `.env.example`                   | the variables the served rung needs; copy to `.env` (gitignored) and fill in. |
 | `.gitignore`                     | keeps build output, `node_modules/`, and `.env` out of the record's history.                                                                                                                                                    |
-| `package.json`                   | the surface commands — `pnpm dev` (the site) and `pnpm provision` / `pnpm refresh` / `pnpm serve` (the agent surface: set up once, publish, then serve) — plus `pnpm build` / `pnpm check`, the pinned `@panaversity/ksor` tool, and the pnpm version this project pins.                                                |
+| `package.json`                   | the surface commands — `pnpm dev` (the site) and `pnpm provision` / `pnpm refresh` / `pnpm serve` (the agent surface: set up once, publish, then serve) — plus `pnpm build` / `pnpm check`, the pinned `@panaversity/ksor` tool and the workspace layout the manifest declares.                                                |
+<!-- ksor:pm pnpm -->
 | `pnpm-workspace.yaml`            | where the workspace looks for code (`system/site`, plus reserved `system/gateways/*` and `system/packages/*`), and the supply-chain policy for installs.                                                                         |
 | `pnpm-lock.yaml`                 | the exact dependency versions — the reason two machines build the same site.                                                                                                                                                     |
+<!-- /ksor:pm -->
+<!-- ksor:pm npm -->
+| `.npmrc`                         | dependency install scripts are denied; the comment inside discloses the one protection this scaffold lacks (a 48-hour quarantine on new releases). |
+| `package-lock.json`              | the exact dependency versions — written by your FIRST install; commit it, it is the reason two machines build the same site. |
+<!-- /ksor:pm -->
+<!-- ksor:pm bun -->
+| `bun.lock`                       | the exact dependency versions — written by your FIRST install; commit it, it is the reason two machines build the same site. |
+<!-- /ksor:pm -->
 
 `format-checker` deliberately contains a program, `check.mjs`, and not only
 prose: rules that are only written down cannot refuse anything. `pnpm check`
@@ -181,9 +222,11 @@ and anything that can serve files can serve it.
   (never pin `system/site` as the root directory — the record lives
   outside it), build with `pnpm build`, serve `system/site/out/`. It also
   declares the MCP **door** as a second service built from the shipped
-  `Dockerfile`, so `/mcp` and the site share one domain. If the
-  build image's pnpm predates the `packageManager` pin, set the
+  `Dockerfile`, so `/mcp` and the site share one domain.
+<!-- ksor:pm pnpm -->
+  If the build image's pnpm predates the `packageManager` pin, set the
   `ENABLE_EXPERIMENTAL_COREPACK=1` build environment variable.
+<!-- /ksor:pm -->
 **Once `instance.md` declares a `database:`, the BUILD needs the DSN too.**
 `pnpm build` first runs `pnpm export-denylist`, which asks the record's
 database what has been withdrawn (`ksor takedown --export`) and writes

--- a/scripts/manager-acceptance.mjs
+++ b/scripts/manager-acceptance.mjs
@@ -1,0 +1,102 @@
+/**
+ * The scaffold, proven under the manager that asked for it (issue #28).
+ *
+ * `ksor init` reads npm_config_user_agent and emits the invoking manager's
+ * scaffold. The emitted-bytes contract lives in
+ * init-manager.integration.test.ts; what THIS walk holds is the claim those
+ * bytes make — that an adopter on npm or bun can install, resolve the pinned
+ * `ksor` bin, run the checker, and build the static site, with no pnpm on the
+ * machine's path anywhere in the walk.
+ *
+ * It installs the LOCAL build rather than the published one (the tier rule
+ * paid for with shipped defects: the test must install the same tree the
+ * artifact installs) — the stamped registry version may not exist yet when CI
+ * runs, so the dependency is swapped to the packed tarball, and that swap is
+ * the ONLY divergence from the emitted scaffold.
+ *
+ * Usage: node scripts/manager-acceptance.mjs <npm|bun>
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+const cli = path.join(repoRoot, "packages", "ksor", "dist", "cli.mjs");
+
+const manager = process.argv[2];
+const AGENTS = {
+  npm: "npm/11.6.0 node/v24.5.0 linux x64 workspaces/false",
+  bun: "bun/1.3.6 npm/? node/v24.3.0 linux x64",
+};
+if (!(manager in AGENTS)) {
+  console.error("usage: node scripts/manager-acceptance.mjs <npm|bun>");
+  process.exit(1);
+}
+
+function run(cmd, args, opts = {}) {
+  console.log(`$ ${cmd} ${args.join(" ")}`);
+  return execFileSync(cmd, args, { encoding: "utf8", stdio: "pipe", ...opts });
+}
+
+const work = mkdtempSync(path.join(tmpdir(), `ksor-mgr-${manager}-`));
+const project = path.join(work, "demo");
+try {
+  // Pack the local build with pnpm — the manifest uses the pnpm-only
+  // `catalog:` protocol, which only `pnpm pack` resolves.
+  run("pnpm", [
+    "--dir",
+    path.join(repoRoot, "packages", "ksor"),
+    "pack",
+    "--out",
+    path.join(work, "ksor-local.tgz"),
+  ]);
+  const tarball = path.join(work, "ksor-local.tgz");
+
+  run(process.execPath, [cli, "init", "demo"], {
+    cwd: work,
+    env: { ...process.env, npm_config_user_agent: AGENTS[manager] },
+  });
+
+  // The one divergence: the stamped version becomes the packed tarball.
+  const manifestPath = path.join(project, "package.json");
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  manifest.dependencies["@panaversity/ksor"] = `file:${tarball}`;
+  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+  const opts = { cwd: project, env: { ...process.env } };
+  if (manager === "npm") {
+    run("npm", ["install", "--no-audit", "--no-fund"], opts);
+    const version = run("npx", ["--no-install", "ksor", "--version"], opts).trim();
+    console.log(`ksor resolves: ${version}`);
+    run("npm", ["run", "check"], opts);
+    run("npm", ["run", "build"], opts);
+  } else {
+    run("bun", ["install"], opts);
+    const version = run("bunx", ["ksor", "--version"], opts).trim();
+    console.log(`ksor resolves: ${version}`);
+    run("bun", ["run", "check"], opts);
+    run("bun", ["run", "build"], opts);
+  }
+
+  for (const artifact of ["index.html", "llms.txt", "llms-full.txt"]) {
+    const p = path.join(project, "system", "site", "out", artifact);
+    if (!existsSync(p)) {
+      console.error(`MISSING from the built site: ${artifact}`);
+      process.exit(1);
+    }
+  }
+  // The walk built the site with the adopter's manager; the lockfile their
+  // first install writes is the reproducibility record the README told them
+  // to commit — assert it actually appeared.
+  const lock = manager === "npm" ? "package-lock.json" : "bun.lock";
+  if (!existsSync(path.join(project, lock))) {
+    console.error(`first install did not write ${lock}`);
+    process.exit(1);
+  }
+  console.log(`manager acceptance (${manager}): ok`);
+} finally {
+  rmSync(work, { recursive: true, force: true });
+}

--- a/specs/ksor/init/spec.md
+++ b/specs/ksor/init/spec.md
@@ -40,10 +40,27 @@ A parent pnpm workspace whose globs would swallow the project produces a
 warning, not a refusal.
 
 **Negative contract.** No network I/O. Never runs a package manager (the
-handoff text carries `pnpm install && pnpm dev`). Deterministic: the same
-ksor version and name produce byte-identical trees — enforced by shipping
-every emitted byte (the lockfile included) as template content in the ksor
-package. Atomic: staged in a sibling `.ksor-init-<random>/` then renamed
+handoff text carries the install/dev commands). Deterministic: the same
+ksor version, name AND invoking manager produce byte-identical trees —
+enforced by shipping every emitted byte (the lockfile included) as template
+content in the ksor package. _Revision 2026-08-24 (issue #28, owner): the
+scaffold meets the adopter's package manager. init reads
+`npm_config_user_agent` — the run that scaffolds is the run that knows the
+toolchain — and emits that manager's scaffold: `npx …` → npm, `bunx …` →
+bun, anything else (pnpm included) → pnpm, the most-protected posture. The
+emission is templates + the two stamps + a PURE manager translation:
+`ksor:pm` marker blocks in markdown, an ordered command-spelling map, a
+structured package.json transform, and per-manager machinery (pnpm keeps
+pnpm-workspace.yaml + the committed site-only lockfile; npm gains `.npmrc`
+with `ignore-scripts=true`; npm and bun declare `workspaces` in the
+manifest, ship NO lockfile — the stamped version cannot be pre-resolved into
+one — and their README says to commit the lock the first install writes).
+What npm and bun cannot give is pnpm's 48-hour release quarantine; that
+absence is DISCLOSED in the emitted scaffold, never silently dropped. bun
+scripts are cd-chains because `bun --cwd <dir> run <script>` ran the wrong
+script inside a workspace (observed live, bun 1.3.6). Each manager's shape
+is walked in CI: install, bin resolution, checker, full static build
+(`scripts/manager-acceptance.mjs`)._ Atomic: staged in a sibling `.ksor-init-<random>/` then renamed
 (`init .`: ordered writes with rollback); a failed init leaves the
 filesystem as found; stale stage dirs are reported, never deleted. Runs
 `git init` unless already inside a repository; never stages or commits. No


### PR DESCRIPTION
Closes #28.

## Problem

`ksor init` emitted a project only pnpm could run. Decision 1 makes Node the one prerequisite precisely so nothing else has to be installed first — and the scaffold's own answer to "no pnpm?" was *install a second package manager*. The adopter owns the repo (decision 4); the scaffold should meet their toolchain, not conscript it.

## Solution (decision 25 — three owner calls, recorded)

- **Managers**: pnpm + npm + bun, each proven end to end (install → `ksor` bin resolves → checker → full static build) before any code landed.
- **Selection**: detection only — `npm_config_user_agent` names the manager that spawned init, so `npx …` emits an npm scaffold, `bunx …` a bun one, anything unrecognized the pnpm shape. No `--pm` flag; the run that scaffolds is the run that knows the toolchain.
- **The posture gap is disclosed, not silenced**: npm/bun have no equivalent of pnpm's 48-hour release quarantine. The install-script denial half carries over (`.npmrc ignore-scripts=true`; bun's own default refusal) and the emitted scaffold names the half that cannot.

Emission stays pure and deterministic per manager: templates + the two stamps + a manager translation — `ksor:pm` marker blocks in markdown, an ordered command-spelling map, a structured `package.json` transform. The pnpm scaffold is unchanged. npm/bun declare `workspaces` in the manifest and ship no lockfile (the stamped CLI version cannot be pre-resolved into one — the tarball hash doesn't exist at template-build time); their README says to commit the lock the first install writes.

One live catch worth the walk: `bun --cwd system/site run build` executed the **wrong script** in a workspace (bun 1.3.6), so bun scripts are cd-chains, which bun's own cross-platform shell runs on Windows too.

## Held by

- `init-manager.integration.test.ts` — per-manager emitted bytes, `.npmrc` checked structurally, **zero surviving "pnpm"** outside the canonical disclosure, determinism, skill-mirror byte-identity.
- `init/manager.test.ts` — detection table, manifest transform, marker grammar, longest-spelling-wins ordering.
- The existing template-identity acceptance now pins *templates + stamps + translation* and pins its own runs to the pnpm shape regardless of which manager runs the suite.
- **CI**: new `Manager acceptance (npm|bun)` matrix jobs walk the real scaffold with the local tarball swapped in — same pattern as container-acceptance, `pnpm pack` per the catalog-protocol rule.

Spec revised in the same commit (`specs/ksor/init/spec.md` negative contract); `deploying.md` gains one sentence saying docs use the pnpm spelling and your scaffold's README speaks your manager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)