### PR TITLE
Show something running, where the prose puts it

### DIFF
--- a/.changeset/embed-what-runs.md
+++ b/.changeset/embed-what-runs.md
@@ -1,0 +1,22 @@
+---
+"@panaversity/ksor": patch
+---
+
+A document can now show something running, where the prose puts it. Give a link
+the title `embed` and the site renders it as a click-to-load frame:
+
+```markdown
+[Play run-until-done](goal-loop.sim.html "embed")
+```
+
+It stays an ordinary CommonMark link everywhere else — GitHub, a plain editor,
+`/md/`, `llms-full.txt` — so nothing was added to `knowledge/`.
+
+Prefer carrying the page in. A `<name>.sim.html` beside its document, exactly
+like a figure, is published by the build and served from your own site: it
+works offline, tells nobody outside what someone is reading, and is versioned
+with the document. An `https:` link works too, but many hosts send
+`X-Frame-Options: SAMEORIGIN` and a browser will refuse to frame them.
+
+Nothing is requested until a reader clicks, so a built page still makes zero
+external requests.

--- a/.changeset/embed-what-runs.md
+++ b/.changeset/embed-what-runs.md
@@ -19,4 +19,5 @@ with the document. An `https:` link works too, but many hosts send
 `X-Frame-Options: SAMEORIGIN` and a browser will refuse to frame them.
 
 Nothing is requested until a reader clicks, so a built page still makes zero
-external requests.
+external requests. A carried page is measured, so the frame is exactly as tall
+as what it holds — you never write a height into a document.

--- a/packages/ksor/src/embed-rule.test.ts
+++ b/packages/ksor/src/embed-rule.test.ts
@@ -1,0 +1,162 @@
+/**
+ * A marked link -> a click-to-load frame.
+ *
+ * The half worth testing hardest is what this REFUSES. Every ordinary link it
+ * reframed by mistake would put a third party's page inside the record,
+ * announced as part of it — which is the one thing an embed must never do
+ * without an author asking for it in the document.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  EMBED_CASES,
+  EMBED_TITLE,
+  hostOf,
+  matchEmbed,
+  publicSimPath,
+  recordDirOf,
+  rehypeEmbeds,
+  servedSimUrl,
+  SIM_SUFFIX,
+} from "../templates/scaffold/system/site/lib/embed-rule.js";
+
+describe("the rule", () => {
+  for (const testCase of EMBED_CASES) {
+    it(`${testCase.title === undefined ? "no title" : JSON.stringify(testCase.title)} ${testCase.url} -> ${testCase.embeds ? "frame" : "link"}`, () => {
+      expect(matchEmbed(testCase.url, testCase.title) !== null).toBe(testCase.embeds);
+    });
+  }
+
+  it("opts in on the link TITLE, so no ordinary link is reframed", () => {
+    expect(EMBED_TITLE).toBe("embed");
+    expect(matchEmbed("https://example.org/sim", "embed")).not.toBeNull();
+    expect(matchEmbed("https://example.org/sim", undefined)).toBeNull();
+  });
+
+  it("surfaces the host, because that is what the reader consents to", () => {
+    expect(hostOf("https://agentfactory.panaversity.org/sims/goal-loop?v=3")).toBe(
+      "agentfactory.panaversity.org",
+    );
+    expect(hostOf("not a url")).toBeNull();
+  });
+});
+
+/** hast nodes, hand-built — the shapes the plugin actually meets. */
+function paragraph(children: readonly unknown[]): Record<string, unknown> {
+  return { type: "element", tagName: "p", properties: {}, children };
+}
+function link(url: string, label: string, title?: string): Record<string, unknown> {
+  return {
+    type: "element",
+    tagName: "a",
+    properties: title === undefined ? { href: url } : { href: url, title },
+    children: [{ type: "text", value: label }],
+  };
+}
+function tree(children: readonly unknown[]): Record<string, unknown> {
+  return { type: "root", children };
+}
+
+describe("the plugin", () => {
+  it("replaces a lone marked link with an Embed", () => {
+    const root = tree([paragraph([link("https://example.org/sim", "Play it", "embed")])]);
+    rehypeEmbeds()(root as never);
+
+    const node = (root.children as Record<string, unknown>[])[0]!;
+    expect(node.type).toBe("mdxJsxFlowElement");
+    expect(node.name).toBe("Embed");
+    const attributes = node.attributes as { name: string; value: string }[];
+    const byName = Object.fromEntries(attributes.map((a) => [a.name, a.value]));
+    expect(byName.url).toBe("https://example.org/sim");
+    // The link text is the label, so the frame and the link out say the same
+    // thing the author wrote.
+    expect(byName.label).toBe("Play it");
+    expect(byName.host).toBe("example.org");
+  });
+
+  it("leaves a marked link that shares its paragraph alone", () => {
+    const root = tree([
+      paragraph([
+        { type: "text", value: "See " },
+        link("https://example.org/sim", "Play it", "embed"),
+      ]),
+    ]);
+    rehypeEmbeds()(root as never);
+
+    expect((root.children as Record<string, unknown>[])[0]!.tagName).toBe("p");
+  });
+
+  it("leaves an ordinary link alone", () => {
+    const root = tree([paragraph([link("https://example.org/sim", "Play it")])]);
+    rehypeEmbeds()(root as never);
+
+    expect((root.children as Record<string, unknown>[])[0]!.tagName).toBe("p");
+  });
+
+  it("reaches a link nested below the root", () => {
+    const root = tree([
+      {
+        type: "element",
+        tagName: "div",
+        properties: {},
+        children: [paragraph([link("https://example.org/sim", "Play it", "embed")])],
+      },
+    ]);
+    rehypeEmbeds()(root as never);
+
+    const div = (root.children as Record<string, unknown>[])[0]!;
+    expect((div.children as Record<string, unknown>[])[0]!.name).toBe("Embed");
+  });
+});
+
+/**
+ * A sim carried IN the record.
+ *
+ * The cross-origin arm above is the one that cannot be relied on: every sim
+ * this was built for answers `x-frame-options: SAMEORIGIN` (measured
+ * 2026-08-24, all seven), so a frame pointed at their host can never render.
+ * Carrying the page and serving it from here is what makes the affordance
+ * work at all — and it is also what keeps the zero-external-request guarantee.
+ */
+describe("a sim carried in the record", () => {
+  it("is served under the record path, so two documents may each own one name", () => {
+    expect(publicSimPath("loop-engineering/goal-loop" + SIM_SUFFIX)).toBe(
+      "loop-engineering/goal-loop.html",
+    );
+    expect(publicSimPath("goal-loop" + SIM_SUFFIX)).toBe("goal-loop.html");
+    expect(servedSimUrl("loop-engineering", "goal-loop" + SIM_SUFFIX)).toBe(
+      "/sims/loop-engineering/goal-loop.html",
+    );
+    expect(servedSimUrl("", "goal-loop" + SIM_SUFFIX)).toBe("/sims/goal-loop.html");
+  });
+
+  it("finds the document's place under BOTH record roots", () => {
+    // A record that declares `audiences:` or carries a takedown is read from
+    // the staged copy; every other record is read from `knowledge/` directly.
+    // Keying on the staged one alone dropped the directory from every url on
+    // the common record (found live 2026-08-24).
+    expect(recordDirOf("/r/system/site/.staged-knowledge/loop-engineering/index.md")).toBe(
+      "loop-engineering",
+    );
+    expect(recordDirOf("/r/knowledge/loop-engineering/index.md")).toBe("loop-engineering");
+    expect(recordDirOf("/r/knowledge/index.md")).toBe("");
+    expect(recordDirOf(undefined)).toBe("");
+  });
+
+  it("names itself as the record's own, not as a third party", () => {
+    expect(matchEmbed("goal-loop" + SIM_SUFFIX, EMBED_TITLE)?.host).toBe("this record");
+    expect(matchEmbed("https://example.org/x", EMBED_TITLE)?.host).toBe("example.org");
+  });
+
+  it("rewrites the link to where the build serves it", () => {
+    const root = tree([paragraph([link("goal-loop" + SIM_SUFFIX, "Play it", "embed")])]);
+    rehypeEmbeds()(root as never, { path: "/r/knowledge/loop-engineering/index.md" });
+
+    const node = (root.children as Record<string, unknown>[])[0]!;
+    const attributes = node.attributes as { name: string; value: string }[];
+    const byName = Object.fromEntries(attributes.map((a) => [a.name, a.value]));
+    expect(byName.url).toBe("/sims/loop-engineering/goal-loop.html");
+    // The panel says a very different thing for a page the record carries.
+    expect(byName.owned).toBe("true");
+  });
+});

--- a/packages/ksor/src/scaffold-e2e.integration.test.ts
+++ b/packages/ksor/src/scaffold-e2e.integration.test.ts
@@ -610,6 +610,90 @@ describe.runIf(enabled)("scaffold e2e — the site, in a real browser", () => {
     }
   });
 
+  it("frames a link titled `embed`, requests nothing until asked, and leaves /md/ alone", () => {
+    const outDir = path.join(project, "system", "site", "out");
+    const doc = path.join(project, "knowledge", "embed-host.md");
+    const URL = "https://sims.example.org/zzsimzz";
+    try {
+      writeFileSync(
+        doc,
+        "---\ntitle: Embed host\nstatus: approved\n---\n\n" +
+          // The marked link, alone in its paragraph.
+          `[Play the zzsimzz](${URL} "embed")\n\n` +
+          // An ordinary link to the SAME url, which must stay a link — the
+          // opt-in is the title, so this pair is the whole rule in one file.
+          `See [the zzsimzz](${URL}) for more.\n`,
+      );
+      expect(buildScaffold(project).status, "build with an embed").toBe(0);
+
+      const page = readFileSync(path.join(outDir, "docs", "embed-host", "index.html"), "utf8");
+
+      // Nothing is requested until a reader asks: the built page ships the
+      // placeholder, and the frame is created on click. This is the clause
+      // that keeps the zero-external-request guarantee true.
+      expect(page, "an embed must not ship a frame").not.toContain("<iframe");
+      expect(page, "the host must be named, so the click is informed").toContain(
+        "sims.example.org",
+      );
+
+      // The ordinary link survives as a link.
+      expect(page, "the plain link was reframed").toContain("See ");
+
+      // REHYPE, not remark: the agent surface keeps the author's link rather
+      // than this site's component. The whole reason for the phase choice.
+      const twin = readFileSync(path.join(outDir, "md", "embed-host.md"), "utf8");
+      expect(twin, "the markdown twin lost the author's link").toContain(URL);
+      expect(twin, "the markdown twin served a React component").not.toContain("<Embed");
+    } finally {
+      rmSync(doc, { force: true });
+    }
+  });
+
+  it("serves a sim the record carries, from this site, under the record's own path", () => {
+    const outDir = path.join(project, "system", "site", "out");
+    const dir = path.join(project, "knowledge", "sims-host");
+    const doc = path.join(dir, "index.md");
+    const sim = path.join(dir, "zzloopzz.sim.html");
+    try {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(sim, "<!doctype html><title>zzsimtitlezz</title><p>zzsimbodyzz</p>\n");
+      writeFileSync(
+        doc,
+        "---\ntitle: Sims host\nstatus: approved\n---\n\n" +
+          // Written as a link to the file BESIDE the document, exactly the way
+          // a figure is. The served url is derived, never authored.
+          '[Play it](zzloopzz.sim.html "embed")\n',
+      );
+      expect(buildScaffold(project).status, "build with a carried sim").toBe(0);
+
+      // Published where it can be SERVED, under the record path — so two
+      // documents may each own a `zzloopzz.sim.html` without colliding.
+      const served = path.join(outDir, "sims", "sims-host", "zzloopzz.html");
+      expect(existsSync(served), "the sim was not published where it can be served").toBe(true);
+      expect(readFileSync(served, "utf8")).toContain("zzsimbodyzz");
+
+      const page = readFileSync(path.join(outDir, "docs", "sims-host", "index.html"), "utf8");
+      // The derived url, not the record path.
+      expect(page).toContain("/sims/sims-host/zzloopzz.html");
+      expect(page, "the record's own path must not reach the page").not.toContain(
+        "zzloopzz.sim.html",
+      );
+      // Still click-to-load, and now honestly described: it IS part of the
+      // record, so the panel may not say a third party runs it.
+      expect(page, "a sim must not ship a frame").not.toContain("<iframe");
+      expect(page).toContain("Part of this record");
+
+      // No route and no markdown twin: a sim is an asset, not a document.
+      expect(existsSync(path.join(outDir, "docs", "sims-host", "zzloopzz.sim"))).toBe(false);
+      expect(existsSync(path.join(outDir, "md", "sims-host", "zzloopzz.sim.html"))).toBe(false);
+
+      // And it never becomes a document: nothing in the record index names it.
+      expect(readFileSync(path.join(outDir, "llms.txt"), "utf8")).not.toContain("zzloopzz");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("renders code tabs from a fence's info string, and carries the group", () => {
     const knowledge = path.join(project, "knowledge");
     const doc = path.join(knowledge, "tabbed.md");

--- a/packages/ksor/templates/scaffold/AGENTS.md
+++ b/packages/ksor/templates/scaffold/AGENTS.md
@@ -686,6 +686,31 @@ CI — and a first deploy without it serves an empty record. Full walkthrough:
 - **A long line is the reader's to unwrap.** Nothing to author — a fenced block
   wider than the column gets a button beside its copy button that wraps it, and
   a block that fits gets no button at all.
+- **Something running, as an embed.** A document that wants to show a page in
+  motion — a simulation, a player, a dashboard — links to it and gives the link
+  the title `embed`:
+
+  ```markdown
+  [Play run-until-done](goal-loop.sim.html "embed")
+  ```
+
+  Still CommonMark: a link title is a tooltip everywhere else, so GitHub, a
+  plain editor, `/md/` and `llms-full.txt` all show the author's link. Nothing
+  loads until a reader clicks, which is what keeps a built page free of
+  external requests — and the panel names what it is about to reach, so the
+  click is informed.
+
+  **Carry the page in where you can.** A file named `<name>.sim.html`, sitting
+  beside its document exactly like a figure, is published by the build and
+  served from this site — so it works offline, tells nobody outside what
+  someone is reading, and is versioned with the document instead of changing
+  under it. It is an ASSET, not an attachment: named freely, as many per
+  document as the prose needs.
+
+  An `https:` link works too, for a page you cannot carry. It is the weaker
+  option for a reason worth knowing: many hosts send `X-Frame-Options:
+SAMEORIGIN`, which forbids any other site from framing them, and a browser
+  enforces that whatever this record does. Check before you rely on one.
 
 - Copy load-bearing values (numbers, thresholds, dates) exactly from their
   source, and name the source in `provenance`.

--- a/packages/ksor/templates/scaffold/AGENTS.md
+++ b/packages/ksor/templates/scaffold/AGENTS.md
@@ -700,6 +700,11 @@ CI — and a first deploy without it serves an empty record. Full walkthrough:
   external requests — and the panel names what it is about to reach, so the
   click is informed.
 
+  **You do not state a height.** A page carried in the record is measured, so
+  the frame is exactly as tall as what it holds — on this record's own seven,
+  to the pixel. A number written into a document would be a number some other
+  measure makes wrong.
+
   **Carry the page in where you can.** A file named `<name>.sim.html`, sitting
   beside its document exactly like a figure, is published by the build and
   served from this site — so it works offline, tells nobody outside what

--- a/packages/ksor/templates/scaffold/gitignore
+++ b/packages/ksor/templates/scaffold/gitignore
@@ -11,6 +11,9 @@ system/site/.staged-knowledge/
 # and the lock that keeps one evaluation of a build staging at a time; it only
 # outlives a build that was killed mid-stage, and the next build clears it
 system/site/.staged-knowledge.lock
+# a build's copy of every `.sim.html` in the record, put where it can be
+# SERVED; the record owns the sim, this is only where the site publishes it
+system/site/public/sims/
 *.tsbuildinfo
 
 # secrets never enter the record — system/ is their future home (serve)

--- a/packages/ksor/templates/scaffold/system/site/components/embed.tsx
+++ b/packages/ksor/templates/scaffold/system/site/components/embed.tsx
@@ -183,18 +183,12 @@ export function Embed({
 
   return (
     <figure
-      className="not-prose my-8"
-      // A little wider than the prose measure, not a lot. A page built to be
-      // interactive is laid out for a screen rather than for a 60-character
-      // column, so it reads cramped at the measure — but 64rem overshot far
-      // enough that the block stopped belonging to the document around it.
-      // Centred on the column and clamped to the viewport, so it never causes
-      // a horizontal scroll.
-      style={{
-        width: "min(56rem, calc(100vw - 3rem))",
-        marginLeft: "50%",
-        transform: "translateX(-50%)",
-      }}
+      // The measure, like every other figure in the document. Wider was tried
+      // twice — 64rem, then 56rem — and both read as a block that had stopped
+      // belonging to the text around it (owner, seen live). These pages are
+      // responsive and lay themselves out at whatever width they are given, so
+      // the measure costs them nothing.
+      className="not-prose my-8 w-full"
     >
       <div
         // A ratio rather than a fixed height, so the frame scales with the

--- a/packages/ksor/templates/scaffold/system/site/components/embed.tsx
+++ b/packages/ksor/templates/scaffold/system/site/components/embed.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { ExternalLink, Play } from "lucide-react";
+import { useState, type ReactElement } from "react";
+
+import { Button } from "@/components/ui/button";
+
+/**
+ * An interactive page the document points at.
+ *
+ * Authored as an ordinary link (see lib/embed-rule.ts); rendered here as a
+ * frame the reader loads by asking. The click is not politeness — the
+ * scaffold's browser test asserts ZERO external requests on a built page, and
+ * that guarantee is what makes this record work offline, behind a firewall,
+ * and without telling a third party which document someone is reading. An
+ * always-on frame would break it on every page carrying one.
+ *
+ * Two things the panel says out loud, because they are the reason for the
+ * click. It NAMES the host, so a reader consents to a party rather than to a
+ * button. And it says the page is not part of the record: an embed carries no
+ * provenance claim, cannot be cited, and can change under the document without
+ * anyone reviewing it. The link out is always there and costs nothing, because
+ * a plain `<a>` is not a request.
+ */
+export function Embed({
+  url,
+  host,
+  label,
+  owned,
+}: {
+  readonly url: string;
+  readonly host: string;
+  readonly label: string;
+  /** "true" when the page is carried IN the record and served from here. */
+  readonly owned?: string;
+}): ReactElement {
+  const [loaded, setLoaded] = useState(false);
+  const isOwned = owned === "true";
+
+  return (
+    <figure className="not-prose my-8">
+      <div
+        // A ratio rather than a fixed height, so the frame scales with the
+        // measure. The floor is there because these pages are usually taller
+        // than they are wide, and a narrow window would otherwise letterbox
+        // an interactive thing down to a strip.
+        className="relative w-full overflow-hidden rounded-lg border border-fd-border bg-fd-muted"
+        style={{ aspectRatio: "16 / 10", minHeight: "26rem" }}
+      >
+        {loaded ? (
+          <iframe
+            src={url}
+            title={label}
+            allowFullScreen
+            // The host learns that its page was opened, not which document of
+            // this record opened it.
+            referrerPolicy="no-referrer"
+            // Scripts, because the point of the page is that it runs. Not
+            // top-navigation, and not forms: a framed page may not steer the
+            // reader out of the record or collect anything from inside it.
+            sandbox="allow-scripts allow-same-origin allow-popups"
+            loading="lazy"
+            className="absolute inset-0 size-full"
+          />
+        ) : (
+          <div className="absolute inset-0 flex flex-col items-center justify-center gap-4 px-6 text-center">
+            <Play aria-hidden className="size-8 text-fd-muted-foreground" />
+            <Button onClick={() => setLoaded(true)}>{label}</Button>
+            <p className="max-w-sm text-xs text-fd-muted-foreground">
+              {isOwned
+                ? "Part of this record, served from this site. Nothing leaves your browser."
+                : `Runs on ${host}, and is not part of this record. Nothing is requested from there until you load it.`}
+            </p>
+          </div>
+        )}
+      </div>
+
+      <figcaption className="mt-2 flex items-center justify-between gap-3 text-xs text-fd-muted-foreground">
+        <span>{label}</span>
+        <a
+          href={url}
+          target="_blank"
+          rel="noreferrer"
+          className="inline-flex items-center gap-1 hover:text-fd-foreground"
+        >
+          {isOwned ? "Open on its own" : `Open on ${host}`}
+          <ExternalLink aria-hidden className="size-3" />
+        </a>
+      </figcaption>
+    </figure>
+  );
+}

--- a/packages/ksor/templates/scaffold/system/site/components/embed.tsx
+++ b/packages/ksor/templates/scaffold/system/site/components/embed.tsx
@@ -74,8 +74,15 @@ export function Embed({
     );
     if (blocks.length === 0) return;
     const bottom = Math.max(...blocks.map((el) => el.offsetTop + el.offsetHeight));
-    const padding = Number.parseFloat(getComputedStyle(body).paddingBottom) || 0;
-    const measured = Math.ceil(bottom + padding);
+    // The body's own bottom edge, padding AND margin. A page that does not
+    // reset `body { margin }` keeps the user agent's 8px, and leaving the
+    // margin out left exactly that much overflowing — one scrollbar, on the
+    // one sim of seven whose stylesheet omits the reset (found live).
+    // `offsetTop` already carries the top margin.
+    const style = getComputedStyle(body);
+    const edge =
+      (Number.parseFloat(style.paddingBottom) || 0) + (Number.parseFloat(style.marginBottom) || 0);
+    const measured = Math.ceil(bottom + edge);
     // GROW-ONLY. A running page changes height every beat — measured
     // oscillating 504 to 562 on one sim — and following it exactly would
     // shift everything below the frame while someone is reading. The high
@@ -120,13 +127,14 @@ export function Embed({
   return (
     <figure
       className="not-prose my-8"
-      // Wider than the prose measure. A page built to be interactive is laid
-      // out for a screen, not for a 60-character column: constrained to the
-      // measure it either scrolls in a box or under-fills the height its
-      // author stated (both seen live). Centred on the column and clamped to
-      // the viewport, so it never causes a horizontal scroll.
+      // A little wider than the prose measure, not a lot. A page built to be
+      // interactive is laid out for a screen rather than for a 60-character
+      // column, so it reads cramped at the measure — but 64rem overshot far
+      // enough that the block stopped belonging to the document around it.
+      // Centred on the column and clamped to the viewport, so it never causes
+      // a horizontal scroll.
       style={{
-        width: "min(64rem, calc(100vw - 3rem))",
+        width: "min(56rem, calc(100vw - 3rem))",
         marginLeft: "50%",
         transform: "translateX(-50%)",
       }}
@@ -137,15 +145,18 @@ export function Embed({
         // than they are wide, and a narrow window would otherwise letterbox
         // an interactive thing down to a strip.
         className="relative w-full overflow-hidden rounded-lg border border-fd-border bg-fd-muted"
-        // The invitation is a card; the frame takes the page's own height once
-        // it has one. Until it is measured — and always, for a frame we may
-        // not measure — a ratio with a floor.
+        // The invitation is a card. Once the page is measured the height goes
+        // on the FRAME instead and this box wraps it: put on the box, the
+        // border is inside that height, so the frame came out two pixels short
+        // and every single embed carried a scrollbar (found live — content 862
+        // in a frame of 860). Until it is measured, and always for a frame we
+        // may not measure, a ratio with a floor.
         style={
           !loaded
             ? { height: "14rem" }
             : height === null
               ? { aspectRatio: "16 / 10", minHeight: "26rem" }
-              : { height }
+              : undefined
         }
       >
         {loaded ? (
@@ -163,7 +174,11 @@ export function Embed({
             // reader out of the record or collect anything from inside it.
             sandbox="allow-scripts allow-same-origin allow-popups"
             loading="lazy"
-            className="absolute inset-0 size-full"
+            // Absolute only while the box owns the height, which is the ratio
+            // case. With a measured height the frame owns it and lays out in
+            // flow, so the box is exactly as tall as the page plus its border.
+            className={height === null ? "absolute inset-0 size-full" : "block w-full"}
+            style={height === null ? undefined : { height }}
           />
         ) : (
           <div className="absolute inset-0 flex flex-col items-center justify-center gap-4 px-6 text-center">

--- a/packages/ksor/templates/scaffold/system/site/components/embed.tsx
+++ b/packages/ksor/templates/scaffold/system/site/components/embed.tsx
@@ -57,6 +57,26 @@ function containScrolling(doc: Document | null): void {
   proto.__ksorContained = true;
 }
 
+/**
+ * Close the gutter a framed page leaves around itself.
+ *
+ * A page that does not reset `body { margin }` keeps the user agent's 8px, and
+ * that band shows whatever is behind the frame — so a sim painted near-black
+ * sat inside a ring of near-white. Matching the colour instead was tried and
+ * does not work: these pages paint below the body, so `html`, `body` and even
+ * the wrapper all compute to transparent (measured on the one that has the
+ * gutter), and chasing the colour down the tree would be guesswork.
+ *
+ * Zeroing it is the honest fix, and it is what six of the seven sims already
+ * do in their own stylesheet — this only makes the seventh agree. Presentation
+ * of the frame is the host's to decide; the page's content is untouched.
+ */
+function closeGutter(doc: Document | null): void {
+  const body = doc?.body;
+  if (!body) return;
+  body.style.margin = "0";
+}
+
 export function Embed({
   url,
   host,
@@ -150,6 +170,7 @@ export function Embed({
       return;
     }
     containScrolling(doc);
+    closeGutter(doc);
     const body = doc?.body;
     if (!body || typeof ResizeObserver === "undefined") return;
     watcher.current?.disconnect();
@@ -180,7 +201,22 @@ export function Embed({
         // measure. The floor is there because these pages are usually taller
         // than they are wide, and a narrow window would otherwise letterbox
         // an interactive thing down to a strip.
-        className="relative w-full overflow-hidden rounded-lg border border-fd-border bg-fd-muted"
+        className={
+          // Before the click this is a card, and it should read as one. After
+          // it, the page inside brings its own surface — and the box's does
+          // not match it: a sim painted near-black arrived ringed in
+          // near-white, on every side the page did not fill.
+          //
+          // Fitting the WIDTH to the page was tried and cannot work: these
+          // pages are responsive, so narrowing the frame made them reflow
+          // narrower still, which left a fresh gap and, on one, a scrollbar
+          // (measured). A page that does not fill the width now simply sits on
+          // the page, which is the honest arrangement — it is the record's own
+          // figure, not a screenshot in a mount.
+          loaded
+            ? "relative w-full overflow-hidden rounded-lg"
+            : "relative w-full overflow-hidden rounded-lg border border-fd-border bg-fd-muted"
+        }
         // The invitation is a card. Once the page is measured the height goes
         // on the FRAME instead and this box wraps it: put on the box, the
         // border is inside that height, so the frame came out two pixels short

--- a/packages/ksor/templates/scaffold/system/site/components/embed.tsx
+++ b/packages/ksor/templates/scaffold/system/site/components/embed.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ExternalLink, Play } from "lucide-react";
-import { useState, type ReactElement } from "react";
+import { useCallback, useEffect, useRef, useState, type ReactElement } from "react";
 
 import { Button } from "@/components/ui/button";
 
@@ -35,20 +35,123 @@ export function Embed({
   readonly owned?: string;
 }): ReactElement {
   const [loaded, setLoaded] = useState(false);
+  const [height, setHeight] = useState<number | null>(null);
+  const frame = useRef<HTMLIFrameElement>(null);
   const isOwned = owned === "true";
 
+  /**
+   * Fit the frame to the page it holds, so nothing scrolls in a box and no
+   * band of dead space sits under it.
+   *
+   * Measure the body's CHILDREN, never `documentElement.scrollHeight`. These
+   * pages set `min-height: 100vh`, and inside a frame the viewport IS the
+   * frame — so the document's scroll height is just the frame's own height
+   * echoed back, and a frame sized from it grows without bound. Watched that
+   * run away before the CSS explained it (2026-08-24). The children do not
+   * depend on the frame: measured across all seven sims of the record this was
+   * built for, each returned the same height at a 300px frame and a 1400px
+   * one.
+   *
+   * Possible at all only because a carried page is SAME-ORIGIN. A cross-origin
+   * frame refuses `contentDocument`, so it keeps the ratio box and this
+   * returns without touching anything.
+   */
+  const fit = useCallback((): void => {
+    let doc: Document | null = null;
+    try {
+      doc = frame.current?.contentDocument ?? null;
+    } catch {
+      return; // cross-origin: not ours to measure
+    }
+    const body = doc?.body;
+    if (!body) return;
+    // NOT `instanceof HTMLElement`. The elements inside a frame belong to the
+    // frame's realm, so they are instances of ITS HTMLElement and never of this
+    // one — the filter matched nothing, and the frame kept the ratio box while
+    // looking as though measuring had simply not helped (found live).
+    const blocks = [...body.children].filter(
+      (el): el is HTMLElement => typeof (el as HTMLElement).offsetHeight === "number",
+    );
+    if (blocks.length === 0) return;
+    const bottom = Math.max(...blocks.map((el) => el.offsetTop + el.offsetHeight));
+    const padding = Number.parseFloat(getComputedStyle(body).paddingBottom) || 0;
+    const measured = Math.ceil(bottom + padding);
+    // GROW-ONLY. A running page changes height every beat — measured
+    // oscillating 504 to 562 on one sim — and following it exactly would
+    // shift everything below the frame while someone is reading. The high
+    // water mark costs a little slack after a shrink and never a scrollbar.
+    if (measured > 0)
+      setHeight((current) => (current === null ? measured : Math.max(current, measured)));
+  }, []);
+
+  const watcher = useRef<ResizeObserver | null>(null);
+
+  /**
+   * Measure on load, then keep watching — these pages animate, and some add a
+   * row per beat.
+   *
+   * Set up HERE rather than in an effect on `loaded`: that effect runs the
+   * moment the click flips the state, which is before the frame's document
+   * exists, so it observed an empty `about:blank` and never fired again (found
+   * live — the frame fitted once and then ignored everything).
+   *
+   * Watch the CHILDREN, not the body. The body's own box is pinned by the
+   * page's `min-height: 100vh` to exactly the frame, so it never reports a
+   * change.
+   */
+  const handleLoad = useCallback((): void => {
+    fit();
+    let doc: Document | null = null;
+    try {
+      doc = frame.current?.contentDocument ?? null;
+    } catch {
+      return;
+    }
+    const body = doc?.body;
+    if (!body || typeof ResizeObserver === "undefined") return;
+    watcher.current?.disconnect();
+    const observer = new ResizeObserver(fit);
+    for (const child of body.children) observer.observe(child);
+    watcher.current = observer;
+  }, [fit]);
+
+  useEffect(() => () => watcher.current?.disconnect(), []);
+
   return (
-    <figure className="not-prose my-8">
+    <figure
+      className="not-prose my-8"
+      // Wider than the prose measure. A page built to be interactive is laid
+      // out for a screen, not for a 60-character column: constrained to the
+      // measure it either scrolls in a box or under-fills the height its
+      // author stated (both seen live). Centred on the column and clamped to
+      // the viewport, so it never causes a horizontal scroll.
+      style={{
+        width: "min(64rem, calc(100vw - 3rem))",
+        marginLeft: "50%",
+        transform: "translateX(-50%)",
+      }}
+    >
       <div
         // A ratio rather than a fixed height, so the frame scales with the
         // measure. The floor is there because these pages are usually taller
         // than they are wide, and a narrow window would otherwise letterbox
         // an interactive thing down to a strip.
         className="relative w-full overflow-hidden rounded-lg border border-fd-border bg-fd-muted"
-        style={{ aspectRatio: "16 / 10", minHeight: "26rem" }}
+        // The invitation is a card; the frame takes the page's own height once
+        // it has one. Until it is measured — and always, for a frame we may
+        // not measure — a ratio with a floor.
+        style={
+          !loaded
+            ? { height: "14rem" }
+            : height === null
+              ? { aspectRatio: "16 / 10", minHeight: "26rem" }
+              : { height }
+        }
       >
         {loaded ? (
           <iframe
+            ref={frame}
+            onLoad={handleLoad}
             src={url}
             title={label}
             allowFullScreen

--- a/packages/ksor/templates/scaffold/system/site/components/embed.tsx
+++ b/packages/ksor/templates/scaffold/system/site/components/embed.tsx
@@ -22,6 +22,41 @@ import { Button } from "@/components/ui/button";
  * anyone reviewing it. The link out is always there and costs nothing, because
  * a plain `<a>` is not a request.
  */
+
+/**
+ * A framed page may not scroll the document that hosts it.
+ *
+ * `scrollIntoView` scrolls EVERY ancestor scrolling box, and a frame's
+ * ancestors include the host page — so a page that auto-scrolls its own log
+ * throws the reader somewhere else entirely. Six of the seven sims this was
+ * built for do exactly that, and clicking one moved the page 5,807px (found
+ * live).
+ *
+ * The call still does its real job inside the frame; only the part that moved
+ * the host is undone, in the same task, so nothing is painted in between.
+ *
+ * Same-origin only, which is all it can be: a cross-origin frame's prototypes
+ * are not reachable, and it cannot scroll us either.
+ */
+function containScrolling(doc: Document | null): void {
+  const view = doc?.defaultView;
+  if (!view) return;
+  const proto = view.Element.prototype as Element & {
+    scrollIntoView: (...args: unknown[]) => void;
+    __ksorContained?: boolean;
+  };
+  if (proto.__ksorContained) return;
+  const native = proto.scrollIntoView;
+  proto.scrollIntoView = function contained(this: Element, ...args: unknown[]): void {
+    const { scrollX, scrollY } = window;
+    native.apply(this, args);
+    if (window.scrollX !== scrollX || window.scrollY !== scrollY) {
+      window.scrollTo(scrollX, scrollY);
+    }
+  };
+  proto.__ksorContained = true;
+}
+
 export function Embed({
   url,
   host,
@@ -114,6 +149,7 @@ export function Embed({
     } catch {
       return;
     }
+    containScrolling(doc);
     const body = doc?.body;
     if (!body || typeof ResizeObserver === "undefined") return;
     watcher.current?.disconnect();

--- a/packages/ksor/templates/scaffold/system/site/components/mdx.tsx
+++ b/packages/ksor/templates/scaffold/system/site/components/mdx.tsx
@@ -35,15 +35,14 @@ export function getMDXComponents(components?: MDXComponents) {
     // here or a document whose page forgot to pass one serves a 500 rather
     // than a page without an aid.
     TeachingAid: () => null,
-    // `remarkCodeTab` (source.config.ts) rewrites consecutive fenced blocks
-    // that declare `tab="…"` into these, so they have to be in the map or the
-    // build fails on an unknown component rather than at authoring time.
     // A long line is the reader's to unwrap, per block — see
     // components/code-block.tsx. Replaces fumadocs' own `pre`.
     pre: WrappableCodeBlock,
     // `rehypeEmbeds` (source.config.ts) rewrites a link titled `embed` into
-    // this, for the same reason: an unknown component fails the build.
+    // this; an unknown component fails the build, so it has to be in the map.
     Embed,
+    // `remarkCodeTab` (source.config.ts) rewrites consecutive fenced blocks
+    // that declare `tab="…"` into these, for the same reason.
     Tabs,
     Tab,
     CodeBlockTabsTrigger: BrandedTabsTrigger,

--- a/packages/ksor/templates/scaffold/system/site/components/mdx.tsx
+++ b/packages/ksor/templates/scaffold/system/site/components/mdx.tsx
@@ -1,6 +1,7 @@
 import defaultMdxComponents from "fumadocs-ui/mdx";
 
 import { WrappableCodeBlock } from "@/components/code-block";
+import { Embed } from "@/components/embed";
 import { CodeBlockTabsTrigger } from "fumadocs-ui/components/codeblock";
 import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 import type { MDXComponents } from "mdx/types";
@@ -40,6 +41,9 @@ export function getMDXComponents(components?: MDXComponents) {
     // A long line is the reader's to unwrap, per block — see
     // components/code-block.tsx. Replaces fumadocs' own `pre`.
     pre: WrappableCodeBlock,
+    // `rehypeEmbeds` (source.config.ts) rewrites a link titled `embed` into
+    // this, for the same reason: an unknown component fails the build.
+    Embed,
     Tabs,
     Tab,
     CodeBlockTabsTrigger: BrandedTabsTrigger,

--- a/packages/ksor/templates/scaffold/system/site/lib/embed-rule.ts
+++ b/packages/ksor/templates/scaffold/system/site/lib/embed-rule.ts
@@ -129,6 +129,9 @@ export const EMBED_CASES: readonly EmbedCase[] = [
   { url: "https://example.org/sim", title: "Embed", embeds: false },
   { url: "https://example.org/sim", title: "embedded", embeds: false },
   { url: "https://example.org/sim", title: " embed", embeds: false },
+  // No height token: the frame measures the page it holds, so a record never
+  // carries a number that a different measure would make wrong.
+  { url: "goal-loop.sim.html", title: "embed 660", embeds: false },
   // http would be blocked as mixed content, so it stays a link that works.
   { url: "http://example.org/sim", title: EMBED_TITLE, embeds: false },
   // Neither of these is a url a frame could reach.

--- a/packages/ksor/templates/scaffold/system/site/lib/embed-rule.ts
+++ b/packages/ksor/templates/scaffold/system/site/lib/embed-rule.ts
@@ -1,0 +1,243 @@
+/**
+ * An interactive page the document points at, as a CLICK-TO-LOAD frame.
+ *
+ * A record often wants to show something running — a simulation, a dashboard,
+ * a player — at one exact point in the prose. A deck is one per document and
+ * lives in an attachment (`<doc>.slides.yaml`); this is the other shape: many
+ * per document, each where the sentence before it puts it.
+ *
+ * The form is an ordinary CommonMark link whose TITLE is the word `embed`:
+ *
+ *     [Play run-until-done](https://example.org/sims/goal-loop "embed")
+ *
+ * Chosen the way the alert syntax was chosen — for what it does everywhere the
+ * record is read that is NOT this site. GitHub renders a link with a tooltip.
+ * `/md/` and `llms-full.txt` carry the author's link. A plain editor shows a
+ * link. No grammar is added to `knowledge/`, so critical rule 2 holds.
+ *
+ * The TITLE, rather than a lone link on its own line, because the opt-in has
+ * to be something an author WROTE. A rule that reframes any link standing
+ * alone would silently pull a third party's page into the record the first
+ * time someone put a citation on its own line.
+ *
+ * REHYPE, not remark, for the reason `alert-rule.ts` records: this record's
+ * markdown is serialized from the mdast, so rewriting there would publish this
+ * site's React component to the agent surface in place of the author's link.
+ *
+ * A LEAF: no imports, so the rule can be tested on its own.
+ */
+
+/** The link title that opts a link in. Anything else is an ordinary link. */
+export const EMBED_TITLE = "embed";
+
+/** What the panel names when the page is the record's own. */
+export const SELF_HOST = "this record";
+
+export interface EmbedMatch {
+  readonly url: string;
+  readonly host: string;
+}
+
+/**
+ * The host a frame would reach, or null when the value is not a url.
+ *
+ * Surfaced rather than hidden: the placeholder names it, so a reader who
+ * clicks has already been told whose page is about to load. That naming is
+ * half of why there is no host allowlist here — the other half is that an
+ * allowlist written into a scaffold would be one adopter's hosts shipped to
+ * every other adopter.
+ */
+export function hostOf(value: string): string | null {
+  try {
+    return new URL(value).hostname;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The frame this link asks for, or null when it is an ordinary link.
+ *
+ * https only. A browser blocks an http frame inside a secure page as mixed
+ * content, so an http embed publishes a panel that silently never loads —
+ * worse than refusing it, because nothing goes red.
+ */
+/**
+ * The suffix that marks an asset as a page to be SERVED rather than bundled.
+ *
+ * A sim is an asset of its document, exactly like the figures beside it: many
+ * per document, named freely, staged only when a published document links to
+ * it. It is deliberately NOT an attachment — an attachment is named after its
+ * parent (`<doc>.quiz.yaml`), and seven sims cannot all be `index.sim.html`.
+ */
+export const SIM_SUFFIX = ".sim.html";
+
+/**
+ * Where a sim is served, derived from where it sits in the record.
+ *
+ * The record path is the identity (product principle 3), so two documents
+ * may each own a `goal-loop.sim.html` without colliding.
+ */
+export function publicSimPath(recordRelative: string): string {
+  return recordRelative.slice(0, -SIM_SUFFIX.length).replaceAll("\\", "/") + ".html";
+}
+
+export function matchEmbed(url: string, title: string | undefined): EmbedMatch | null {
+  if (title !== EMBED_TITLE) return null;
+
+  // A sim carried IN the record. Same origin, so no third party learns
+  // anything, it works offline, and no host can refuse to be framed — which
+  // is not hypothetical: every sim this was first built for answers
+  // `x-frame-options: SAMEORIGIN`, so a cross-origin frame to them can never
+  // render (measured 2026-08-24, all seven).
+  if (url.endsWith(SIM_SUFFIX) && !url.includes(":")) {
+    return { url, host: SELF_HOST };
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== "https:") return null;
+
+  return { url, host: parsed.hostname };
+}
+
+export interface EmbedCase {
+  readonly url: string;
+  /** `undefined` is the ordinary link — no title at all. */
+  readonly title: string | undefined;
+  readonly embeds: boolean;
+}
+
+/** The rule, as a table — what embeds, and what deliberately does not. */
+export const EMBED_CASES: readonly EmbedCase[] = [
+  { url: "https://example.org/sims/goal-loop", title: EMBED_TITLE, embeds: true },
+  // Carried in the record, beside its document.
+  { url: "goal-loop.sim.html", title: EMBED_TITLE, embeds: true },
+  { url: "sims/goal-loop.sim.html", title: EMBED_TITLE, embeds: true },
+  // Still opt-in: an ordinary link to a sim is an ordinary link.
+  { url: "goal-loop.sim.html", title: undefined, embeds: false },
+  { url: "https://example.org/sims/goal-loop?v=3", title: EMBED_TITLE, embeds: true },
+  // No title is the ordinary case, and by far the commonest link in a record.
+  { url: "https://example.org/sims/goal-loop", title: undefined, embeds: false },
+  // A title an author wrote for a reader is a tooltip, not an instruction.
+  { url: "https://example.org/sims/goal-loop", title: "The run-until-done sim", embeds: false },
+  // Near misses on the marker, which must stay links.
+  { url: "https://example.org/sim", title: "Embed", embeds: false },
+  { url: "https://example.org/sim", title: "embedded", embeds: false },
+  { url: "https://example.org/sim", title: " embed", embeds: false },
+  // http would be blocked as mixed content, so it stays a link that works.
+  { url: "http://example.org/sim", title: EMBED_TITLE, embeds: false },
+  // Neither of these is a url a frame could reach.
+  { url: "/sims/goal-loop", title: EMBED_TITLE, embeds: false },
+  { url: "mailto:records@example.org", title: EMBED_TITLE, embeds: false },
+];
+
+interface EmbedNode {
+  type?: string;
+  tagName?: string;
+  name?: string;
+  value?: string;
+  properties?: { href?: unknown; title?: unknown };
+  attributes?: readonly { type: string; name: string; value: string }[];
+  children?: EmbedNode[];
+}
+
+/** The link's own text, which becomes the frame's title and the link out. */
+function labelOf(node: EmbedNode): string {
+  return (node.children ?? [])
+    .map((child) => (child.type === "text" ? (child.value ?? "") : labelOf(child)))
+    .join("")
+    .trim();
+}
+
+/** The record-relative directory a staged document sits in, or "". */
+/**
+ * BOTH roots, because there are two. A record that declares `audiences:` or
+ * carries a takedown is read from `.staged-knowledge/`; every other record is
+ * read from `knowledge/` directly, which is the level-0 fast path and the
+ * common case. Keying on the staged one alone dropped the directory from
+ * every url on exactly the records most people have (found live 2026-08-24:
+ * `/sims/goal-loop.html` for a sim that lives in `loop-engineering/`).
+ */
+const RECORD_ROOTS = [".staged-knowledge/", "knowledge/"] as const;
+
+export function recordDirOf(filePath: string | undefined): string {
+  if (!filePath) return "";
+  const normalized = filePath.replaceAll("\\", "/");
+  for (const marker of RECORD_ROOTS) {
+    const at = normalized.lastIndexOf(marker);
+    if (at === -1) continue;
+    const rel = normalized.slice(at + marker.length);
+    const cut = rel.lastIndexOf("/");
+    return cut === -1 ? "" : rel.slice(0, cut);
+  }
+  return "";
+}
+
+/** The served url for a sim linked from a document in `dir`. */
+export function servedSimUrl(dir: string, target: string): string {
+  const joined = dir === "" ? target : `${dir}/${target}`;
+  return "/sims/" + publicSimPath(joined);
+}
+
+function embedFor(node: EmbedNode, dir: string): EmbedNode | null {
+  if (node.type !== "element" || node.tagName !== "p") return null;
+
+  // ALONE in its paragraph. hast keeps the source's whitespace between inline
+  // children, so a link that shares a sentence still has text nodes beside it
+  // — and reframing that would swallow the sentence around the link.
+  const meaningful = (node.children ?? []).filter(
+    (child) => child.type !== "text" || (child.value ?? "").trim() !== "",
+  );
+  const [link] = meaningful;
+  if (meaningful.length !== 1 || !link || link.type !== "element" || link.tagName !== "a") {
+    return null;
+  }
+
+  const { href, title } = link.properties ?? {};
+  if (typeof href !== "string") return null;
+  const match = matchEmbed(href, typeof title === "string" ? title : undefined);
+  if (match === null) return null;
+
+  // A sim is written as a link to the file BESIDE the document, exactly like
+  // a figure. The url it is served at is derived here rather than authored,
+  // so the record never contains a path into the site's own build output.
+  const url = href.endsWith(SIM_SUFFIX) ? servedSimUrl(dir, href) : match.url;
+
+  return {
+    type: "mdxJsxFlowElement",
+    name: "Embed",
+    attributes: [
+      { type: "mdxJsxAttribute", name: "url", value: url },
+      { type: "mdxJsxAttribute", name: "host", value: match.host },
+      // Carried in the record, or someone else's page. The two say very
+      // different things to a reader, so the panel is told which.
+      { type: "mdxJsxAttribute", name: "owned", value: String(match.host === SELF_HOST) },
+      { type: "mdxJsxAttribute", name: "label", value: labelOf(link) },
+    ],
+    children: [],
+  };
+}
+
+function convertEmbeds(node: EmbedNode, dir: string): void {
+  const children = node.children;
+  if (!children) return;
+
+  for (let i = 0; i < children.length; i++) {
+    const child = children[i];
+    if (!child) continue;
+    convertEmbeds(child, dir);
+    const embed = embedFor(child, dir);
+    if (embed) children[i] = embed;
+  }
+}
+
+export function rehypeEmbeds(): (tree: EmbedNode, file?: { path?: string }) => void {
+  return (tree: EmbedNode, file?: { path?: string }): void => {
+    convertEmbeds(tree, recordDirOf(file?.path));
+  };
+}

--- a/packages/ksor/templates/scaffold/system/site/lib/stage-knowledge.ts
+++ b/packages/ksor/templates/scaffold/system/site/lib/stage-knowledge.ts
@@ -544,13 +544,17 @@ function fillStage(recordDir: string, stageDir: string, denied: DenylistManifest
       removeStage(stageDir);
       throw error;
     }
-    if (stageHolds(recordDir, stageDir, plan)) return;
+    if (stageHolds(recordDir, stageDir, plan)) {
+      publishSims(stageDir);
+      return;
+    }
     removeStage(stageDir);
     for (const from of plan.files) {
       const to = path.join(stageDir, path.relative(recordDir, from));
       mkdirSync(path.dirname(to), { recursive: true });
       copyFileSync(from, to);
     }
+    publishSims(stageDir);
   });
 }
 
@@ -707,7 +711,12 @@ function watchRecord(recordDir: string, stageDir: string): void {
  * ships its bytes there. Said rather than fixed, because the moment either
  * governance exists the staged dir is what this walks and the rule applies.
  */
-function publishSims(sourceDir: string, lockDir: string): void {
+/** Whether the record carries a sim at all — a lock nobody needs is churn. */
+function hasSims(dir: string): boolean {
+  return walkFiles(dir).some((file) => file.endsWith(SIM_SUFFIX));
+}
+
+function publishSims(sourceDir: string): void {
   const target = path.resolve(process.cwd(), PUBLIC_SIM_DIR);
 
   const walk = (dir: string, rel: string): void => {
@@ -741,12 +750,14 @@ function publishSims(sourceDir: string, lockDir: string): void {
     }
   };
 
-  // UNDER THE LOCK, for the reason `withStageLock` records at length: a build
-  // evaluates this file in seven processes, and a destructive pass run by two
-  // of them at once fails as `ENOENT`/`EINVAL` out of `copyFileSync`. Walked
-  // into directly while prototyping this (2026-08-24) — the same four shapes,
-  // from a pass that had not yet learned the lesson beside it.
-  withStageLock(lockDir, () => walk(sourceDir, ""));
+  // The CALLER holds the stage lock, and this takes none of its own — for the
+  // reason `withStageLock` records at length, plus one this change learned on
+  // Windows: taking it a SECOND time per evaluation doubles the create/delete
+  // churn on one lock file, and `wx` create against a file in Windows'
+  // pending-delete state fails as `EPERM`, which is not `EEXIST` and so is
+  // rethrown. Green on macOS and Linux, red on Windows CI, from a pass that
+  // was correct about needing the lock and wrong about taking it again.
+  walk(sourceDir, "");
 }
 
 export function knowledgeSourceDir(): string {
@@ -767,16 +778,24 @@ export function knowledgeSourceDir(): string {
     // because two evaluations removing one tree is the `ENOTEMPTY` shape of the
     // same race; the existence check keeps a record that never stages from
     // taking a lock on every build.
-    if (existsSync(stageDir)) withStageLock(stageDir, () => removeStage(stageDir));
     refuseVisibilityWithoutAudiences(recordDir);
     assertAttachmentsWellFormed(recordDir);
-    publishSims(recordDir, recordDir);
+    // ONE acquisition on this path too, doing both jobs — and keyed on the
+    // stage path rather than the record's, because `${recordDir}.lock` would
+    // drop a lock file beside `knowledge/`, in the adopter's repo, for a build
+    // that never stages anything.
+    const stale = existsSync(stageDir);
+    if (stale || hasSims(recordDir)) {
+      withStageLock(stageDir, () => {
+        if (stale) removeStage(stageDir);
+        publishSims(recordDir);
+      });
+    }
     return RECORD_DIR;
   }
   if (audienceModel === null) refuseVisibilityWithoutAudiences(recordDir);
   assertAttachmentsWellFormed(recordDir);
   fillStage(recordDir, stageDir, denied);
   watchRecord(recordDir, stageDir);
-  publishSims(stageDir, stageDir);
   return STAGE_DIR;
 }

--- a/packages/ksor/templates/scaffold/system/site/lib/stage-knowledge.ts
+++ b/packages/ksor/templates/scaffold/system/site/lib/stage-knowledge.ts
@@ -14,6 +14,7 @@ import path from "node:path";
 import { ATTACHMENT_SUFFIXES, isAttachment, parentDocumentOf } from "./attachment-rule";
 import { audienceModel, buildAudience, refuse, visibleInBuild } from "./audience";
 import { isDenied, recordPathFrom, stableIdFrom, type DenylistManifest } from "./denial-rule";
+import { publicSimPath, SIM_SUFFIX } from "./embed-rule";
 import { appName, instanceFrontmatter } from "./shared";
 
 // Both relative to the site directory — the directory every build runs from
@@ -21,6 +22,8 @@ import { appName, instanceFrontmatter } from "./shared";
 // resolves a collection's `dir`.
 const RECORD_DIR = "../../knowledge";
 const STAGE_DIR = "./.staged-knowledge";
+// Served, not bundled. Next copies public/ into the export as-is.
+const PUBLIC_SIM_DIR = "./public/sims";
 
 // ONE frontmatter boundary, the checker's exactly: BOM stripped, CRLF
 // normalized, lax close (a `----` line closes — review finding 2026-08-19:
@@ -686,6 +689,66 @@ function watchRecord(recordDir: string, stageDir: string): void {
  * per-request filter leaked on the fifth and sixth consumer of the record
  * its own author had not enumerated (research/visibility.md §4–§5).
  */
+
+/**
+ * A sim is the one asset that has to be SERVED rather than bundled: it is a
+ * page, and a page needs a url before anything can frame it. Next copies
+ * `public/` into the export as-is, so that is where it goes.
+ *
+ * A PASS OF ITS OWN, over the directory the collection actually reads — not a
+ * rider on staging. Staging runs only for a record that declares `audiences:`
+ * or carries a takedown, and most records declare neither, so a sim hung off
+ * it published for the rare record and silently vanished for the common one
+ * (found live 2026-08-24: nothing reached `public/` on the level-0 path).
+ * Reading the SOURCE dir inherits the filtering when there is any, and works
+ * when there is none. What it does NOT inherit at level 0 is the staging
+ * plan's rule that only a REFERENCED asset ships: a record with no audiences
+ * and no takedowns publishes every document anyway, so an unreferenced sim
+ * ships its bytes there. Said rather than fixed, because the moment either
+ * governance exists the staged dir is what this walks and the rule applies.
+ */
+function publishSims(sourceDir: string, lockDir: string): void {
+  const target = path.resolve(process.cwd(), PUBLIC_SIM_DIR);
+
+  const walk = (dir: string, rel: string): void => {
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const from = path.join(dir, entry.name);
+      const next = rel === "" ? entry.name : `${rel}/${entry.name}`;
+      if (entry.isDirectory()) {
+        walk(from, next);
+        continue;
+      }
+      if (!entry.name.endsWith(SIM_SUFFIX)) continue;
+      const to = path.join(target, publicSimPath(next));
+      // Same size AND same mtime is this file's own definition of unchanged
+      // (see `stageHolds`). Skipping the write is what keeps the common
+      // build from touching the tree at all.
+      try {
+        const source = statSync(from);
+        const published = statSync(to);
+        if (published.size === source.size && published.mtimeMs >= source.mtimeMs) continue;
+      } catch {
+        // Not published yet, which is the ordinary first-build case.
+      }
+      mkdirSync(path.dirname(to), { recursive: true });
+      copyFileSync(from, to);
+    }
+  };
+
+  // UNDER THE LOCK, for the reason `withStageLock` records at length: a build
+  // evaluates this file in seven processes, and a destructive pass run by two
+  // of them at once fails as `ENOENT`/`EINVAL` out of `copyFileSync`. Walked
+  // into directly while prototyping this (2026-08-24) — the same four shapes,
+  // from a pass that had not yet learned the lesson beside it.
+  withStageLock(lockDir, () => walk(sourceDir, ""));
+}
+
 export function knowledgeSourceDir(): string {
   const stageDir = path.resolve(process.cwd(), STAGE_DIR);
   const recordDir = path.resolve(process.cwd(), RECORD_DIR);
@@ -707,11 +770,13 @@ export function knowledgeSourceDir(): string {
     if (existsSync(stageDir)) withStageLock(stageDir, () => removeStage(stageDir));
     refuseVisibilityWithoutAudiences(recordDir);
     assertAttachmentsWellFormed(recordDir);
+    publishSims(recordDir, recordDir);
     return RECORD_DIR;
   }
   if (audienceModel === null) refuseVisibilityWithoutAudiences(recordDir);
   assertAttachmentsWellFormed(recordDir);
   fillStage(recordDir, stageDir, denied);
   watchRecord(recordDir, stageDir);
+  publishSims(stageDir, stageDir);
   return STAGE_DIR;
 }

--- a/packages/ksor/templates/scaffold/system/site/lib/stage-knowledge.ts
+++ b/packages/ksor/templates/scaffold/system/site/lib/stage-knowledge.ts
@@ -447,7 +447,20 @@ function withStageLock<T>(stageDir: string, work: () => T): T {
       writeFileSync(lockFile, String(process.pid), { flag: "wx" });
       break;
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      // EEXIST is "someone holds it". EPERM is the SAME THING on Windows: a
+      // create against a path whose file is in the pending-delete state — the
+      // window between another process calling `rmSync` and the filesystem
+      // actually releasing the name — raises EPERM, not EEXIST. Rethrowing it
+      // failed the build for the ordinary contended case, and only on Windows,
+      // and only sometimes: green on five CI runs of this same code and red on
+      // the next two, because it depends on landing inside a window a few
+      // milliseconds wide (2026-08-25, `Init acceptance (Windows)`).
+      //
+      // Waiting is safe for both: a holder that has died leaves a lock
+      // `lockIsAbandoned` breaks, so neither code can wait forever on a
+      // process that is gone.
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "EEXIST" && code !== "EPERM") throw error;
       if (lockIsAbandoned(lockFile)) {
         rmSync(lockFile, { force: true });
         continue;

--- a/packages/ksor/templates/scaffold/system/site/source.config.ts
+++ b/packages/ksor/templates/scaffold/system/site/source.config.ts
@@ -145,6 +145,7 @@ export default defineConfig({
        * publishes this site's React component to the agent surface.
        */
       rehypeGithubAlerts,
+      /**
        * An interactive page the document points at, as a click-to-load
        * frame. Authored as an ordinary link titled `embed`, so the record
        * stays CommonMark and every other reader of it sees a link.

--- a/packages/ksor/templates/scaffold/system/site/source.config.ts
+++ b/packages/ksor/templates/scaffold/system/site/source.config.ts
@@ -1,6 +1,7 @@
 import { defineCollections, defineConfig, defineDocs } from "fumadocs-mdx/config";
 import { remarkCodeTab } from "fumadocs-core/mdx-plugins/remark-code-tab";
 import { rehypeGithubAlerts } from "./lib/alert-rule";
+import { rehypeEmbeds } from "./lib/embed-rule";
 import { metaSchema, pageSchema } from "fumadocs-core/source/schema";
 import { z } from "zod";
 import { DeckSchema } from "./lib/deck";
@@ -144,6 +145,14 @@ export default defineConfig({
        * publishes this site's React component to the agent surface.
        */
       rehypeGithubAlerts,
+       * An interactive page the document points at, as a click-to-load
+       * frame. Authored as an ordinary link titled `embed`, so the record
+       * stays CommonMark and every other reader of it sees a link.
+       *
+       * REHYPE, so `/md/` and `llms-full.txt` keep the author's link
+       * rather than this site's component. See lib/embed-rule.ts.
+       */
+      rehypeEmbeds,
     ],
     /**
      * Alternative versions of the same instruction, as TABS.


### PR DESCRIPTION
## Problem

A record can show a figure, a table, a deck. It could not show something **running** — a simulation, a player, a dashboard — at one exact point in the prose. A deck is one per document and lives in an attachment; this is the other shape, many per document, each where the sentence before it puts it.

The lesson that made this concrete carries seven interactive sims. Rendering it here, they became seven links out.

## Solution

Give a link the title `embed`:

```markdown
[Play run-until-done](goal-loop.sim.html "embed")
```

Chosen the way the alert syntax was chosen — for what it does everywhere the record is read that is **not** this site. GitHub renders a link with a tooltip, a plain editor shows a link, `/md/` and `llms-full.txt` carry the author's link. Nothing was added to `knowledge/`.

The **title**, rather than a lone link on its own line, because the opt-in has to be something an author wrote — a rule that reframed any standing-alone link would pull a third party's page into the record the first time someone put a citation on its own line. Rehype rather than remark, for the reason `alert-rule.ts` records: the markdown is serialized from the mdast, so rewriting there publishes the site's React component to the agent surface.

**Prefer carrying the page in.** A `<name>.sim.html` beside its document, exactly like a figure, is published by the build and served from this site. It is an **asset, not an attachment**, and the naming rule settles it: an attachment is named after its parent, and seven sims cannot all be `index.sim.html`. It keeps every guarantee an attachment has — no route, no markdown twin, no `llms.txt` line, no stable id.

## Behavior

- Nothing is requested until a reader clicks; a built page still makes zero external requests.
- The panel names what it is about to reach, so the click is a decision. A carried page says it is part of the record; a third-party page says it is not.
- A sim is served under the record path, so two documents may each own a `goal-loop.sim.html`.

## What running it taught

**The cross-origin arm is genuinely weak, and measuring said how weak.** All seven sims answer `x-frame-options: SAMEORIGIN` — the host forbids any other site from framing it, and the browser enforces that whatever we do. Found by clicking: the panel loaded and rendered a broken document. That is what motivated carrying the page in.

**Publishing hung off staging worked for the rare record and vanished for the common one.** Staging runs only when a record declares `audiences:` or carries a takedown; most declare neither. It is a pass of its own now, over whichever directory the collection actually reads.

**That pass ran unlocked and failed as `ENOENT`/`EINVAL` out of `copyFileSync`** — two of the four shapes `withStageLock` already carries a scar for, from a build that evaluates this file in seven processes. It holds the same lock now and skips a file already published.

Green: guard (11 rules), `check:corpus`, typecheck, 966 unit, 299 integration, and the full `KSOR_E2E=1` walkthrough including the zero-external-request assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDg8jY3xdg9RvLZLqfHchG