### PR TITLE
Make the release-note lookup survive more than one release

### DIFF
--- a/.changeset/release-note-lookup-spans-releases.md
+++ b/.changeset/release-note-lookup-spans-releases.md
@@ -1,0 +1,25 @@
+---
+"@panaversity/ksor": patch
+---
+
+**Fix the release-note lookup, properly this time.** The previous release added
+`releaseNote()` so doc-truth assertions could survive a changeset being folded
+into the changelog. It resolved a consumed note to the NEWEST changelog
+section, which is only correct for the release that consumes it: a note
+consumed in 0.0.41 lives in the 0.0.41 section forever, so by 0.0.42 the lookup
+returned a different release entirely.
+
+Two failures came out of that, and the second was worse than the bug it
+replaced: presence assertions went red, and a fenced-block scan went VACUOUS —
+passing because the section handed to it contained no code blocks at all.
+
+`releaseNote()` now returns the whole changelog once a note is consumed, plus
+whether the note is still `pending`. Assertions about the PRESENCE of prose use
+the text (finding it anywhere in the changelog proves it shipped); assertions
+about STRUCTURE gate on `pending`, because "every fenced block must show
+`--approve-by`" is a rule about a note still under review, not one to apply to
+the whole published history.
+
+Verified in both states and mutation-tested against the released tree: removing
+`--approve-by` or changing the tool-size figure in the changelog turns the
+assertions red.

--- a/packages/ksor/src/docs-truth.integration.test.ts
+++ b/packages/ksor/src/docs-truth.integration.test.ts
@@ -28,8 +28,11 @@ import { verbs } from "./index.js";
 const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
 const read = (rel: string): string =>
   rel.startsWith(".changeset/")
-    ? releaseNote(repoRoot, rel)
+    ? releaseNote(repoRoot, rel).text
     : readFileSync(path.join(repoRoot, rel), "utf8");
+/** True when this note is still a pending changeset a reviewer can change. */
+const isPending = (rel: string): boolean =>
+  !rel.startsWith(".changeset/") || releaseNote(repoRoot, rel).pending;
 
 const SCAFFOLD = "packages/ksor/templates/scaffold";
 
@@ -66,6 +69,12 @@ describe("every runbook that migrates a record shows how to keep it published", 
   ];
 
   it.each(RUNBOOKS)("%s — no `migrate --write` block omits --approve-by", (file) => {
+    // Structure, not presence: this scans EVERY fenced block, so once a
+    // changeset is folded into the changelog it would scan the whole published
+    // history and assert today's rule against prose written before it existed.
+    // Skipped there rather than run against the wrong text — which is how the
+    // first version of this fix turned the case vacuous instead of red.
+    if (!isPending(file)) return;
     const offenders = fencedBlocks(read(file))
       .filter((block) => /ksor migrate\b[^\n]*--write/.test(block))
       .filter((block) => !block.includes("--approve-by"));

--- a/packages/ksor/src/release-note.ts
+++ b/packages/ksor/src/release-note.ts
@@ -1,41 +1,51 @@
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 
+/** Where a release note lives, and whether it is still under review. */
+export interface ReleaseNote {
+  readonly text: string;
+  /**
+   * True while the changeset file still exists — i.e. this note is going out
+   * in the NEXT release and is the thing a reviewer can still change.
+   */
+  readonly pending: boolean;
+}
+
 /**
  * The text of a release note, wherever it currently lives.
  *
- * A changeset is a TRANSIENT file. `changeset version` folds every pending one
- * into `packages/ksor/CHANGELOG.md` and DELETES it, so a test that reads
- * `.changeset/<slug>.md` directly passes on every feature PR and then throws
- * ENOENT in the release job — the one run where nothing is allowed to be red,
- * and the one run whose failure costs a red release rather than a red PR.
+ * A changeset is TRANSIENT: `changeset version` folds every pending one into
+ * `packages/ksor/CHANGELOG.md` and deletes it. A test that reads
+ * `.changeset/<slug>.md` directly is therefore green on every feature PR and
+ * throws ENOENT in the release job — which is what happened on the 0.0.41
+ * Version PR.
  *
- * That is not hypothetical: it happened on the 0.0.41 Version PR (2026-08-26),
- * where four assertions across two suites died on a file the release had just
- * consumed by design. The assertions were RIGHT — this prose is what an
- * upgrading adopter reads first, and it must say what it says. Only the place
- * they looked was wrong.
+ * The first fix for that returned the NEWEST changelog section, and it was
+ * wrong in a way that mattered more than the bug it replaced. A note consumed
+ * in 0.0.41 lives in the 0.0.41 section FOREVER; by 0.0.42 the newest section
+ * is a different release, so presence assertions failed, and — worse — a
+ * fenced-block scan went VACUOUS, passing because the section it was handed
+ * contained no code blocks at all. A test that cannot fail is the defect this
+ * repo post-mortems most often, and that fix introduced one.
  *
- * So: the pending changeset if it is still pending, and otherwise the NEWEST
- * section of the changelog it was folded into. Scoped to the newest section
- * deliberately — the whole changelog carries every release ever made, and a
- * rule this project adopted at 0.0.41 must not be asserted against prose
- * written at 0.0.7.
+ * So: the pending changeset while it is pending, and otherwise the WHOLE
+ * changelog, which is where the note actually is. Callers that assert the
+ * PRESENCE of prose can use the text as-is — finding it anywhere in the
+ * changelog proves it shipped. Callers that scan STRUCTURE (fenced blocks,
+ * "every block must…") must gate on `pending`, because that rule is about a
+ * note still under review, and applying it to the whole published history
+ * asserts today's rules against prose written before they existed.
  */
-export function releaseNote(repoRoot: string, changesetRel: string): string {
+export function releaseNote(repoRoot: string, changesetRel: string): ReleaseNote {
   const pending = path.join(repoRoot, changesetRel);
-  if (existsSync(pending)) return readFileSync(pending, "utf8");
+  if (existsSync(pending)) return { text: readFileSync(pending, "utf8"), pending: true };
 
   const changelog = path.join(repoRoot, "packages", "ksor", "CHANGELOG.md");
-  const text = readFileSync(changelog, "utf8");
-  // `## <version>` delimits a release; the first is the one just cut.
-  const from = text.indexOf("\n## ");
-  if (from === -1) {
+  if (!existsSync(changelog)) {
     throw new Error(
-      `${changesetRel} is consumed and ${changelog} declares no release section — ` +
+      `${changesetRel} is consumed and ${changelog} does not exist — ` +
         `the note cannot be checked in either place`,
     );
   }
-  const next = text.indexOf("\n## ", from + 1);
-  return next === -1 ? text.slice(from) : text.slice(from, next);
+  return { text: readFileSync(changelog, "utf8"), pending: false };
 }

--- a/packages/ksor/src/tool-surface-docs.integration.test.ts
+++ b/packages/ksor/src/tool-surface-docs.integration.test.ts
@@ -81,7 +81,7 @@ describe("the documented tool-definition sizes", () => {
     for (const rel of documents) {
       // A changeset is consumed at release; its prose lives on in CHANGELOG.md.
       const text = rel.startsWith(".changeset/")
-        ? releaseNote(ROOT, rel)
+        ? releaseNote(ROOT, rel).text
         : readFileSync(path.join(ROOT, rel), "utf8");
       expect(text, `${rel} prints the transmitted figure`).toContain(grouped(transmitted));
       expect(text, `${rel} reconciles it with the per-tool sum`).toContain(grouped(sum));


### PR DESCRIPTION
## Problem

The previous release added `releaseNote()` so doc-truth assertions could survive a changeset being folded into the changelog. It resolved a consumed note to the **newest** changelog section — correct only for the release that consumes it.

A note folded in at 0.0.41 lives in the **0.0.41 section forever**. So on the 0.0.42 Version PR every assertion was handed a different release:

```
AssertionError: expected '\n## 0.0.42\n\n### Patch Changes\n\n-…' to contain '--approve-by'
AssertionError: .changeset/okf-door-on-the-profile.md prints the transmitted figure:
               expected '\n## 0.0.42\n…' to contain '16,734'
```

**The third symptom was worse than the bug it replaced.** The fenced-block scan (`no migrate --write block omits --approve-by`) did not fail — it passed **vacuously**, because the section it was handed contained no code blocks at all. A test that cannot fail is the defect this repo post-mortems most often, and the previous fix introduced one.

## Solution

`releaseNote()` returns the whole changelog once a note is consumed, and reports whether it is still `pending`. The two kinds of assertion are then separated, because they need different things:

| Assertion kind | Consumed behaviour | Why |
|---|---|---|
| **presence** of prose (`toContain`) | search the whole changelog | finding it anywhere proves it shipped |
| **structure** (every fenced block must…) | skipped | it is a rule about a note a reviewer can still change; applying it to the whole published history asserts today's rules against older prose |

## Verification

Run in both states, because only one is reachable from a feature branch:

| Tree | Changesets | Result |
|---|---|---|
| this branch | present | 38 passed |
| `origin/changeset-release/main` (0.0.42) + this fix | **0, consumed a release ago** | 38 passed |

**Mutation-tested against the released tree** rather than trusted, since "passes on the version branch" is exactly what the broken version also did:

- redact `--approve-by` from `CHANGELOG.md` (9 occurrences) → `the demotion is stated as a consequence` **fails**
- change `16,734` → `99,999` (2 occurrences) → `are printed with their reconciliation…` **fails**

Both restored; tree clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)