### PR TITLE
Let the release notes outlive the changesets that carried them

### DIFF
--- a/.changeset/release-notes-outlive-their-changesets.md
+++ b/.changeset/release-notes-outlive-their-changesets.md
@@ -1,0 +1,16 @@
+---
+"@panaversity/ksor": patch
+---
+
+**Fix a release gate that broke on the act of releasing.** Four doc-truth
+assertions read `.changeset/<slug>.md` directly. A changeset is a transient
+file — `changeset version` folds it into `CHANGELOG.md` and deletes it — so
+those assertions passed on every feature PR and threw `ENOENT` in the Version
+PR, the one run whose failure costs a red release instead of a red PR. It would
+have done so on every future release, not just this one.
+
+The assertions were right; only the place they looked was wrong. A new
+`releaseNote()` resolves a note to the pending changeset when it is still
+pending, and otherwise to the newest section of the changelog it was folded
+into — scoped to the newest section deliberately, so a rule adopted in this
+release is never asserted against prose written several releases ago.

--- a/packages/ksor/src/docs-truth.integration.test.ts
+++ b/packages/ksor/src/docs-truth.integration.test.ts
@@ -21,10 +21,15 @@ import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
 
+import { releaseNote } from "./release-note.js";
+
 import { verbs } from "./index.js";
 
 const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
-const read = (rel: string): string => readFileSync(path.join(repoRoot, rel), "utf8");
+const read = (rel: string): string =>
+  rel.startsWith(".changeset/")
+    ? releaseNote(repoRoot, rel)
+    : readFileSync(path.join(repoRoot, rel), "utf8");
 
 const SCAFFOLD = "packages/ksor/templates/scaffold";
 

--- a/packages/ksor/src/release-note.ts
+++ b/packages/ksor/src/release-note.ts
@@ -1,0 +1,41 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * The text of a release note, wherever it currently lives.
+ *
+ * A changeset is a TRANSIENT file. `changeset version` folds every pending one
+ * into `packages/ksor/CHANGELOG.md` and DELETES it, so a test that reads
+ * `.changeset/<slug>.md` directly passes on every feature PR and then throws
+ * ENOENT in the release job — the one run where nothing is allowed to be red,
+ * and the one run whose failure costs a red release rather than a red PR.
+ *
+ * That is not hypothetical: it happened on the 0.0.41 Version PR (2026-08-26),
+ * where four assertions across two suites died on a file the release had just
+ * consumed by design. The assertions were RIGHT — this prose is what an
+ * upgrading adopter reads first, and it must say what it says. Only the place
+ * they looked was wrong.
+ *
+ * So: the pending changeset if it is still pending, and otherwise the NEWEST
+ * section of the changelog it was folded into. Scoped to the newest section
+ * deliberately — the whole changelog carries every release ever made, and a
+ * rule this project adopted at 0.0.41 must not be asserted against prose
+ * written at 0.0.7.
+ */
+export function releaseNote(repoRoot: string, changesetRel: string): string {
+  const pending = path.join(repoRoot, changesetRel);
+  if (existsSync(pending)) return readFileSync(pending, "utf8");
+
+  const changelog = path.join(repoRoot, "packages", "ksor", "CHANGELOG.md");
+  const text = readFileSync(changelog, "utf8");
+  // `## <version>` delimits a release; the first is the one just cut.
+  const from = text.indexOf("\n## ");
+  if (from === -1) {
+    throw new Error(
+      `${changesetRel} is consumed and ${changelog} declares no release section — ` +
+        `the note cannot be checked in either place`,
+    );
+  }
+  const next = text.indexOf("\n## ", from + 1);
+  return next === -1 ? text.slice(from) : text.slice(from, next);
+}

--- a/packages/ksor/src/tool-surface-docs.integration.test.ts
+++ b/packages/ksor/src/tool-surface-docs.integration.test.ts
@@ -4,6 +4,8 @@ import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
 
+import { releaseNote } from "./release-note.js";
+
 import {
   buildDefaultGateway,
   buildServer,
@@ -77,7 +79,10 @@ describe("the documented tool-definition sizes", () => {
       ".changeset/okf-door-on-the-profile.md",
     ];
     for (const rel of documents) {
-      const text = readFileSync(path.join(ROOT, rel), "utf8");
+      // A changeset is consumed at release; its prose lives on in CHANGELOG.md.
+      const text = rel.startsWith(".changeset/")
+        ? releaseNote(ROOT, rel)
+        : readFileSync(path.join(ROOT, rel), "utf8");
       expect(text, `${rel} prints the transmitted figure`).toContain(grouped(transmitted));
       expect(text, `${rel} reconciles it with the per-tool sum`).toContain(grouped(sum));
     }


### PR DESCRIPTION
## Problem

The 0.0.41 Version PR (#163) went red on **four assertions across two suites**, every one of them `ENOENT` on a file the release had just consumed by design:

```
Error: ENOENT: no such file or directory, open '.../.changeset/okf-native.md'
Error: ENOENT: no such file or directory, open '.../.changeset/okf-door-on-the-profile.md'
```

A changeset is a **transient** file. `changeset version` folds every pending one into `packages/ksor/CHANGELOG.md` and deletes it. So a test that reads `.changeset/<slug>.md` directly is green on every feature PR and red in the release job — the one run whose failure costs a **red release** instead of a red PR.

This was not specific to 0.0.41. It would have fired on every release from here on.

## Solution

The assertions are correct and worth keeping — that prose is what an upgrading adopter reads first, and it has to say what the flags cost. Only the lookup was wrong.

`releaseNote(repoRoot, changesetRel)` resolves a note to:

- the **pending changeset**, while it is still pending;
- otherwise the **newest section** of the changelog it was folded into.

Scoped to the newest section deliberately: the changelog carries every release ever made, and a rule this project adopted at 0.0.41 must not be asserted against prose written at 0.0.7.

## Behaviour

No runtime change — the helper is used only by the two doc-truth suites.

## Verification

Run in **both** states, because only one of them is reachable on a feature branch:

| Tree | Changesets | Result |
|---|---|---|
| this branch | 39 present | 38 passed |
| `origin/changeset-release/main` + this fix | **0, all consumed** | 38 passed |

The second is the exact tree that failed in CI, which is the red evidence for the fix.

Full local gate: lint · fmt · typecheck · guard · check:corpus clean; `test:unit` 1528 passed; `test:integration` 580 passed, 31 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)