### PR TITLE
Make the document page read at a glance, and see new documents in dev

### DIFF
--- a/.changeset/document-page-row-and-dev-arrivals.md
+++ b/.changeset/document-page-row-and-dev-arrivals.md
@@ -1,0 +1,38 @@
+---
+"@panaversity/ksor": patch
+---
+
+**A document page that reads at a glance, and a dev server that sees new
+documents again.**
+
+The governance row is two tiers. It was one line carrying 79 characters, of
+which the approver was 32 (41%) and the three labels 19 (24%) — so a producer
+id was the longest thing on the page and the two facts a reader actually scans
+for, what state this is in and whether anyone has checked it, competed with it.
+Now the chips lead with Export beside them, and provenance sits beneath in
+muted weight. Nothing is hidden: decision 21 requires a governance act to name
+its actor and decision 27 requires a non-human approver to be disclosed, so the
+approver moved one line down, not one click away, and every byte of it is still
+in the server-rendered markup an agent parses.
+
+Export no longer lands in the middle of the row. It and the reading time each
+carried their own `ms-auto`, and on a row narrow enough to wrap they shared a
+line — where two auto margins SPLIT the free space rather than stacking. They
+are one right-hand cluster now.
+
+**And adding a document to `knowledge/` while `pnpm dev` runs shows it again.**
+This regressed in 0.0.41: `refreshStage` walked the STAGE and skipped anything
+the stage did not already hold, so an arrival — which has no file to walk onto
+— was never written, and the manifest naming what publishes never learned about
+it. Measured: `/docs/<new>/` 404 → 200, sidebar 0 → 1, `llms.txt` 0 → 1;
+0.0.40 served it at 200, so this is a repair rather than a feature. Removals
+still wait for a restart, deliberately — a deleted file leaves fumadocs'
+generated imports pointing at something gone.
+
+The comment explaining why arrivals were refused was also wrong, and is
+corrected: fumadocs-mdx 15.3.0 DOES regenerate on a write into the
+dot-prefixed stage. Our own function was the blocker.
+
+Finally, the starter's `knowledge/surfaces/overview.md` was titled `Surfaces`
+inside the Surfaces section, so its breadcrumb read `Surfaces › Surfaces`. It
+is `Overview` now.

--- a/.changeset/meta-row-and-duplicate-title.md
+++ b/.changeset/meta-row-and-duplicate-title.md
@@ -1,0 +1,17 @@
+---
+"@panaversity/ksor": patch
+---
+
+**Two fixes on the document page.**
+
+The governance row put **Export** in the middle of the row with nothing under
+it. Export and the reading time each carried their own `ms-auto`, and on a row
+narrow enough to wrap they landed on the same line — where two auto margins
+SPLIT the free space between them rather than stacking, so Export came to rest
+mid-row instead of at either end. They are now one right-hand cluster and
+travel together at every width.
+
+And the starter's `knowledge/surfaces/overview.md` was titled `Surfaces` inside
+a section already called Surfaces, so its breadcrumb read `Surfaces › Surfaces`
+and the sidebar showed a Surfaces inside Surfaces. It is titled `Overview` now,
+matching its filename, and the generated section index was regenerated with it.

--- a/packages/ksor/templates/scaffold/knowledge/surfaces/index.md
+++ b/packages/ksor/templates/scaffold/knowledge/surfaces/index.md
@@ -1,5 +1,5 @@
 # Surfaces
 
-* [Surfaces](overview.md) - One source, published through several synchronized projections.
+* [Overview](overview.md) - One source, published through several synchronized projections.
 * [The human surface](for-people.md) - Pages for reading, reviewing and sharing the record.
 * [The agent surface](for-agents.md) - MCP for retrieval with citations, and machine-readable files beside it.

--- a/packages/ksor/templates/scaffold/knowledge/surfaces/overview.md
+++ b/packages/ksor/templates/scaffold/knowledge/surfaces/overview.md
@@ -1,6 +1,6 @@
 ---
 type: Document
-title: Surfaces
+title: Overview
 description: One source, published through several synchronized projections.
 status: stable
 order: 4

--- a/packages/ksor/templates/scaffold/system/site/components/governance.tsx
+++ b/packages/ksor/templates/scaffold/system/site/components/governance.tsx
@@ -216,104 +216,132 @@ export function GovernanceMeta({
   // tier, `unverified` included, and that is the whole point of printing it.
   // The early return this replaced would have hidden the tier on exactly the
   // documents whose tier is the only governance fact they have.
+  /**
+   * TWO TIERS, because the row's length was never its vocabulary.
+   *
+   * Measured on the starter's own document: 79 characters, of which the
+   * APPROVER is 32 (41%) and the three labels 19 (24%). One producer id was
+   * longer than both governance chips together, so the two facts a reader
+   * scans for — what state is this in, and has anyone checked it — competed
+   * with a string that means nothing to them, and Export was pushed onto a
+   * line of its own.
+   *
+   * So the chips lead and the provenance follows beneath them. Nothing is
+   * hidden: decision 21 says a governance act NAMES its actor and decision
+   * 27's starter revision requires a non-human approver to be DISCLOSED, so
+   * demoting `ksor.approval` to a hover would trade a governance guarantee
+   * for a tidier row (critical rule 1). It is one line lower, not one click
+   * away, and every byte of it is still in the server-rendered markup an
+   * agent parses.
+   */
   return (
-    <dl className="mb-7 flex flex-wrap items-baseline gap-x-8 gap-y-2.5 border-b border-fd-border pb-4">
-      {state === null && alsoBadge === null ? null : (
-        <Fact label="Status">
-          <span className="flex flex-wrap items-baseline gap-1.5">
-            {state === null ? null : <Chip text={state} tone={statusTone(status)} />}
-            {alsoBadge === null ? null : (
-              <BadgeChip badge={alsoBadge} effectiveFrom={effectiveFrom} />
-            )}
-          </span>
-        </Fact>
-      )}
-      {/* The tier OKF's own vocabulary names, on every document including the
+    <div className="mb-7 border-b border-fd-border pb-4">
+      <dl className="flex flex-wrap items-baseline gap-x-8 gap-y-2.5">
+        {state === null && alsoBadge === null ? null : (
+          <Fact label="Status">
+            <span className="flex flex-wrap items-baseline gap-1.5">
+              {state === null ? null : <Chip text={state} tone={statusTone(status)} />}
+              {alsoBadge === null ? null : (
+                <BadgeChip badge={alsoBadge} effectiveFrom={effectiveFrom} />
+              )}
+            </span>
+          </Fact>
+        )}
+        {/* The tier OKF's own vocabulary names, on every document including the
           unverified ones — that is the honest state of a stable, approved
           concept nobody has reviewed, and hiding it would leave a reader unable
           to tell "checked" from "never mentioned" (research/okf-native.md
           §1.1). Never a colour: a tier is a fact about review, not a warning. */}
-      <Fact label="Trust">
-        <span className="flex flex-wrap items-baseline gap-1.5">
-          <Chip text={trust.tier} />
-          {trust.by === null ? null : (
-            <span className="font-normal text-fd-muted-foreground">
-              {trust.by}
-              {trust.at === null ? null : <> · {day(trust.at)}</>}
-            </span>
-          )}
-        </span>
-      </Fact>
-      {owner === null ? null : <Fact label="Owner">{owner}</Fact>}
-      {/* Who let this into the record. `ksor.approval` is what makes a `stable`
+        <Fact label="Trust">
+          <span className="flex flex-wrap items-baseline gap-1.5">
+            <Chip text={trust.tier} />
+            {trust.by === null ? null : (
+              <span className="font-normal text-fd-muted-foreground">
+                {trust.by}
+                {trust.at === null ? null : <> · {day(trust.at)}</>}
+              </span>
+            )}
+          </span>
+        </Fact>
+        {/* Actions ride tier ONE: a reader who wants the bytes wants them
+          immediately, and this is the row with room. */}
+        {markdownUrl === undefined && minutes === undefined ? null : (
+          <div className="ms-auto flex items-center gap-x-6">
+            {markdownUrl === undefined ? null : <DocumentActions href={markdownUrl} />}
+            {minutes === undefined ? null : (
+              <div className="flex items-center gap-2 text-sm text-fd-muted-foreground">
+                <Clock aria-hidden className="size-3.5 shrink-0" />
+                <span>{minutes} min read</span>
+              </div>
+            )}
+          </div>
+        )}
+      </dl>
+      {/* Tier two RECEDES. It is provenance — who let this in, when it takes
+          effect, what it replaced — and it is read when a reader goes looking,
+          not scanned. At full `--foreground` weight it competed with the two
+          chips above it for the same attention, which is what made a producer
+          id the loudest thing on the page.
+
+          Links keep full strength: `Replaces` points at the document this one
+          superseded, and that is an action rather than a fact. */}
+      <dl className="mt-2.5 flex flex-wrap items-baseline gap-x-8 gap-y-2.5 empty:mt-0 [&_a]:text-fd-foreground [&_dd]:font-normal [&_dd]:text-fd-muted-foreground">
+        {owner === null ? null : <Fact label="Owner">{owner}</Fact>}
+        {/* Who let this into the record. `ksor.approval` is what makes a `stable`
           document stable at all (record spec §2.2), so a page that showed the
           word and not the signature would be publishing the claim without its
           author. */}
-      {approval === null ? null : (
-        <Fact label="Approved">
-          <>
-            {approval.by} · {day(approval.at)}
-          </>
-        </Fact>
-      )}
-      {/* found live 2026-08-25: a deprecated page named its successor and said
+        {approval === null ? null : (
+          <Fact label="Approved">
+            <>
+              {approval.by} · {day(approval.at)}
+            </>
+          </Fact>
+        )}
+        {/* found live 2026-08-25: a deprecated page named its successor and said
           nothing about WHO withdrew it, though `ksor.deprecated` is required on
           every deprecated concept (record spec §2.2) and readGovernance already
           refuses a document that omits it. Withdrawal is the most consequential
           act in a document's life; publishing it unattributed is exactly the
           gap the approver fact above closes at the other end. */}
-      {deprecated === null ? null : (
-        <Fact label="Withdrawn">
-          <>
-            {deprecated.by} · {day(deprecated.at)}
-          </>
-        </Fact>
-      )}
-      {replaces.length === 0 ? null : (
-        // The other half of a supersession. The withdrawn document names its
-        // successor above the title; this is the successor naming what it
-        // replaced, so the history the record kept is reachable from the
-        // current document instead of only from the retired one.
-        <Fact label="Replaces">
-          <>
-            {replaces.map((entry, index) => (
-              <span key={entry.href ?? `${index}-${entry.label}`}>
-                {index === 0 ? null : ", "}
-                {entry.href === null ? (
-                  entry.label
-                ) : (
-                  <Link
-                    href={entry.href}
-                    className="underline underline-offset-4 transition-colors hover:text-fd-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fd-ring"
-                  >
-                    {entry.label}
-                  </Link>
-                )}
-              </span>
-            ))}
-          </>
-        </Fact>
-      )}
-      {effectiveFrom === null || !showEffective ? null : (
-        <Fact label="Effective from">{day(effectiveFrom)}</Fact>
-      )}
-      {staleAfter === null ? null : <Fact label="Review by">{day(staleAfter)}</Fact>}
-      {markdownUrl === undefined ? null : (
-        // On the governance row, not as a footnote below the sources: it is
-        // how a reader hands this document to an agent (research/site-design.md
-        // F2). Right-aligned: a column of things you DO, against a row of
-        // things the record DECLARES (owner, 2026-08-22).
-        <span className="ms-auto">
-          <DocumentActions href={markdownUrl} />
-        </span>
-      )}
-      {minutes === undefined ? null : (
-        <div className="ms-auto flex items-center gap-2 text-sm text-fd-muted-foreground">
-          <Clock aria-hidden className="size-3.5 shrink-0" />
-          <span>{minutes} min read</span>
-        </div>
-      )}
-    </dl>
+        {deprecated === null ? null : (
+          <Fact label="Withdrawn">
+            <>
+              {deprecated.by} · {day(deprecated.at)}
+            </>
+          </Fact>
+        )}
+        {replaces.length === 0 ? null : (
+          // The other half of a supersession. The withdrawn document names its
+          // successor above the title; this is the successor naming what it
+          // replaced, so the history the record kept is reachable from the
+          // current document instead of only from the retired one.
+          <Fact label="Replaces">
+            <>
+              {replaces.map((entry, index) => (
+                <span key={entry.href ?? `${index}-${entry.label}`}>
+                  {index === 0 ? null : ", "}
+                  {entry.href === null ? (
+                    entry.label
+                  ) : (
+                    <Link
+                      href={entry.href}
+                      className="underline underline-offset-4 transition-colors hover:text-fd-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fd-ring"
+                    >
+                      {entry.label}
+                    </Link>
+                  )}
+                </span>
+              ))}
+            </>
+          </Fact>
+        )}
+        {effectiveFrom === null || !showEffective ? null : (
+          <Fact label="Effective from">{day(effectiveFrom)}</Fact>
+        )}
+        {staleAfter === null ? null : <Fact label="Review by">{day(staleAfter)}</Fact>}
+      </dl>
+    </div>
   );
 }
 

--- a/packages/ksor/templates/scaffold/system/site/lib/stage-knowledge.ts
+++ b/packages/ksor/templates/scaffold/system/site/lib/stage-knowledge.ts
@@ -670,30 +670,51 @@ function fillStage(recordDir: string, stageDir: string, development: boolean): v
 }
 
 /**
- * Dev only: carry edits into the files the stage already holds, so
- * `pnpm dev` shows the record as the owner is writing it rather than as it
- * stood when the server started — the regenerated indexes included, so a
- * retitled document is retitled in its folder's listing too.
+ * Dev only: carry edits AND ARRIVALS into the stage, so `pnpm dev` shows the
+ * record as the owner is writing it rather than as it stood when the server
+ * started — the regenerated indexes included, so a retitled document is
+ * retitled in its folder's listing too.
  *
- * Edits only — never adds, never removals. fumadocs' own watcher cannot see
- * a dot-prefixed collection directory (measured 2026-08-18: adding a file to
- * the stage regenerated nothing, and removing one left the generated imports
- * pointing at a file that was gone), so a document that ARRIVES or changes
- * audience needs the restart `pnpm dev` already needs for instance.md. Leaving
- * that to a restart keeps dev honest in the direction that matters: the
- * published build is always staged from scratch.
+ * Adds and edits — never removals. The 2026-08-18 measurement this refused
+ * adds on ("fumadocs' own watcher cannot see a dot-prefixed collection
+ * directory") no longer holds: on fumadocs-mdx 15.3.0 a file written into
+ * `.staged-knowledge` DOES regenerate the collection, twice-observed as
+ * `[MDX] generated files` in the dev log. What actually kept a new document
+ * off every surface was this function, which walked the STAGE and skipped
+ * anything the stage did not already hold — so a plan entry with no file on
+ * disk was never written, and the manifest that names what publishes never
+ * learned about it either.
+ *
+ * Measured before and after, adding a document while `pnpm dev` ran:
+ * `/docs/<new>/` 404 -> 200, sidebar 0 -> 1, `llms.txt` 0 -> 1. It worked
+ * this way before the stage existed (0.0.40 serves an added document at 200),
+ * so this is a regression repaired rather than a feature.
+ *
+ * REMOVALS still wait for the restart `pnpm dev` already needs for
+ * instance.md: the same measurement found a deleted file leaves fumadocs'
+ * generated imports pointing at something gone, which takes the dev server
+ * down rather than showing a stale page. An arrival has no such failure mode
+ * — nothing points at a file that has only just appeared.
  */
 function refreshStage(recordDir: string, stageDir: string): void {
   // Under the lock like every other write here: a save landing while another
   // evaluation is refilling the stage is the same race from the other side.
   withStageLock(stageDir, () => {
     const plan = planStage(recordDir, true);
-    const permitted = new Map(plan.entries.map((e) => [path.join(stageDir, e.rel), e] as const));
-    for (const staged of walkFiles(stageDir)) {
-      const entry = permitted.get(staged);
-      if (entry === undefined) continue;
+    // Drive from the PLAN, not from the stage. Walking the stage could only
+    // ever find what was already there, which is exactly why an arrival was
+    // invisible: it has no file to walk onto.
+    for (const entry of plan.entries) {
+      const staged = path.join(stageDir, entry.rel);
       const bytes = entry.bytes();
-      if (bytes.equals(readFileSync(staged))) continue;
+      let current: Buffer | null = null;
+      try {
+        current = readFileSync(staged);
+      } catch {
+        // Not staged yet — an arrival. Written below.
+      }
+      if (current !== null && current.equals(bytes)) continue;
+      mkdirSync(path.dirname(staged), { recursive: true });
       writeFileSync(staged, bytes);
     }
     writeManifest(stageDir, plan.manifest);


### PR DESCRIPTION
## The governance row was one long line

Measured on the starter's own document, not eyeballed:

```
"Status stable  Trust unverified  Approved ksor-starter/0.0.42 · 2026-08-25  Export"
79 characters — approver 32 (41%), labels 19 (24%)
```

A **producer id was the longest thing on the page**, so the two facts a reader scans for — what state is this in, has anyone checked it — competed with a string that means nothing to them, and Export was pushed onto a line of its own.

Two tiers now:

```
STATUS [STABLE]   TRUST [UNVERIFIED]              ⤓ EXPORT ⌄     37 chars
approved  ksor-starter/0.0.42 · 2026-08-25                       41 chars
```

**Nothing is hidden.** Decision 21 says a governance act NAMES its actor, and decision 27's starter revision requires a non-human approver to be *disclosed*. Demoting it to a hover would trade a governance guarantee for a tidier row (critical rule 1). It is one line lower, not one click away, and still in the server-rendered markup an agent parses — asserted on the built HTML.

## Export was landing mid-row

Export and the reading time each carried their own `ms-auto`. On a row narrow enough to wrap they shared a line — and **two auto margins split the free space rather than stacking**, parking Export in the middle with nothing under it. They are one right-hand cluster now (`ms-auto` count 2 → 1).

## Adding a document in dev works again — a 0.0.41 regression

| version | add a doc while `pnpm dev` runs |
|---|---|
| 0.0.40 | **200**, in sidebar, in `llms.txt` |
| 0.0.41 | **500** |
| 0.0.42 | **404** |
| this PR | **200**, in sidebar, in `llms.txt` |

`refreshStage` walked the **stage** and skipped anything the stage did not already hold. An arrival has no file to walk onto, so it was never written — and the manifest naming what publishes never learned about it. It drives from the **plan** now.

**The comment justifying the old behaviour was stale and is corrected.** It said *"fumadocs' own watcher cannot see a dot-prefixed collection directory (measured 2026-08-18)"*. On fumadocs-mdx 15.3.0 it does — `[MDX] generated files` fires on a direct write into `.staged-knowledge`. Our own function was the blocker, not the framework. Left as-is, that comment would have sent the next reader after the wrong thing.

**Removals still wait for a restart, deliberately** — a deleted file leaves fumadocs' generated imports pointing at something gone. Verified a removal now leaves a stale page and a **live server** (200) rather than crashing.

## Breadcrumb read `Surfaces › Surfaces`

The starter's `knowledge/surfaces/overview.md` was titled `Surfaces` inside the Surfaces section. It is `Overview` now, matching its filename; the generated section index was regenerated with it.

## Verification

- `fmt` `lint` `guard` `check:corpus` `typecheck` `test:unit` clean
- `test:integration` **580 passed / 31 skipped**
- Built a real scaffold and asserted the **shipped HTML**: two tiers, `ms-auto` 1, approver present, breadcrumb `Surfaces › Overview`
- `site.governance: false` still renders — row gone, no orphaned rule
- Dev behaviour walked live: edit ✓, retitle reaches the index ✓, arrival ✓, removal leaves the server up ✓

**Note on the browser suite:** it was silently failing locally for environment reasons — Playwright 1.62.1 wants chromium build 1234 and only 1200 was installed, which surfaces as three failures unrelated to any change. Installed and re-run; CI runs it on a clean machine regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)