### PR TITLE
Stop echoing a malformed KSOR_SNAPSHOT_KEYS entry into its refusal

### DIFF
--- a/.changeset/snapshot-key-refusal-no-echo.md
+++ b/.changeset/snapshot-key-refusal-no-echo.md
@@ -1,0 +1,9 @@
+---
+"@panaversity/ksor": patch
+---
+
+A malformed `KSOR_SNAPSHOT_KEYS` entry no longer has its text echoed into the
+refusal message. The likeliest operator mistake — pasting a bare secret without
+its `kid=` prefix — put that secret verbatim into an error that lands in
+whatever collects logs. The refusal now names the entry's position and length
+only, and keeps the remedy line.

--- a/packages/content/src/lib/snapshot.test.ts
+++ b/packages/content/src/lib/snapshot.test.ts
@@ -65,6 +65,25 @@ describe("snapshot tokens", () => {
     // MAC fails — the soft "refreshed" path, exactly what ephemeral means.
     expect(validate(keyRingFromEnv(undefined), token, scope, NOW).reason).toBe("invalid");
   });
+
+  it("a malformed entry's refusal never echoes the entry — it is the secret when kid= was forgotten", () => {
+    // The likeliest operator mistake is pasting a bare secret; the refusal
+    // reaches whatever collects logs, so it may name only position and length.
+    for (const [ring, secret] of [
+      ["prod=good-one,s3cr3t-hunter2-oops", "s3cr3t-hunter2-oops"],
+      ["prod=good-one,=s3cr3t-hunter2-oops", "s3cr3t-hunter2-oops"],
+    ] as const) {
+      let message = "";
+      try {
+        keyRingFromEnv(ring);
+      } catch (err) {
+        message = (err as Error).message;
+      }
+      expect(message).not.toContain(secret);
+      expect(message).toMatch(/entry 2 \(\d+ chars\)/);
+      expect(message).toMatch(/kid=secret/);
+    }
+  });
 });
 
 /**

--- a/packages/content/src/lib/snapshot.ts
+++ b/packages/content/src/lib/snapshot.ts
@@ -38,11 +38,13 @@ export function keyRingFromEnv(raw: string | undefined): KeyRing {
   }
   const keys = new Map<string, Buffer>();
   let active: string | null = null;
-  for (const part of raw.split(",")) {
+  for (const [i, part] of raw.split(",").entries()) {
     const eq = part.indexOf("=");
     if (eq <= 0 || eq === part.length - 1) {
+      // Never echo the entry: when kid= was forgotten, the entry IS the
+      // secret, and this message lands in whatever collects logs.
       throw new Error(
-        `KSOR_SNAPSHOT_KEYS entry ${JSON.stringify(part)} is not kid=secret — ` +
+        `KSOR_SNAPSHOT_KEYS entry ${i + 1} (${part.length} chars) is not kid=secret — ` +
           "a half-parsed key ring would mint tokens nothing can validate; " +
           "write comma-separated kid=secret pairs, first one active",
       );


### PR DESCRIPTION
## Problem

`keyRingFromEnv` refused a malformed ring entry by quoting the entry itself: `KSOR_SNAPSHOT_KEYS entry "…" is not kid=secret`. The likeliest operator mistake — pasting a bare secret and forgetting the `kid=` prefix — is precisely the shape where the entry IS the secret, so the credential landed verbatim in the boot error and from there in whatever collects logs. The `=secret` shape (empty kid) leaked the same way. Reproduced live before the fix: the thrown message contained the full secret.

## Solution

The refusal names the entry's position and length only — `entry 2 (19 chars) is not kid=secret` — and keeps the remedy line. Red-first: the new test feeds both leaking shapes, asserts the message never contains the secret and does name position + length; it failed on the old message with the leaked value printed, and the fix turned exactly that red green.

## Behavior

- Malformed ring entry → refusal identifies which entry and how long, never its text.
- All 12 snapshot tests green; full unit tier 944/944; typecheck clean.
- Changeset: patch (`snapshot.ts` is bundled into the published CLI).

From the 2026-08-21 kernel review, finding A3. Fixed directly rather than filed as an issue — the repo is public and the fix is smaller than the disclosure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)