### PR TITLE
Record that the deploy regenerates the lock, and why that stays

### DIFF
--- a/.changeset/deploy-regenerates-by-design.md
+++ b/.changeset/deploy-regenerates-by-design.md
@@ -1,0 +1,20 @@
+---
+"@panaversity/ksor": patch
+---
+
+**Document what a deploy actually does to your lock.** `vercel.json` builds the
+site with `pnpm build`, which runs `ksor build` first — so the host regenerates
+every `index.md` and `build.lock.json` before building. That has two
+consequences worth knowing, and neither was written down: you can deploy
+without ever running `ksor build` yourself, and the `build.lock.json` in your
+repository is not necessarily the one that shipped.
+
+Nothing changes in behaviour. The record checker still runs on the deploy, so a
+record that breaks the profile still fails there, and the `build_id` that did
+ship is stamped into the deployed `llms.txt`.
+
+`docs/deploying.md` now also shows the stricter posture for adopters who want
+the deployed build reviewed before it ships — `buildCommand: "pnpm -C
+system/site build"`, which refuses `ksor-lock-missing` or `ksor-lock-stale`
+until someone runs `ksor build` and commits it. That is one line in your own
+`vercel.json`; ksor ships no flag for it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1274,6 +1274,49 @@ gateway` package, serve-by-spawn) is superseded._
     adopter might" is not an adopter, and the reversal condition is an event
     that can be observed rather than forecast.
 
+29. **The deploy REGENERATES the lock; it does not verify it** (owner,
+    2026-08-26). `vercel.json` builds the site with `pnpm build`, which is
+    `ksor build && <site build>`, so a host regenerates every `index.md` and
+    `build.lock.json` before the site is built. An adopter can therefore deploy
+    without ever having run `ksor build`, and the lock committed to their
+    repository is not necessarily the one that shipped.
+
+    Weighed and kept, because the alternative taxes the wrong person. Measured
+    on a real scaffold: the site build ALONE refuses `ksor-lock-missing` with no
+    lock and `ksor-lock-stale` when a document changed since one was written
+    (naming the document), and succeeds on a matching lock writing no tracked
+    file. So decoupling works — and it would oblige every adopter to run
+    `ksor build` and commit on EVERY knowledge edit, forever, or watch their
+    deploy fail. Product principle 7: governance is a ladder, and demanding a
+    reviewed lock of a level-0 project is a bug, not rigour.
+
+    **What is NOT given up.** The record checker runs on the deploy exactly as
+    it does locally — a record that breaks the profile fails there, exit 1,
+    nothing written. And the `build_id` that shipped is stamped into the
+    deployed `llms.txt`, so what was published is always discoverable from the
+    artifact. What is given up is narrower than it first looks: that the lock
+    in git is the one that shipped, and therefore that a human reviewed the
+    `build_id` in a pull request.
+
+    **The stricter posture needs no product change**, which is why none was
+    made: `buildCommand: "pnpm -C system/site build"` is one line in the
+    adopter's own `vercel.json` (decision 4 — that file is theirs), and the
+    refusals it relies on already exist and are asserted. It is documented in
+    `docs/deploying.md` as a choice rather than shipped as a flag.
+
+    Two costs recorded rather than argued away. `ksor build` rewrites
+    `build.lock.json` on EVERY run because `as_of` is the current instant, so a
+    no-op `pnpm build` leaves git dirty by one line (`--as-of` pins it; the
+    `build_id` itself is stable for the same tree). And `ksor-lock-stale` can
+    never fire on a deploy that regenerates the thing it checks — the gate is
+    real, it is simply not on that path.
+
+    **Reversed by the first adopter who needs the deployed `build_id` to have
+    been reviewed before it shipped** — a regulated record, or an audit that
+    asks which commit produced a published answer. That is an observable event,
+    not a forecast, and when it arrives the change is a default flip plus a
+    migration note, not new machinery.
+
 **Open questions — decide independently when the work arrives:** ~~how
 retrieval and abstention are implemented for `serve`~~ — decided 2026-08-19,
 decision 11: the predecessor kernel converts (revision trail: recorded as

--- a/packages/ksor/docs/deploying.md
+++ b/packages/ksor/docs/deploying.md
@@ -254,6 +254,26 @@ and reaches the site at its next build (it reads the ledger), so the act that
 withdraws a document is the same merged commit on both surfaces. Merge the
 ledger entry, rebuild, redeploy.
 
+**Your deploy runs it too, and that is deliberate.** `vercel.json` builds with
+`pnpm build`, so the host regenerates the indexes and the lock before building
+the site. The consequence is worth knowing in both directions: you can deploy
+without ever having run `ksor build` yourself — the record checker still runs
+there, so a record that breaks the profile still fails the deploy — but the
+`build.lock.json` in your repository is not necessarily the one that shipped.
+The `build_id` that DID ship is stamped into the deployed `llms.txt`.
+
+If you want the stricter property — the deployed build_id is one a human
+reviewed in a pull request — build the site alone instead:
+
+```json
+"buildCommand": "pnpm -C system/site build"
+```
+
+The site refuses `ksor-lock-missing` or `ksor-lock-stale` when the committed
+lock does not describe the tree, so a deploy then fails until someone runs
+`ksor build` and commits the result. That is your file to change; ksor does not
+choose it for you.
+
 ## Keeping people out of the site
 
 The door has auth ([authorization.md](./authorization.md)). The **site** is


### PR DESCRIPTION
## Problem

`vercel.json` builds the site with `pnpm build`, which is `ksor build && <site build>`. So a deploy host regenerates every `index.md` and `build.lock.json` before building. Two consequences were true and written down nowhere:

- an adopter can deploy having **never run `ksor build`** — the host does it for them;
- the `build.lock.json` in their repository is **not necessarily the one that shipped**.

AGENTS.md defines the lock as "the committed record of a build: what was published, from which commit". That deserved either a change or a recorded decision, not silence.

## Solution

Recorded as **decision 29**, and kept as-is.

Measured on a real scaffold from the published 0.0.41:

| Site build alone | Result |
|---|---|
| no lock | refuses `ksor-lock-missing` |
| lock stale (a document edited) | refuses `ksor-lock-stale`, **naming the document** |
| lock matches | succeeds, **0 tracked files modified** |

So the stricter posture works. It was declined because it taxes the wrong person: it would oblige every adopter to run `ksor build` and commit on **every** knowledge edit, forever, or watch their deploy fail. Product principle 7 — governance is a ladder, and demanding a reviewed lock of a level-0 project is a bug, not rigour.

**What is not given up is narrower than it first looks**, and the entry says so rather than overstating the case:

- the record checker runs on the deploy exactly as it does locally, so a record that breaks the profile fails there, exit 1, nothing written;
- the `build_id` that shipped is stamped into the deployed `llms.txt`, so what was published stays discoverable from the artifact.

What *is* given up: the lock in git being the one that shipped, and therefore a human having reviewed the `build_id` in a pull request.

**The stricter posture needs no product change**, which is why none was made — `buildCommand: "pnpm -C system/site build"` is one line in the adopter's own `vercel.json` (decision 4), on refusals that already exist and are asserted. `docs/deploying.md` now shows it as a choice.

Two costs recorded rather than argued away: `ksor build` rewrites the lock on every run because `as_of` is the current instant (so a no-op `pnpm build` leaves git dirty by one line; `build_id` itself is stable for the same tree), and `ksor-lock-stale` can never fire on a deploy that regenerates the thing it checks.

**Reversal condition is observable, not a forecast:** the first adopter who needs the deployed `build_id` to have been reviewed before it shipped.

## Verification

lint · fmt · typecheck · guard · check:corpus clean; `test:unit` 1528 passed; `test:integration` 580 passed, 31 skipped. Docs-only behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)