### PR TITLE
Adopt the owner's OKF-beneath-KSoR stack in the framework summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,15 +190,17 @@ it:
 | Publication integrity | SLSA / Sigstore                     | proof of which source and build produced a published artifact                 |
 | Observability         | OpenTelemetry                       | what the infrastructure did, without becoming another knowledge store         |
 
-The same model in nine lines:
+The same model as a stack, each line resting on the one beneath it — which
+is why OKF sits _under_ KSoR, not beside it:
 
-> **Markdown, in the KSoR Profile of OKF, is the authoritative record.**  
-> **Postgres + pgvector provide retrieval.**  
+> **Markdown is the authoritative medium.**  
+> **OKF makes that record open and portable.**  
+> **KSoR governance makes it authoritative.**  
+> **Postgres + pgvector make it retrievable.**  
 > **Fumadocs serves humans.**  
 > **`llms.txt` lets AI discover it.**  
 > **MCP lets agents interact with it.**  
-> **The same OKF representation lets knowledge systems exchange the record.**  
-> **OAuth/OIDC establishes identity. KSoR governance controls access.**  
+> **OAuth/OIDC establishes identity; KSoR governs access.**  
 > **SLSA/Sigstore proves what was published.**  
 > **OpenTelemetry tells us what happened.**
 
@@ -220,7 +222,12 @@ every surface.
 The full specification — the profile, the conformance classes, the
 governance requirements — is the **[KSoR Standard Proposal
 (KSP-001)](research/ksor-standard-proposal-001-v0.1-draft9.md)**, an open
-standard written so that anyone can implement a conformant KSoR.
+standard written so that anyone can implement a conformant KSoR. It defines
+five conformance classes — a corpus (A), a publisher (B), a retrieval layer
+(C), an agent surface (D), and exchange (E) — plus optional profiles for
+identity, publication integrity, and computation attestation. A complete
+KSoR implements all five classes; a partial implementation (a corpus linter,
+say) is valid too, and states its class.
 
 Which of the nine responsibilities the shipped tool implements today is
 recorded in [`docs/status.md`](docs/status.md) — always the authority, never


### PR DESCRIPTION
## Problem

The framework section's memorable summary opened with "Markdown, in the KSoR Profile of OKF, is the authoritative record" and never said what OKF and KSoR governance each contribute. As the owner put it reviewing Draft 9: that wording makes OKF sound like only an interoperability surface, when Draft 9 made it foundational — the record *is* an OKF bundle, so OKF sits *under* KSoR, not beside it. Separately, the README linked KSP-001 for "the conformance classes" without ever saying what they are.

(This commit was originally pushed to the #144 branch minutes after that PR merged, so it never reached `main` — carried here onto a fresh branch, unchanged.)

## Solution

- Replace the nine-line summary with the owner's layered formulation, introduced as a stack where each line rests on the one beneath it: Markdown is the medium → OKF makes the record open and portable → KSoR governance makes it authoritative → retrieval, serving, discovery, agents, identity, integrity, observability above.
- Name KSP-001's five conformance classes — corpus (A), publisher (B), retrieval layer (C), agent surface (D), exchange (E) — and its three optional profiles in one sentence beside the link, including that partial implementations are valid and state their class.

## Behavior

README-only; the nine-responsibility table is untouched. Note for the KSP-001 editor: Draft 9 §3.2 still carries the older nine-line summary, so the README is now ahead of the proposal on this blockquote — the draft may want to adopt the same stack. No files under `packages/ksor` touched, so no changeset is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)