### PR TITLE
Pin the version in every documented way to run the CLI

### DIFF
--- a/.changeset/pin-init-command-version.md
+++ b/.changeset/pin-init-command-version.md
@@ -1,0 +1,23 @@
+---
+"@panaversity/ksor": patch
+---
+
+The documented way to run `ksor init` pins a version, so a stale runner cache
+can no longer decide which ksor an adopter meets.
+
+`npx @panaversity/ksor init my-sor` is spec `*`, and any cached version
+satisfies it — so npx runs whatever that machine already has without consulting
+the registry. Found live on a Windows box following the README: it replayed
+`0.0.0`, the name-reservation stub published on the first day of the project,
+whose whole implementation prints "the name is reserved; this is not a release"
+and exits 2. Thirty-nine releases later, the first command in the README
+produced a placeholder, and nothing in that output points at the cause.
+
+Both READMEs now say `@panaversity/ksor@latest`. The three "Start here" forms
+change together — `pnpm dlx` reuses its cache for 24 hours by default and
+`bunx` resolves from the install cache before the registry, so pinning only npx
+would have left two of the three supported managers in the trap. `npm install
+-g` is unchanged: an install resolves the `latest` dist-tag by definition.
+
+If you have run ksor before, your own cache is still warm. Run the `@latest`
+form once and it resolves the current release.

--- a/README.md
+++ b/README.md
@@ -37,21 +37,21 @@ manager everywhere:
 **npm**
 
 ```bash
-npx @panaversity/ksor init my-knowledge-sor
+npx @panaversity/ksor@latest init my-knowledge-sor
 cd my-knowledge-sor && npm install && npm run dev
 ```
 
 **pnpm**
 
 ```bash
-pnpm dlx @panaversity/ksor init my-knowledge-sor
+pnpm dlx @panaversity/ksor@latest init my-knowledge-sor
 cd my-knowledge-sor && pnpm install && pnpm dev
 ```
 
 **bun**
 
 ```bash
-bunx @panaversity/ksor init my-knowledge-sor
+bunx @panaversity/ksor@latest init my-knowledge-sor
 cd my-knowledge-sor && bun install && bun run dev
 ```
 

--- a/packages/ksor/README.md
+++ b/packages/ksor/README.md
@@ -10,7 +10,7 @@ when the corpus does not cover the question.
 ## Start
 
 ```bash
-npx @panaversity/ksor init my-sor
+npx @panaversity/ksor@latest init my-sor
 cd my-sor
 pnpm install
 pnpm dev        # the site, live at http://localhost:3000
@@ -72,7 +72,7 @@ Full concept, design goals, and project status:
 
 ```bash
 npm install -g @panaversity/ksor   # command installed: ksor
-npx @panaversity/ksor              # or run without installing
+npx @panaversity/ksor@latest       # or run without installing
 ```
 
 ## License

--- a/packages/ksor/src/install-commands.integration.test.ts
+++ b/packages/ksor/src/install-commands.integration.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Every documented way to RUN the published CLI pins a version.
+ *
+ * A bare `npx @panaversity/ksor init` is spec `*`, which any cached version
+ * satisfies — so npx runs whatever that machine already has without consulting
+ * the registry. Found live on a Windows box following the README: it replayed
+ * `0.0.0`, the name-reservation stub published 2026-08-17, whose whole
+ * implementation prints "the name is reserved; this is not a release" and exits
+ * 2. Thirty-nine releases later the reader met a placeholder, and nothing about
+ * that output says the cause is a stale cache.
+ *
+ * `pnpm dlx` and `bunx` cache the same way (dlx reuses its cache for 24h by
+ * default; bunx resolves from the install cache before the registry), so
+ * decision 25's "meet the adopter's package manager" means all three forms
+ * carry the pin or the trap is closed for one third of adopters.
+ *
+ * This is the drift test for that, in the tier AGENTS.md assigns repo-tree
+ * scans. The alternative is noticing the next unpinned snippet by hand.
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
+const read = (rel: string): string => readFileSync(path.join(repoRoot, rel), "utf8");
+
+/** The runners that resolve a package spec at call time — each one caches. */
+const RUNNERS = ["npx", "pnpm dlx", "bunx", "npm exec", "yarn dlx"];
+
+/**
+ * `npm install -g @panaversity/ksor` is NOT here and must not be: an install
+ * resolves the `latest` dist-tag by definition, so pinning it would freeze
+ * adopters on whatever version the README last named.
+ */
+const SPEC = new RegExp(`(${RUNNERS.join("|")})\\s+(@panaversity/ksor(@[^\\s]+)?)`, "g");
+
+describe("documented run-the-CLI commands pin a version", () => {
+  it.each([
+    ["README.md", "the product pitch — the first command any adopter runs"],
+    ["packages/ksor/README.md", "the README shipped inside the npm tarball"],
+  ])("%s", (file, why) => {
+    const found = [...read(file).matchAll(SPEC)];
+    expect(found.length, `${why} — no runner invocation found at all`).toBeGreaterThan(0);
+    const unpinned = found.filter((m) => !m[3]).map((m) => m[0]);
+    expect(
+      unpinned,
+      `${why} — unpinned, so a stale runner cache decides the version: ${unpinned.join(" | ")}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

An adopter following the README on Windows ran `npx @panaversity/ksor init my-first-ksor` and got:

```
ksor 0.0.0 — the name is reserved; this is not a release.
```

That is the name-reservation stub published on the project's first day. Its entire implementation prints that banner and exits 2. `latest` is 0.0.39.

A bare `npx @panaversity/ksor` is spec `*`, and any cached version satisfies it — so npx runs whatever the machine already holds without consulting the registry. That box had run ksor back when 0.0.0 *was* current, and has been replaying it since. Nothing in the output points at the cause, and the exit code makes it look like a broken install.

This is not Windows-specific; Windows is where it happened to surface.

## Solution

Both READMEs pin `@panaversity/ksor@latest`.

All three manager forms change together, per decision 25: `pnpm dlx` reuses its cache for 24 hours by default and `bunx` reads the install cache before the registry, so pinning npx alone would have closed the trap for one of three supported managers. `npm install -g` is untouched — an install resolves the `latest` dist-tag by definition, and pinning it would freeze adopters on whatever version the README last named.

`install-commands.integration.test.ts` is the drift test. It scans both READMEs and fails on any runner invocation without a version specifier, printing the strings it found. Written first and watched red on both files; after the fix, one line was re-broken to confirm it fails on that single line.

## Behavior

- The first command in the README resolves the current release on a machine with a warm cache.
- A future unpinned snippet fails in CI on the string it saw, rather than reaching an adopter.
- No runtime behavior changes. Docs and one test.

## Not in this PR

`0.0.0` remains installable and is what every warm cache in the wild holds. `npm deprecate @panaversity/ksor@0.0.0` would make npm print a pointer at install time — a registry action for the owner to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)