### PR TITLE
Fix inert .env embed tuning knobs (#149)

### DIFF
--- a/.changeset/fix-inert-embed-env-knobs.md
+++ b/.changeset/fix-inert-embed-env-knobs.md
@@ -1,0 +1,5 @@
+---
+"@panaversity/ksor-content": patch
+---
+
+The three embed tuning variables (`KSOR_EMBED_TIMEOUT_S`, `KSOR_QUERY_EMBED_TIMEOUT_S`, `KSOR_EMBED_CACHE_MAX`) now take effect when set in `.env`. They were previously read into module-scope constants that evaluated before `loadDotEnv()` runs, so a value set only in `.env` (never exported into the shell) was silently ignored.

--- a/packages/content/src/lib/embedding.test.ts
+++ b/packages/content/src/lib/embedding.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { aembedIntent, embedInput, embedIntent, generateText, vlit } from "./embedding.js";
+import {
+  aembedIntent,
+  embedInput,
+  embedIntent,
+  embedTimeoutS,
+  generateText,
+  queryEmbedTimeoutS,
+  vlit,
+} from "./embedding.js";
 import type { EmbeddingProvider, TextGenerator } from "./embedding.js";
 
 /** A scriptable provider: `plan` yields one outcome per attempt (a vector
@@ -40,6 +48,30 @@ function stubProvider(opts: {
 
 afterEach(() => {
   vi.useRealTimers();
+});
+
+describe("embed timeout knobs are read lazily, not frozen at module scope (issue #149)", () => {
+  afterEach(() => {
+    delete process.env["KSOR_EMBED_TIMEOUT_S"];
+    delete process.env["KSOR_QUERY_EMBED_TIMEOUT_S"];
+  });
+
+  it("embedTimeoutS() honors KSOR_EMBED_TIMEOUT_S set after import", () => {
+    // Before the fix this was a module-scope `const` evaluated at import —
+    // before cli.ts's main() ever calls loadDotEnv() — so setting the env
+    // var here could never change the exported value. It is impossible to
+    // write this assertion against the old shape without reimporting the
+    // module, which is exactly the bug.
+    expect(embedTimeoutS()).toBe(60); // the documented default, unset
+    process.env["KSOR_EMBED_TIMEOUT_S"] = "45";
+    expect(embedTimeoutS()).toBe(45);
+  });
+
+  it("queryEmbedTimeoutS() honors KSOR_QUERY_EMBED_TIMEOUT_S set after import", () => {
+    expect(queryEmbedTimeoutS()).toBe(10); // the documented default, unset
+    process.env["KSOR_QUERY_EMBED_TIMEOUT_S"] = "7";
+    expect(queryEmbedTimeoutS()).toBe(7);
+  });
 });
 
 describe("embedInput", () => {

--- a/packages/content/src/lib/embedding.ts
+++ b/packages/content/src/lib/embedding.ts
@@ -87,11 +87,17 @@ import { envFloat, envInt } from "../env.js";
 
 export { envFloat, envInt };
 
-export const EMBED_TIMEOUT_S: number = envFloat("KSOR_EMBED_TIMEOUT_S", 60.0, 1.0);
+// Read lazily, INSIDE a function, not as a module-scope const. `cli.ts`
+// imports this module (through the provider registry) statically, so a
+// module-level env read here would evaluate before `main()` calls
+// `loadDotEnv()` and freeze at the default forever — the same ESM-ordering
+// trap `drainTimeoutMs` in packages/content-gateway/src/http.ts already
+// guards against (issue #149).
+export const embedTimeoutS = (): number => envFloat("KSOR_EMBED_TIMEOUT_S", 60.0, 1.0);
 /** Oracle env var: SOR_QUERY_EMBED_TIMEOUT_S. Note: query-embed.ts reads the
  * SAME variable with a different default (5.0) as its hard wall clock — two
  * deliberate reads, carried from the oracle (embedding.py:62 vs query_embed.py:44). */
-export const QUERY_EMBED_TIMEOUT_S: number = envFloat("KSOR_QUERY_EMBED_TIMEOUT_S", 10.0, 1.0);
+export const queryEmbedTimeoutS = (): number => envFloat("KSOR_QUERY_EMBED_TIMEOUT_S", 10.0, 1.0);
 
 // ---------------------------------------------------------------------------
 // Pure helpers (eval-locked; the embed_input recipe won the bake-off —

--- a/packages/content/src/lib/providers/registry.ts
+++ b/packages/content/src/lib/providers/registry.ts
@@ -16,7 +16,7 @@
  */
 
 import { EMBED_DIM, EMBED_MODEL, EMBED_TASK_DOCUMENT, EMBED_TASK_QUERY } from "../../config.js";
-import { EMBED_TIMEOUT_S, QUERY_EMBED_TIMEOUT_S } from "../embedding.js";
+import { embedTimeoutS, queryEmbedTimeoutS } from "../embedding.js";
 import type { EmbeddingProvider } from "../embedding.js";
 import { FakeEmbeddingProvider } from "./fake.js";
 import { GeminiEmbeddingProvider } from "./gemini.js";
@@ -115,7 +115,7 @@ export function buildShippedProvider(
     dim: opts.dim ?? EMBED_DIM,
     documentTaskLabel: EMBED_TASK_DOCUMENT,
     queryTaskLabel: EMBED_TASK_QUERY,
-    documentTimeoutS: EMBED_TIMEOUT_S,
-    queryTimeoutS: QUERY_EMBED_TIMEOUT_S,
+    documentTimeoutS: embedTimeoutS(),
+    queryTimeoutS: queryEmbedTimeoutS(),
   });
 }

--- a/packages/content/src/lib/query-embed.test.ts
+++ b/packages/content/src/lib/query-embed.test.ts
@@ -229,6 +229,48 @@ describe("the circuit breaker", () => {
   });
 });
 
+describe("env knobs are read lazily, not frozen at module scope (issue #149)", () => {
+  afterEach(() => {
+    delete process.env["KSOR_EMBED_CACHE_MAX"];
+    delete process.env["KSOR_QUERY_EMBED_TIMEOUT_S"];
+  });
+
+  it("honors KSOR_EMBED_CACHE_MAX set after import — no _testing.setCacheMax involved", async () => {
+    // Before the fix, CACHE_MAX_INITIAL was a module-scope `const` evaluated
+    // at import — before cli.ts's main() ever calls loadDotEnv() — so this
+    // env var could never take effect once the process was running. Setting
+    // it here, after import, and then relying only on the public
+    // `_testing.reset()` seam (never `setCacheMax`) is exactly the case that
+    // was impossible to honor before the fix.
+    process.env["KSOR_EMBED_CACHE_MAX"] = "2";
+    _testing.reset();
+    const { provider, calls } = countingProvider();
+    await embedQueryVlit("q1", { provider }); // miss (1)
+    await embedQueryVlit("q2", { provider }); // miss (2)
+    await embedQueryVlit("q1", { provider }); // hit — q1 moves to the tail
+    await embedQueryVlit("q3", { provider }); // miss (3) — evicts q2, the LRU, at cap 2
+    await embedQueryVlit("q1", { provider }); // still cached
+    expect(calls(), "provider calls before re-fetch: " + calls()).toBe(3);
+    await embedQueryVlit("q2", { provider }); // evicted → miss (4)
+    expect(calls(), "provider calls after re-fetch: " + calls()).toBe(4);
+  });
+
+  it("honors KSOR_QUERY_EMBED_TIMEOUT_S set after import — the wall clock fires early", async () => {
+    // Before the fix, EMBED_WALL_TIMEOUT_S was frozen at its 5s default
+    // regardless of this env var.
+    process.env["KSOR_QUERY_EMBED_TIMEOUT_S"] = "1";
+    vi.useFakeTimers();
+    const { provider, calls } = countingProvider({
+      next: () => new Promise<number[][]>(() => {}), // a hang, never settles
+    });
+    const pending = embedQueryVlit("a hanging query, short custom timeout", { provider });
+    const assertion = expect(pending).rejects.toBeInstanceOf(QueryEmbedTimeoutError);
+    await vi.advanceTimersByTimeAsync(1_001); // would need 5_001 before the fix
+    await assertion;
+    expect(calls()).toBe(1);
+  });
+});
+
 describe("the wall clock", () => {
   it("bounds a provider HANG: times out with the timeout class and trips the breaker", async () => {
     vi.useFakeTimers();

--- a/packages/content/src/lib/query-embed.ts
+++ b/packages/content/src/lib/query-embed.ts
@@ -37,9 +37,20 @@ import type { EmbeddingProvider } from "./embedding.js";
 // Each L1 entry is a ~1536-float pgvector literal (~25 KB), so 10k entries
 // ≈ 250 MB — the dominant in-process footprint. Env-tunable (fail-soft) so
 // an operator can shrink it to fit a smaller memory allocation.
+//
+// Read lazily and MEMOIZED on first use, never as a module-scope const:
+// `cli.ts` imports this module statically, so a module-level env read here
+// would evaluate before `main()` calls `loadDotEnv()` and freeze at the
+// default forever — the same ESM-ordering trap `drainTimeoutMs` in
+// packages/content-gateway/src/http.ts already guards against (issue #149).
+// `_testing.reset()` clears the memo, so a test that sets the env var after
+// import still sees it honored on the next read.
 /** Oracle env var: SOR_EMBED_CACHE_MAX. */
-const CACHE_MAX_INITIAL: number = envInt("KSOR_EMBED_CACHE_MAX", 10000, 1);
-let cacheMax: number = CACHE_MAX_INITIAL;
+let cacheMaxMemo: number | undefined;
+function cacheMax(): number {
+  cacheMaxMemo ??= envInt("KSOR_EMBED_CACHE_MAX", 10000, 1);
+  return cacheMaxMemo;
+}
 
 export const BREAKER_COOLDOWN_S = 10.0;
 
@@ -49,8 +60,12 @@ export const BREAKER_COOLDOWN_S = 10.0;
 // both (oracle E2E review SB8). Deliberately the SAME env var embedding.ts
 // reads with default 10.0 as the per-request HTTP timeout — two reads, two
 // defaults, carried from the oracle (query_embed.py:44 vs embedding.py:62).
+//
+// Read lazily, INSIDE a function, not as a module-scope const — the same
+// ESM-ordering trap as the cache cap above (issue #149): a module-level read
+// here evaluates before loadDotEnv() and freezes at the default forever.
 /** Oracle env var: SOR_QUERY_EMBED_TIMEOUT_S. */
-export const EMBED_WALL_TIMEOUT_S: number = envFloat("KSOR_QUERY_EMBED_TIMEOUT_S", 5.0, 0.1);
+export const embedWallTimeoutS = (): number => envFloat("KSOR_QUERY_EMBED_TIMEOUT_S", 5.0, 0.1);
 
 // L1 (insertion-ordered Map → LRU), the in-flight map, and the breaker are
 // MODULE-GLOBAL: one embedding space per process is the deployed shape. A
@@ -102,16 +117,17 @@ export function breakerOpenUntil(provider: EmbeddingProvider): number {
 }
 
 function withWallClock(work: Promise<number[][]>): Promise<number[][]> {
+  const timeoutS = embedWallTimeoutS();
   return new Promise((resolve, reject) => {
     const timer = setTimeout(() => {
       // The losing embed cannot be cancelled (module note); its settlement is
       // already observed by the handlers below, so nothing goes unhandled.
       reject(
         new QueryEmbedTimeoutError(
-          `query embed exceeded the ${EMBED_WALL_TIMEOUT_S}s wall clock — treated as a provider failure (degrade to keyword-only)`,
+          `query embed exceeded the ${timeoutS}s wall clock — treated as a provider failure (degrade to keyword-only)`,
         ),
       );
-    }, EMBED_WALL_TIMEOUT_S * 1000);
+    }, timeoutS * 1000);
     work.then(
       (value) => {
         clearTimeout(timer);
@@ -151,7 +167,7 @@ async function embedMiss(
     const literal = vlit(vec);
     cache.delete(key);
     cache.set(key, literal); // insert at the LRU tail
-    while (cache.size > cacheMax) {
+    while (cache.size > cacheMax()) {
       const oldest = cache.keys().next().value;
       if (oldest === undefined) break;
       cache.delete(oldest);
@@ -208,16 +224,19 @@ export async function embedQueryVlit(
   }
 }
 
-/** Test seam: reset module state (and the env-derived cache cap) between
- * tests; shrink the cap to make eviction observable. Never a production path. */
+/** Test seam: reset module state between tests; shrink the cap to make
+ * eviction observable. Clears the memoized cache-cap read too, so a test that
+ * sets KSOR_EMBED_CACHE_MAX after import sees it honored on the next read
+ * (issue #149) rather than a value already memoized from a previous case.
+ * Never a production path. */
 export const _testing: { reset(): void; setCacheMax(n: number): void } = {
   reset(): void {
     cache.clear();
     inflight.clear();
     breakerOpenUntilByMs.clear();
-    cacheMax = CACHE_MAX_INITIAL;
+    cacheMaxMemo = undefined;
   },
   setCacheMax(n: number): void {
-    cacheMax = n;
+    cacheMaxMemo = n;
   },
 };

--- a/packages/ksor/src/env-module-scope-drift.integration.test.ts
+++ b/packages/ksor/src/env-module-scope-drift.integration.test.ts
@@ -1,0 +1,72 @@
+/**
+ * A tuning knob read at module scope is inert for the shipped binary: `cli.ts`
+ * imports every kernel module STATICALLY, so a `const X = envInt(...)` /
+ * `= envFloat(...)` at column 0 evaluates before `main()` calls
+ * `loadDotEnv()` — the value is frozen at its default forever, and an
+ * adopter's `.env` setting silently changes nothing, with no error pointing
+ * at why (issue #149; the fourth live instance of this ESM-ordering trap).
+ *
+ * `http.ts`'s `drainTimeoutMs` already carries the fix — read inside a
+ * function, at USE time, after `loadDotEnv()` has run — and
+ * `drain-knob.integration.test.ts` already guards that one file. This is the
+ * CLASS guard the finding asked for: every kernel package is scanned, not
+ * just that file, so a fifth recurrence of the same trap is a red light here
+ * instead of a fifth review round.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
+
+/**
+ * Same transient-install exclusion as env-documented.integration.test.ts:
+ * init.integration.test.ts roots a fake npm install under packages/ksor and
+ * fills it with a copy of templates/scaffold. Descending into it would scan
+ * those files a second time, and can crash on an entry deleted mid-walk by
+ * that other suite.
+ */
+const TRANSIENT = /^ksor-fakeinstall-/;
+
+function kernelSourceFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const name = entry.name;
+    if (name === "node_modules" || name === "dist" || name.startsWith(".")) continue;
+    if (TRANSIENT.test(name)) continue;
+    const full = path.join(dir, name);
+    if (entry.isDirectory()) kernelSourceFiles(full, out);
+    // Test files never ship in the bundled binary, so a const inside one is
+    // not subject to the ESM-ordering trap this guards against.
+    else if (name.endsWith(".ts") && !name.endsWith(".test.ts")) out.push(full);
+  }
+  return out;
+}
+
+// Module scope = column 0 (no leading whitespace). A knob read inside a
+// function is indented — by the time that function body runs, main() has
+// already called loadDotEnv(), which is exactly what makes it safe.
+const MODULE_SCOPE_ENV_READ = /^(export )?const \w+\s*(:[^=]+)?=\s*env(Int|Float)\(/;
+
+describe("no kernel package reads env(Int|Float) at module scope", () => {
+  it("every const = envInt(...) / envFloat(...) is read inside a function, not at import time", () => {
+    const offenders: string[] = [];
+    for (const file of kernelSourceFiles(path.join(repoRoot, "packages"))) {
+      const lines = readFileSync(file, "utf8").split("\n");
+      lines.forEach((line, i) => {
+        if (MODULE_SCOPE_ENV_READ.test(line)) {
+          offenders.push(`${path.relative(repoRoot, file).replace(/\\/g, "/")}:${i + 1}`);
+        }
+      });
+    }
+    expect(
+      offenders,
+      "these are evaluated at import time, before loadDotEnv() runs in cli.ts's main() — " +
+        "convert each to a function called at use time (the drainTimeoutMs pattern in " +
+        "packages/content-gateway/src/http.ts): " +
+        offenders.join(", "),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

Three `.env`-documented tuning knobs do nothing when set the way `env.example` tells an adopter to set them — via `.env`, never exported into the shell:

| Variable | Where it was read (pre-fix) | Default |
| --- | --- | --- |
| `KSOR_EMBED_TIMEOUT_S` | `packages/content/src/lib/embedding.ts:90` | 60.0s |
| `KSOR_QUERY_EMBED_TIMEOUT_S` | `packages/content/src/lib/query-embed.ts:53` (read again in `embedding.ts` with a different default) | 5.0s / 10.0s |
| `KSOR_EMBED_CACHE_MAX` | `packages/content/src/lib/query-embed.ts:41` | 10000 |

### Root cause

`packages/ksor/src/cli.ts` statically imports the kernel packages (`content`, `content-gateway`, …) at the top of the file, and calls `loadDotEnv()` only later, inside `main()`. In ESM, static imports are fully evaluated — top to bottom, module by module — *before* the importing module's own body runs. So a `const X = envFloat(...)` / `envInt(...)` sitting at column 0 in an imported kernel module evaluates before `loadDotEnv()` has populated `process.env`, and freezes at its hardcoded default for the lifetime of the process.

The failure mode is silent by design of the trap: an exported shell variable works (it's already in `process.env` before the process starts), so a developer testing with `KSOR_EMBED_CACHE_MAX=1000 ksor ...` sees it work, ships the doc, and the `.env`-only path — the one the scaffold's `env.example` actually tells adopters to use — never gets exercised. This is the **fourth** live instance of the same ESM-ordering trap in this codebase; `content-gateway/src/http.ts`'s `drainTimeoutMs` already carries the established fix.

### User-facing impact (from the issue)

An adopter on a 512 MB runtime sets `KSOR_EMBED_CACHE_MAX=1000` in `.env`, exactly as documented, to keep the query-embed LRU cache small. The cap silently stays at the 10,000-entry default (~250 MB of cached vectors), and the process OOMs in production with nothing pointing at why — the value was accepted, just never read.

## Fix

Convert every module-scope `env(Int|Float)(...)` read in the affected files to a function called at **use time**, after `cli.ts`'s `main()` has already run `loadDotEnv()`. This is the same pattern `drainTimeoutMs` already established — no new abstraction introduced.

- **`packages/content/src/lib/embedding.ts`**: `EMBED_TIMEOUT_S` / `QUERY_EMBED_TIMEOUT_S` module-scope consts → `embedTimeoutS()` / `queryEmbedTimeoutS()` functions. `packages/content/src/lib/providers/registry.ts`'s `buildShippedProvider` calls the functions at the point it builds the provider, instead of closing over a frozen constant.
- **`packages/content/src/lib/query-embed.ts`**:
  - `CACHE_MAX_INITIAL` (module-scope const) + mutable `cacheMax` variable → a memoized `cacheMax()` function (`cacheMaxMemo ??= envInt(...)`), read once lazily on first real use rather than once at import time.
  - `EMBED_WALL_TIMEOUT_S` (module-scope const) → `embedWallTimeoutS()`, called once per `withWallClock` invocation (the query path's hard wall-clock bound).
  - The `_testing` seam is preserved with the same public surface: `_testing.reset()` now clears `cacheMaxMemo` (instead of resetting to a precomputed `CACHE_MAX_INITIAL`), so a test that sets the env var *after* import is honored on the very next read — which is the case that was previously impossible to express. `_testing.setCacheMax()` is unchanged.

No behavior changes for a caller that exports the variable into its shell — those already worked, and still do.

## Why a class guard, not just a point fix

The issue calls out that this is the fourth recurrence of the same class of bug, found by manual review each time. A mechanical fix for three instances doesn't stop a fifth. This PR adds `packages/ksor/src/env-module-scope-drift.integration.test.ts`, which:

- walks every non-test `.ts` file under `packages/` (skipping `node_modules`, `dist`, dotdirs, and the transient fake-install directory another suite creates),
- regexes for `^(export )?const \w+... = env(Int|Float)\(` at column 0 (module scope — anything indented is inside a function, which is exactly what makes it safe),
- and fails, naming the exact `file:line` of every offender, if it finds one.

This generalizes the single-file check `drain-knob.integration.test.ts` already had for `http.ts` to every kernel package, so a fifth instance of this trap is a red CI light instead of a fifth review round.

## Testing

All run locally against this branch:

- `pnpm typecheck` — green, no errors.
- `pnpm test:unit` — **999/999 tests passed** (59 files), including four new red-first tests:
  - `embedTimeoutS()` / `queryEmbedTimeoutS()` honor their env vars when set **after** module import (`embedding.test.ts`) — impossible to express against the old module-scope-const shape, which is the point.
  - `KSOR_EMBED_CACHE_MAX` set after import drives real LRU eviction end-to-end through the public API (`query-embed.test.ts`), using only the existing `_testing.reset()` seam — never `_testing.setCacheMax()`.
  - `KSOR_QUERY_EMBED_TIMEOUT_S` set after import shortens the wall-clock bound, proven with `vi.useFakeTimers()` against a provider call that hangs forever (would need 5.001s pre-fix; fires at 1.001s post-fix).
- `pnpm build` — green across `content`, `content-gateway`, `ksor`.
- The new drift test (`env-module-scope-drift.integration.test.ts`) and its sibling `drain-knob.integration.test.ts` — both pass in isolation.
- `pnpm test:integration` — I diffed the full suite against the same suite with this fix stashed out; the identical 9 files / 60 tests fail either way (Windows-only: `EPERM` on `symlink()` needs dev-mode/admin, plus a pre-existing path bug in one test's harness). Neither is touched by this diff — confirmed by running the exact same suite with the fix removed and seeing the same failures.
- `pnpm guard` reports 13 symlink-related violations on this machine (`CLAUDE.md`, `.claude/skills/*`) — these are a local Windows checkout artifact (`core.symlinks=false`, so git checked committed symlinks out as plain text), unrelated to this change and present on `main` as well.

## How to verify

1. Set `KSOR_EMBED_CACHE_MAX=5` (or any of the three vars) in a scaffolded project's `.env`, with nothing exported into the shell.
2. Before this fix: the value is silently ignored — the cache still caps at 10,000.
3. After this fix: `pnpm test:unit -- query-embed.test.ts embedding.test.ts` exercises this exact scenario, and `env-module-scope-drift.integration.test.ts` would fail-fast naming the offending line if any of the three reads (or a future one) ever regressed back to module scope.

## Changeset

`.changeset/fix-inert-embed-env-knobs.md` — patch bump on `@panaversity/ksor-content`, per this repo's convention (pre-1.0, patch by default; body written for release-notes readers).

Fixes #149
