### PR TITLE
Add preview, name the Vercel root cause, and cut the interview to three questions

### DIFF
--- a/.changeset/preview-script-and-vercel-root.md
+++ b/.changeset/preview-script-and-vercel-root.md
@@ -1,0 +1,40 @@
+---
+"@panaversity/ksor": patch
+---
+
+**`pnpm preview` — somewhere for `pnpm build` to land.**
+
+The site is a static export, so there is no server to start; that is what makes
+the record hostable anywhere. But it also means the natural thing to try after a
+build — `pnpm start` — answers `ERR_PNPM_NO_SCRIPT_OR_SERVER`, which explains
+none of that. `pnpm preview` serves `system/site/out` on the same bytes a host
+would. It is `node:http` and nothing else: no dependency, no network fetch, works
+offline and behind a firewall, for the same reason the build downloads nothing.
+Run before a build, it says so and exits `3`.
+
+**And the Vercel dashboard import now says what actually goes wrong.** Vercel
+auto-detects a root directory by looking for a framework, finds the Next app, and
+fills the field with `system/site`. The build then reads
+`system/site/vercel.json`, which does not exist, and fails with
+`Project framework is set to "services", but no services are declared` — even
+though the import screen just listed both services, because that step reads the
+root file and the build step uses the Root Directory override. The fix is one
+field: set Root Directory to the repository root. `docs/deploying.md` now names
+the error, the cause and the fix, plus the site-only fallback.
+
+Found by an adopter, and it will recur on every dashboard import until Vercel's
+detection changes — the layout that triggers it is decision 8 and is not moving.
+
+**And the intake interview asks three questions, not seven.** Seven did not
+survive contact: an agent running the skill decided five were too many,
+defaulted them, and reported "answered: all seven" — including the one that
+decides who may approve a document, which it filled from a git handle. A
+process the tool executing it shortcuts is too long.
+
+Scope, Boundary and Authority are asked, because none can be defaulted: the
+first two give the abstention gate an edge to be outside of, and the third is
+a governance act, which never gets guessed (decision 21). The other four are
+STATED as defaults in one block — read by both, declines firmly, one `public`
+audience, no sources yet — written only if the owner does not object, and the
+write-back must name which were answered and which were defaulted. Reporting a
+default as an answer is now called out in the skill as the thing not to do.

--- a/.changeset/preview-script-and-vercel-root.md
+++ b/.changeset/preview-script-and-vercel-root.md
@@ -38,3 +38,13 @@ STATED as defaults in one block — read by both, declines firmly, one `public`
 audience, no sources yet — written only if the owner does not object, and the
 write-back must name which were answered and which were defaulted. Reporting a
 default as an answer is now called out in the skill as the thing not to do.
+
+**The scaffold README no longer tells you to uncomment something that ships
+uncommented.** 0.0.42 filled in `instance.md`'s `database:` block; the README
+kept instructing the adopter to uncomment it, and named a refusal
+(`instance.md declares no database: block`) they could no longer reach. The
+emitted `AGENTS.md` had already been corrected and the README had not — two
+documents describing one file, and only one of them updated. Vercel is three
+steps ending in the Root Directory fix, `preview` sits beside `build`, and a
+"When something refuses you" table maps every refusal an adopter meets to what
+to do about it.

--- a/.changeset/preview-script-and-vercel-root.md
+++ b/.changeset/preview-script-and-vercel-root.md
@@ -48,3 +48,25 @@ documents describing one file, and only one of them updated. Vercel is three
 steps ending in the Root Directory fix, `preview` sits beside `build`, and a
 "When something refuses you" table maps every refusal an adopter meets to what
 to do about it.
+
+**The scaffold README is restructured around what the record is FOR.** It now
+opens on the agent interface — an MCP door that answers with citations and
+declines what the record does not cover — rather than on an architecture
+diagram, because a reader classifies the project in the first fifteen seconds
+and "governed markdown plus a site" puts it in the wrong bucket.
+
+`ksor calibrate` moves into the main command path, between `refresh` and
+`serve`. It was a parenthetical and a remedy-after-the-fact, which meant the
+README's own three-question test failed at exactly the question it says
+matters. Verified on the five-document starter: calibrate needs an ingested
+corpus but NO running server, produces `vector_floor: 0.609`, and with it
+applied the test passes as written — the paraphrased in-corpus question is
+answered at 0.701 while an adjacent miss abstains at 0.550 and a far-outside
+one at 0.512. The "expect answers, not refusals" note moves from postscript to
+precondition, where it prevents the disappointment instead of explaining it.
+
+Also: Neon is named for hosted Postgres rather than leaving it abstract (it is
+already what this project's own docs are measured against, and pgvector is on
+its free tier), the deploy section ends at the Root Directory fix, and a
+"When something refuses you" table maps every refusal an adopter meets to the
+one thing to do about it.

--- a/packages/ksor/docs/deploying.md
+++ b/packages/ksor/docs/deploying.md
@@ -113,6 +113,34 @@ What the image deliberately does NOT contain (see `.dockerignore`):
 
 ## Deploying both surfaces to Vercel
 
+> **Importing from the Vercel dashboard: clear the Root Directory first.**
+> Vercel auto-detects a root directory by looking for a framework, finds the
+> Next app, and fills the field with **`system/site`**. The build then reads
+> `system/site/vercel.json`, which does not exist, and fails with:
+>
+> ```
+> Error: Project framework is set to "services", but no services are declared.
+> ```
+>
+> The services ARE declared — in `vercel.json` at the repository root, which is
+> the only place they can be, because one of them builds the site and the other
+> builds a container from the root `Dockerfile`. The import screen even lists
+> both, because that step reads the root file; the BUILD step uses the Root
+> Directory override instead.
+>
+> **Set Root Directory to the repository root (`./`) and redeploy.** Nothing in
+> the record changes. Found by an adopter on 2026-08-26, and it will happen on
+> every dashboard import until Vercel's detection changes — the layout that
+> triggers it, code under `system/`, is decision 8 and is not moving.
+>
+> Also confirm **Application Preset is `Services`**; with any other preset the
+> `services` key is ignored and `/mcp` never exists. Vercel Services is in Beta.
+>
+> **If it still argues, deploy the site alone** — it needs no preset and no
+> services: build command `pnpm -C system/site build`, output directory
+> `system/site/out`. That is the stricter posture decision 29 describes, and
+> the door can be deployed separately.
+
 The emitted `vercel.json` declares both services and routes between them:
 
 ```json

--- a/packages/ksor/src/init/manager.ts
+++ b/packages/ksor/src/init/manager.ts
@@ -123,6 +123,7 @@ export function transformManifest(source: string, manager: PackageManager): stri
 const SCRIPT_NAMES = [
   "dev",
   "build",
+  "preview",
   "check",
   "serve",
   "provision",

--- a/packages/ksor/templates/scaffold/.agents/skills/intake-interview/SKILL.md
+++ b/packages/ksor/templates/scaffold/.agents/skills/intake-interview/SKILL.md
@@ -12,49 +12,75 @@ prose IS the agent surface's system prompt (`ksor serve` wires it into the MCP
 server's instructions). Do not draft it from guesses — interview the owner, one
 question at a time, and write down what they actually say.
 
-## The first six questions
+## Ask THREE questions, one at a time
 
-Ask these one at a time; follow up until each answer is concrete enough to
-act on:
+Seven questions is where this skill used to start, and it did not survive
+contact: an agent running it decided five were too many, defaulted them, and
+reported "answered: all seven" — including the one that decides who may
+approve a document. A process the tool executing it shortcuts is too long.
 
-1. **Authority** — "What should this record be the _final word_ on? Finish
-   the sentence: when someone here disagrees with this corpus, the corpus
-   wins about ___."
-2. **Boundary** — "What is explicitly _outside_ it — near-miss topics people
-   will ask about that this record should refuse rather than guess at?"
-3. **Audience** — "Who reads it — people, agents, both? In what situations,
-   making what decisions?"
-4. **Sources** — "Which existing materials are authoritative inputs (name
-   the actual documents, systems, people), and which are explicitly _not_
-   trusted?"
-5. **Strictness** — "When the record doesn't cover a question, how firmly
-   should it decline? ('Not in this corpus' is a correct answer here —
-   confirm the owner wants that behavior and where they want it softened.)"
-6. **Audiences** — "Does every reader of this record see every document? If
-   not, what are the audiences?" A yes is the common answer and the whole
-   answer: register none, and every document says `ksor.audience: [public]`.
-   Anything else means registering each audience in
-   `.ksor/governance.yaml` under `audiences:`, with a one-line
-   `description:` of who is in it — `public` is reserved and never
-   registered. There is no ranking and no default: a document lists the
-   audiences that may read it, a reader holds a list that always includes
-   `public`, and the document is visible when the two lists OVERLAP. Tell
-   the owner what this does and does not do: builds are made per audience,
-   but anyone who can clone the repository reads everything in it — if
-   someone must not read a document and can clone, that document belongs in
-   a different repository.
+So three are asked, and they are the three that cannot be defaulted:
 
-## Then ask the seventh, because a policy cannot be guessed
+1. **Scope** — "What should this record be the _final word_ on? Finish the
+   sentence: when someone here disagrees with this corpus, the corpus wins
+   about ___."
+2. **Boundary** — "What is just _outside_ that — the near-miss topics people
+   will ask about here that the record should refuse rather than guess at?"
+3. **Authority** — "Who may approve a document for publication, and who may
+   withdraw one?"
 
-7. **Authority** — "Who may approve a document for publication, and who may
-   withdraw one?" Names, not roles-in-the-abstract: they become
-   `approval_authorities` and `takedown_authorities` in
-   `.ksor/governance.yaml`, and the checker refuses an approval or a
-   takedown by anyone the policy does not name. The scaffold ships
-   `human:you` in both — a placeholder that must not survive this
-   conversation. An actor is `human:<handle>`, `process:<name>` or
-   `<producer>/<version>`; handles are published with the record, so use the
-   handle the owner would put in a commit, never an email address.
+Scope and Boundary are asked because the abstention gate is meaningless
+without an edge: a record authoritative for everything has no outside, so an
+agent asked something the owner never wrote about reaches for its training
+instead of declining. Authority is asked because a governance act names its
+actor and the tool never guesses one — the scaffold ships `human:you` in
+both authority lists, and a placeholder that survives this conversation is a
+person who was never there.
+
+Follow up until each is concrete. "Our engineering docs" is not yet an
+answer; "our leave, expense and conduct policies — the current ones, not
+historical versions" is.
+
+## Then STATE the defaults; do not ask them
+
+Show these as a block, say they are defaults, and invite a correction. Do not
+walk them one at a time — they are near-constant, and asking makes the
+interview feel like a form.
+
+|           | default                                           |
+| --------- | ------------------------------------------------- |
+| read by   | people and agents both                            |
+| declines  | firmly — "not in this corpus" is a correct answer |
+| audiences | one, `public` — every reader sees every document  |
+| sources   | none yet — the corpus is still the samples        |
+
+Each is written only if the owner does not object, and the write-back names
+which were answered and which were defaulted. **Never report a default as an
+answer.** Two answered and four defaulted is an honest sentence; "all seven
+answered" is not, and it is what happened the first time this skill ran.
+
+**If the owner says NOT every reader sees every document**, then and only
+then: register each audience in `.ksor/governance.yaml` under `audiences:`
+with a one-line `description:` of who is in it — `public` is reserved and
+never registered. There is no ranking and no default: a document lists the
+audiences that may read it, a reader holds a list that always includes
+`public`, and the document is visible when the two lists OVERLAP. Tell them
+what this does and does not do: builds are made per audience, but anyone who
+can clone the repository reads everything in it — if someone must not read a
+document and can clone, that document belongs in a different repository.
+
+## What the answers become
+
+Scope and Boundary become the BODY of `instance.md`, which `ksor serve` wires
+into the MCP server's instructions — so it is read by every agent that
+connects, and vague prose there is vague instructions everywhere.
+
+Authority becomes `approval_authorities` and `takedown_authorities` in
+`.ksor/governance.yaml`. Names, not roles-in-the-abstract: the checker refuses
+an approval or a takedown by anyone the policy does not name. An actor is
+`human:<handle>`, `process:<name>` or `<producer>/<version>`; handles are
+published with the record, so use the handle the owner would put in a commit,
+never an email address.
 
 ## Then write
 

--- a/packages/ksor/templates/scaffold/.claude/skills/intake-interview/SKILL.md
+++ b/packages/ksor/templates/scaffold/.claude/skills/intake-interview/SKILL.md
@@ -12,49 +12,75 @@ prose IS the agent surface's system prompt (`ksor serve` wires it into the MCP
 server's instructions). Do not draft it from guesses — interview the owner, one
 question at a time, and write down what they actually say.
 
-## The first six questions
+## Ask THREE questions, one at a time
 
-Ask these one at a time; follow up until each answer is concrete enough to
-act on:
+Seven questions is where this skill used to start, and it did not survive
+contact: an agent running it decided five were too many, defaulted them, and
+reported "answered: all seven" — including the one that decides who may
+approve a document. A process the tool executing it shortcuts is too long.
 
-1. **Authority** — "What should this record be the _final word_ on? Finish
-   the sentence: when someone here disagrees with this corpus, the corpus
-   wins about ___."
-2. **Boundary** — "What is explicitly _outside_ it — near-miss topics people
-   will ask about that this record should refuse rather than guess at?"
-3. **Audience** — "Who reads it — people, agents, both? In what situations,
-   making what decisions?"
-4. **Sources** — "Which existing materials are authoritative inputs (name
-   the actual documents, systems, people), and which are explicitly _not_
-   trusted?"
-5. **Strictness** — "When the record doesn't cover a question, how firmly
-   should it decline? ('Not in this corpus' is a correct answer here —
-   confirm the owner wants that behavior and where they want it softened.)"
-6. **Audiences** — "Does every reader of this record see every document? If
-   not, what are the audiences?" A yes is the common answer and the whole
-   answer: register none, and every document says `ksor.audience: [public]`.
-   Anything else means registering each audience in
-   `.ksor/governance.yaml` under `audiences:`, with a one-line
-   `description:` of who is in it — `public` is reserved and never
-   registered. There is no ranking and no default: a document lists the
-   audiences that may read it, a reader holds a list that always includes
-   `public`, and the document is visible when the two lists OVERLAP. Tell
-   the owner what this does and does not do: builds are made per audience,
-   but anyone who can clone the repository reads everything in it — if
-   someone must not read a document and can clone, that document belongs in
-   a different repository.
+So three are asked, and they are the three that cannot be defaulted:
 
-## Then ask the seventh, because a policy cannot be guessed
+1. **Scope** — "What should this record be the _final word_ on? Finish the
+   sentence: when someone here disagrees with this corpus, the corpus wins
+   about ___."
+2. **Boundary** — "What is just _outside_ that — the near-miss topics people
+   will ask about here that the record should refuse rather than guess at?"
+3. **Authority** — "Who may approve a document for publication, and who may
+   withdraw one?"
 
-7. **Authority** — "Who may approve a document for publication, and who may
-   withdraw one?" Names, not roles-in-the-abstract: they become
-   `approval_authorities` and `takedown_authorities` in
-   `.ksor/governance.yaml`, and the checker refuses an approval or a
-   takedown by anyone the policy does not name. The scaffold ships
-   `human:you` in both — a placeholder that must not survive this
-   conversation. An actor is `human:<handle>`, `process:<name>` or
-   `<producer>/<version>`; handles are published with the record, so use the
-   handle the owner would put in a commit, never an email address.
+Scope and Boundary are asked because the abstention gate is meaningless
+without an edge: a record authoritative for everything has no outside, so an
+agent asked something the owner never wrote about reaches for its training
+instead of declining. Authority is asked because a governance act names its
+actor and the tool never guesses one — the scaffold ships `human:you` in
+both authority lists, and a placeholder that survives this conversation is a
+person who was never there.
+
+Follow up until each is concrete. "Our engineering docs" is not yet an
+answer; "our leave, expense and conduct policies — the current ones, not
+historical versions" is.
+
+## Then STATE the defaults; do not ask them
+
+Show these as a block, say they are defaults, and invite a correction. Do not
+walk them one at a time — they are near-constant, and asking makes the
+interview feel like a form.
+
+|           | default                                           |
+| --------- | ------------------------------------------------- |
+| read by   | people and agents both                            |
+| declines  | firmly — "not in this corpus" is a correct answer |
+| audiences | one, `public` — every reader sees every document  |
+| sources   | none yet — the corpus is still the samples        |
+
+Each is written only if the owner does not object, and the write-back names
+which were answered and which were defaulted. **Never report a default as an
+answer.** Two answered and four defaulted is an honest sentence; "all seven
+answered" is not, and it is what happened the first time this skill ran.
+
+**If the owner says NOT every reader sees every document**, then and only
+then: register each audience in `.ksor/governance.yaml` under `audiences:`
+with a one-line `description:` of who is in it — `public` is reserved and
+never registered. There is no ranking and no default: a document lists the
+audiences that may read it, a reader holds a list that always includes
+`public`, and the document is visible when the two lists OVERLAP. Tell them
+what this does and does not do: builds are made per audience, but anyone who
+can clone the repository reads everything in it — if someone must not read a
+document and can clone, that document belongs in a different repository.
+
+## What the answers become
+
+Scope and Boundary become the BODY of `instance.md`, which `ksor serve` wires
+into the MCP server's instructions — so it is read by every agent that
+connects, and vague prose there is vague instructions everywhere.
+
+Authority becomes `approval_authorities` and `takedown_authorities` in
+`.ksor/governance.yaml`. Names, not roles-in-the-abstract: the checker refuses
+an approval or a takedown by anyone the policy does not name. An actor is
+`human:<handle>`, `process:<name>` or `<producer>/<version>`; handles are
+published with the record, so use the handle the owner would put in a commit,
+never an email address.
 
 ## Then write
 

--- a/packages/ksor/templates/scaffold/README.md
+++ b/packages/ksor/templates/scaffold/README.md
@@ -11,17 +11,23 @@ Two worlds live here:
 - **`system/` — the system.** The site (and later, services) that serve the
   record. Replaceable machinery.
 
+**Contents** — [Working here](#working-here) · [Serving to agents](#serving-to-agents) · [The files](#the-files-explained) · [When something refuses you](#when-something-refuses-you) · [Deploying](#deploying) · [Ownership](#ownership)
+
 ## Working here
 
 ```sh
 pnpm install
 pnpm dev        # browse the knowledge at http://localhost:3000
+pnpm build      # the static site, into system/site/out/
+pnpm preview    # serve what you just built — there is no `start`, see below
 ```
 
 <!-- ksor:pm pnpm -->
+
 No pnpm? Run `npm install -g pnpm` — or `corepack enable pnpm` on Node
 versions that bundle corepack.
 <!-- /ksor:pm -->
+
 The first `pnpm install` also fetches the
 `ksor` tool (pinned in `package.json`) and writes it into your lockfile —
 commit the updated lockfile.
@@ -121,19 +127,18 @@ part of `pnpm dev`. Three steps, and the order is load-bearing: the command
 block is last because it needs both of the things above it. Skip ahead to it
 and `pnpm provision` refuses, naming the config step 1 writes.
 
-**1. Uncomment the `database:` block already in `instance.md`.** It names the
-VARIABLE holding your DSN, never the DSN itself:
+**1. Nothing to configure.** `instance.md` already names the VARIABLE holding
+your DSN — never the DSN itself:
 
 ```yaml
 database:
   dsn_env: KSOR_DB_URL
 ```
 
-Nothing below works until it is there — `pnpm provision` refuses with
-`instance.md declares no database: block`. That is also the whole required
-config: `embedding:` already defaults to Gemini at 1536 dimensions, and leaving
-`retrieval:` out starts you with the abstention gate off and honest about it
-(turn it on afterwards with `ksor calibrate`, once the record is serving).
+That is the whole required config. `embedding:` defaults to Gemini at 1536
+dimensions, and leaving `retrieval:` out starts you with the abstention gate
+off and honest about it — turn it on with `ksor calibrate` once the record is
+serving. Change the variable name here only if you want a different one.
 
 **2. Copy the environment file**, then fill in `KSOR_DB_URL`, `GEMINI_API_KEY`
 and `KSOR_AUTH=disabled-local`:
@@ -212,6 +217,7 @@ the record well-formed (`format-checker`, also `pnpm check`).
 ### A note on the lockfile
 
 <!-- ksor:pm pnpm -->
+
 The committed `pnpm-lock.yaml` covers the site. It cannot cover
 `@panaversity/ksor` itself, because the version pinned in `package.json` is
 stamped by the CLI that scaffolded this project and could not be resolved before
@@ -224,6 +230,7 @@ add CI of your own, note that pnpm turns on `--frozen-lockfile` automatically
 whenever `CI` is set.
 <!-- /ksor:pm -->
 <!-- ksor:pm npm -->
+
 No lockfile ships with this scaffold: npm keeps ONE lock for the whole
 workspace, and the `@panaversity/ksor` version pinned in `package.json` was
 stamped by the CLI that scaffolded this project — it could not be resolved
@@ -238,6 +245,7 @@ equivalent — `.npmrc` here carries the install-script denial half of that
 posture, and this sentence is the disclosure of the half it cannot.
 <!-- /ksor:pm -->
 <!-- ksor:pm bun -->
+
 No lockfile ships with this scaffold: the `@panaversity/ksor` version pinned
 in `package.json` was stamped by the CLI that scaffolded this project — it
 could not be resolved into a lock before it existed. Your FIRST
@@ -257,14 +265,17 @@ An audit of this scaffold reports vulnerabilities in `next`, and will keep
 doing so: a framework that large always has open advisories against whatever
 version you have pinned.
 <!-- ksor:pm npm -->
+
 `npm install` prints the count at the end of every install, so you meet it
 before you have run anything, next to an invitation to run
 `npm audit fix --force`.
 <!-- /ksor:pm -->
 <!-- ksor:pm pnpm -->
+
 pnpm reports it only when you run `pnpm audit`.
 <!-- /ksor:pm -->
 <!-- ksor:pm bun -->
+
 bun reports it only when you run `bun audit`.
 <!-- /ksor:pm -->
 
@@ -285,41 +296,65 @@ machine and in your CI; and any advisory at all if you later add a served route
 and stop exporting. Read what an advisory affects before deciding it is inert —
 the static export is a reason, not a blanket.
 
+## When something refuses you
+
+This project refuses loudly and on purpose. Most of what looks like a failure
+is a rule doing its job — and every refusal names the fix, so the table is a
+map rather than a substitute.
+
+| What you see                                                         | What it means                                                                                                   | What to do                                                                |
+| -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `pnpm check` refuses a document                                      | `status: stable` without both `generated` and `ksor.approval`, or an approval earlier than the text it approves | add both keys; approval cannot precede what it approves                   |
+| `pnpm preview` exits `3`                                             | there is no `system/site/out/` yet                                                                              | run the build first                                                       |
+| `start` — missing script | there is none: the site is a static export, so nothing serves it at runtime                                     | `pnpm preview`, or upload the folder                                      |
+| `pnpm serve` refuses to boot                                         | it will not run unauthenticated by accident                                                                     | `KSOR_AUTH=disabled-local` in `.env` for a loopback run                   |
+| a deployed or containerised door refuses `disabled-local`            | it binds `0.0.0.0` — a public bind                                                                              | set `KSOR_AUTH=disabled-public` in the host environment, or configure SSO |
+| the agent answers a question it should decline                       | the abstention gate is off on a fresh record (`abstain OFF`, `gate: "off"`)                                     | `pnpm exec ksor calibrate --instance instance.md`                         |
+| a deployed door serves an empty record                               | deploying does not publish — and a laptop DSN is unreachable from a host                                        | point both at one hosted Postgres, then `pnpm refresh`                    |
+| the home page and `/llms.txt` are empty                              | every document is still a draft — correct, not broken                                                           | approve one and rebuild                                                   |
+| a new document never appears on the built site                       | drafts reach no built surface at all                                                                            | publish it: `status: stable` plus both governance keys                    |
+| an expired document still shows on the site but not through the door | the static build evaluated `stale_after` at build time                                                          | rebuild and redeploy; schedule a rebuild if you use it                    |
+| Vercel: `no services are declared`                                   | Root Directory was auto-filled with `system/site`                                                               | set it to `./`                                                            |
+
 ## The files, explained
 
 Nothing here is decoration, and the dotfiles are not ceremony — each one is a
 different coding agent's way of finding the same working contract.
 
-| Entry                            | What it is                                                                                                                                                                                                                       |
-| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `knowledge/`                     | **the record** — your governed markdown. The product; everything else serves it.                                                                                                                                                 |
-| `system/`                        | the code that serves the record: the site today, more as you need it.                                                                                                                                                            |
+| Entry                            | What it is                                                                                                                                                                                                                                                                                                                                  |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `knowledge/`                     | **the record** — your governed markdown. The product; everything else serves it.                                                                                                                                                                                                                                                            |
+| `system/`                        | the code that serves the record: the site today, more as you need it.                                                                                                                                                                                                                                                                       |
 | `instance.md`                    | what this record is authoritative for; its `name:` is the identity every surface publishes and its `title:` the display title every page leads with (both read at server/build start — restart `pnpm dev` after changing either). Its BODY is the agent surface's system prompt — `ksor serve` wires it into the MCP server's instructions. |
-| `.ksor/governance.yaml`          | **the root of authority** — which audiences exist, who may approve a document, who may take one down. Committed; every governance act is checked against it. |
-| `.ksor/takedowns.yaml`           | the takedown ledger: every withdrawal and every lift, append-only and committed, so the site honours a takedown with no database in the loop. It appears at your first `ksor takedown` — an empty ledger would assert an act nobody performed. |
-| `build.lock.json`                | what the last `ksor build` published — the corpus, the commit, the toolchain — and what every machine surface stamps. Committed; written by `ksor build`, never by hand. |
-| `Dockerfile`, `.dockerignore`    | how the agent surface reaches a host. The Dockerfile names no host; `vercel.json` points at it rather than replacing it, so moving hosts is a redeploy. |
-| `vercel.json`                    | one domain, two services — the static site and the MCP door — for the host this scaffold answers the setup interview for. Delete it if you deploy elsewhere. |
-| `AGENTS.md`                      | the working contract every coding agent reads first — the rules for writing knowledge here.                                                                                                                                      |
-| `CLAUDE.md`                      | one line, pointing at `AGENTS.md`. Claude Code looks for this filename, not that one.                                                                                                                                            |
-| `.agents/skills/`                | the agent kit: `intake-interview` (define the record with you), `add-sources` (turn source material into governed documents), `make-slides` (generate a presentation from a document and attach it), `make-summary` (write a document's summary and attach it), `format-checker` (the rules, as a program).                                                        |
-| `.claude/skills/`                | byte-identical copies of the kit — Claude Code discovers skills only here. The checker enforces the mirror, so the two cannot drift.                                                                                             |
-| `.gemini/settings.json`          | points Gemini CLI at `AGENTS.md`; Gemini does not read that filename on its own.                                                                                                                                                 |
-| `.github/workflows/validate.yml` | your CI: runs the same checker on every pull request and push to main.                                                                                                                                                           |
-| `.gitattributes`                 | markdown is checked out byte-stable on every platform, so the same commit hashes the same everywhere.                                                                                                                            |
-| `.env.example`                   | the variables the served rung needs; copy to `.env` (gitignored) and fill in. |
-| `.gitignore`                     | keeps build output, `node_modules/`, and `.env` out of the record's history — and negates two paths inside `.ksor/`, because the policy and the ledger ARE the record.                                                          |
-| `package.json`                   | the surface commands — `pnpm dev` (the site) and `pnpm provision` / `pnpm refresh` / `pnpm serve` (the agent surface: set up once, publish, then serve) — plus `pnpm build` / `pnpm check`, the pinned `@panaversity/ksor` tool and the workspace layout the manifest declares.                                                |
+| `.ksor/governance.yaml`          | **the root of authority** — which audiences exist, who may approve a document, who may take one down. Committed; every governance act is checked against it.                                                                                                                                                                                |
+| `.ksor/takedowns.yaml`           | the takedown ledger: every withdrawal and every lift, append-only and committed, so the site honours a takedown with no database in the loop. It appears at your first `ksor takedown` — an empty ledger would assert an act nobody performed.                                                                                              |
+| `build.lock.json`                | what the last `ksor build` published — the corpus, the commit, the toolchain — and what every machine surface stamps. Committed; written by `ksor build`, never by hand.                                                                                                                                                                    |
+| `Dockerfile`, `.dockerignore`    | how the agent surface reaches a host. The Dockerfile names no host; `vercel.json` points at it rather than replacing it, so moving hosts is a redeploy.                                                                                                                                                                                     |
+| `vercel.json`                    | one domain, two services — the static site and the MCP door — for the host this scaffold answers the setup interview for. Delete it if you deploy elsewhere.                                                                                                                                                                                |
+| `AGENTS.md`                      | the working contract every coding agent reads first — the rules for writing knowledge here.                                                                                                                                                                                                                                                 |
+| `CLAUDE.md`                      | one line, pointing at `AGENTS.md`. Claude Code looks for this filename, not that one.                                                                                                                                                                                                                                                       |
+| `.agents/skills/`                | the agent kit: `intake-interview` (define the record with you), `add-sources` (turn source material into governed documents), `make-slides` (generate a presentation from a document and attach it), `make-summary` (write a document's summary and attach it), `format-checker` (the rules, as a program).                                 |
+| `.claude/skills/`                | byte-identical copies of the kit — Claude Code discovers skills only here. The checker enforces the mirror, so the two cannot drift.                                                                                                                                                                                                        |
+| `.gemini/settings.json`          | points Gemini CLI at `AGENTS.md`; Gemini does not read that filename on its own.                                                                                                                                                                                                                                                            |
+| `.github/workflows/validate.yml` | your CI: runs the same checker on every pull request and push to main.                                                                                                                                                                                                                                                                      |
+| `.gitattributes`                 | markdown is checked out byte-stable on every platform, so the same commit hashes the same everywhere.                                                                                                                                                                                                                                       |
+| `.env.example`                   | the variables the served rung needs; copy to `.env` (gitignored) and fill in.                                                                                                                                                                                                                                                               |
+| `.gitignore`                     | keeps build output, `node_modules/`, and `.env` out of the record's history — and negates two paths inside `.ksor/`, because the policy and the ledger ARE the record.                                                                                                                                                                      |
+| `package.json`                   | the surface commands — `pnpm dev` (the site) and `pnpm provision` / `pnpm refresh` / `pnpm serve` (the agent surface: set up once, publish, then serve) — plus `pnpm build` / `pnpm check`, the pinned `@panaversity/ksor` tool and the workspace layout the manifest declares.                                                             |
+
 <!-- ksor:pm pnpm -->
-| `pnpm-workspace.yaml`            | where the workspace looks for code (`system/site`, plus reserved `system/gateways/*` and `system/packages/*`), and the supply-chain policy for installs.                                                                         |
-| `pnpm-lock.yaml`                 | the exact dependency versions — the reason two machines build the same site.                                                                                                                                                     |
+
+| `pnpm-workspace.yaml` | where the workspace looks for code (`system/site`, plus reserved `system/gateways/*` and `system/packages/*`), and the supply-chain policy for installs. |
+| `pnpm-lock.yaml` | the exact dependency versions — the reason two machines build the same site. |
 <!-- /ksor:pm -->
 <!-- ksor:pm npm -->
-| `.npmrc`                         | dependency install scripts are denied; the comment inside discloses the one protection this scaffold lacks (a 48-hour quarantine on new releases). |
-| `package-lock.json`              | the exact dependency versions — written by your FIRST install; commit it, it is the reason two machines build the same site. |
+
+| `.npmrc` | dependency install scripts are denied; the comment inside discloses the one protection this scaffold lacks (a 48-hour quarantine on new releases). |
+| `package-lock.json` | the exact dependency versions — written by your FIRST install; commit it, it is the reason two machines build the same site. |
 <!-- /ksor:pm -->
 <!-- ksor:pm bun -->
-| `bun.lock`                       | the exact dependency versions — written by your FIRST install; commit it, it is the reason two machines build the same site. |
+
+| `bun.lock` | the exact dependency versions — written by your FIRST install; commit it, it is the reason two machines build the same site. |
 <!-- /ksor:pm -->
 
 `format-checker` deliberately contains a program, `check.mjs`, and not only
@@ -336,16 +371,29 @@ The built site is a folder of files — 2 MB of HTML, JS and CSS with zero
 host-specific dependencies. `pnpm build` writes it to `system/site/out/`,
 and anything that can serve files can serve it.
 
-- **Vercel** — connect the repository (or run `vercel`); the shipped
-  `vercel.json` answers the setup interview: deploy from the repo root
-  (never pin `system/site` as the root directory — the record lives
-  outside it), build with `pnpm build`, serve `system/site/out/`. It also
-  declares the MCP **door** as a second service built from the shipped
-  `Dockerfile`, so `/mcp` and the site share one domain.
+- **Vercel — push, import, and fix one field.**
+
+  1. Push the repository to GitHub.
+  2. Import it in Vercel.
+  3. **Set Root Directory to `./`.** Vercel auto-fills it with `system/site`,
+     because that is where it finds a framework — and then the build reads
+     `system/site/vercel.json`, which does not exist, and fails with
+     `Project framework is set to "services", but no services are declared`.
+     The services ARE declared, in `vercel.json` at the repo root, which is
+     the only place they can be: one builds the site, the other builds a
+     container from the root `Dockerfile`.
+
+  That is the whole setup — the shipped `vercel.json` answers the rest, and
+  `/mcp` and the site end up on one domain. The door additionally needs
+  `KSOR_DB_URL`, `GEMINI_API_KEY` and `KSOR_AUTH=disabled-public` in Vercel's
+  environment; the site alone needs none of them.
+
 <!-- ksor:pm pnpm -->
-  If the build image's pnpm predates the `packageManager` pin, set the
-  `ENABLE_EXPERIMENTAL_COREPACK=1` build environment variable.
+
+If the build image's pnpm predates the `packageManager` pin, set the
+`ENABLE_EXPERIMENTAL_COREPACK=1` build environment variable.
 <!-- /ksor:pm -->
+
 **`pnpm build` runs `ksor build` first.** It generates every `index.md`,
 runs the record checker, and writes `build.lock.json` — the committed record
 of what was published, from which commit, with which toolchain — and only

--- a/packages/ksor/templates/scaffold/README.md
+++ b/packages/ksor/templates/scaffold/README.md
@@ -3,132 +3,155 @@
 A **Knowledge System of Record**: the governed source of knowledge this
 project's people and AI agents operate from.
 
-Two worlds live here:
+Three things live here, and they are not the same kind of thing:
 
 - **`knowledge/` — the record.** Plain governed markdown (plus the optional
   study attachments a document may carry). Yours forever, readable anywhere,
   portable without this repository's code.
-- **`system/` — the system.** The site (and later, services) that serve the
+- **`system/` — the system.** The site, and later the services, that serve the
   record. Replaceable machinery.
+- **`.ksor/governance.yaml` — the authority.** Which audiences exist, who may
+  approve a document, who may take one down. Every governance act is checked
+  against it, so the record never claims authority nobody granted.
 
-**Contents** — [Working here](#working-here) · [Serving to agents](#serving-to-agents) · [The files](#the-files-explained) · [When something refuses you](#when-something-refuses-you) · [Deploying](#deploying) · [Ownership](#ownership)
+The point of all this is the **agent interface**: an MCP door that answers from
+the record with citations, and declines — in as many words — when the record
+does not cover the question. That refusal is the feature; an agent that
+improvises over a gap is the thing a system of record exists to prevent.
+Beside it, the **human interface** is a site your readers browse. Same record,
+same governance, different machinery: the site is files, the door is a process,
+and they deploy separately.
 
-## Working here
+**Contents**
+
+- [Quick start](#quick-start)
+- [Explore the human interface](#explore-the-human-interface)
+- [Serving to agents](#serving-to-agents)
+- [Quick deployment](#quick-deployment)
+- [Make the record yours: replace the starters](#make-the-record-yours-replace-the-starters)
+- [Writing knowledge](#writing-knowledge)
+- [Deploying](#deploying)
+- [Reference](#reference) — [commands](#commands) · [the files](#the-files-explained) · [when something refuses you](#when-something-refuses-you) · [dependencies](#dependencies-and-advisories)
+- [Ownership](#ownership)
+
+---
+
+## Quick start
 
 ```sh
 pnpm install
 pnpm dev        # browse the knowledge at http://localhost:3000
-pnpm build      # the static site, into system/site/out/
-pnpm preview    # serve what you just built — there is no `start`, see below
 ```
 
 <!-- ksor:pm pnpm -->
 
 No pnpm? Run `npm install -g pnpm` — or `corepack enable pnpm` on Node
 versions that bundle corepack.
+
 <!-- /ksor:pm -->
 
-The first `pnpm install` also fetches the
-`ksor` tool (pinned in `package.json`) and writes it into your lockfile —
-commit the updated lockfile.
+**Commit the lockfile your first install writes.**
 
-**The five starter documents publish on the first build.** They ship
-`status: stable`, so `pnpm dev` and `pnpm build` both give you a working
-record straight away — pages, a sidebar, a `/llms.txt` an agent can read —
-instead of an empty shelf. They are approved by `ksor-starter/KSOR-STAMP-VERSION`:
-the tool that wrote them, named as a producer rather than as a person, because
-no person reviewed a word of it. That is what the trust tier _unverified_ on
-every one of those pages says, and it is true.
+<!-- ksor:pm pnpm -->
 
-**So your first act here is replacing them.** They describe KSoR, not your
-organisation, and a record that describes the wrong thing describes it on every
-surface. Delete each one as your own knowledge arrives — and when the last is
-gone, delete `ksor-starter/KSOR-STAMP-VERSION` from `approval_authorities` in
-`.ksor/governance.yaml` too. Nothing of yours should be approved by a tool. Ask
-your coding agent to run the intake interview: it replaces the `human:you`
-placeholder in that file with your real handle and writes `instance.md` with
-you.
+The committed `pnpm-lock.yaml` covers the site but not `@panaversity/ksor`
+itself: the version pinned in `package.json` was stamped by the CLI that
+scaffolded this project and could not be resolved before that happened. Your
+first `pnpm install` writes it in. Commit the result before you push — pnpm
+turns on `--frozen-lockfile` automatically whenever `CI` is set, so an
+uncommitted pin fails your CI rather than warning you. (`vercel.json` already
+installs with `--no-frozen-lockfile`, and the shipped `validate.yml` runs no
+install.)
 
-**What you write starts unpublished.** A new document is `status: draft`, and
-`pnpm build` admits a draft to no surface at all: no page, no sidebar row, no
-`/llms.txt` entry, nothing for an agent to read. `pnpm dev` shows it, marked —
-the preview is where drafts live.
+<!-- /ksor:pm -->
+<!-- ksor:pm npm -->
 
-Publishing one adds two keys beside `status: stable` — what produced the text,
-and who approved it. Both, or `pnpm check` refuses the document:
+No lockfile ships with this scaffold: npm keeps ONE lock for the whole
+workspace, and the `@panaversity/ksor` version pinned in `package.json` was
+stamped by the CLI that scaffolded this project — it could not be resolved into
+a lock before it existed. Your FIRST `npm install` writes `package-lock.json`;
+run it before you push, and COMMIT the result — that lock is why two machines
+build the same site.
 
-```yaml
-status: stable
-generated: { by: "human:you", at: 2026-01-31T09:00:00Z }
-ksor:
-  audience: [public] # already there — every document carries it, drafts too
-  approval: { by: "human:you", at: 2026-01-31T09:00:00Z }
+One honest difference from the pnpm scaffold: pnpm quarantines newly published
+dependency versions for 48 hours (`minimumReleaseAge`), so a routine install
+never picks up a day-zero compromised release. npm has no equivalent — the
+`.npmrc` here carries the install-script denial half of that posture, and this
+sentence is the disclosure of the half it cannot.
+
+<!-- /ksor:pm -->
+<!-- ksor:pm bun -->
+
+No lockfile ships with this scaffold: the `@panaversity/ksor` version pinned in
+`package.json` was stamped by the CLI that scaffolded this project — it could
+not be resolved into a lock before it existed. Your FIRST `bun install` writes
+`bun.lock`; run it before you push, and COMMIT the result — that lock is why two
+machines build the same site.
+
+One honest difference from the pnpm scaffold: pnpm quarantines newly published
+dependency versions for 48 hours (`minimumReleaseAge`), so a routine install
+never picks up a day-zero compromised release. bun has no equivalent — its
+default refusal of dependency install scripts covers the OTHER half of that
+posture, and this sentence is the disclosure.
+
+<!-- /ksor:pm -->
+
+---
+
+## Explore the human interface
+
+Before changing anything, get a feel for how the record behaves. With
+`pnpm dev` running:
+
+- **Edit a starter document.** Change its body, save, watch the page update.
+- **Add a new document.** It appears on the dev site, marked — and it would be
+  on no built surface at all, because a new document is `status: draft`. No
+  page, no sidebar row, no `/llms.txt` entry. That is the system working, not a
+  broken build.
+- **Ask your coding agent to do the same.** `AGENTS.md` carries the working
+  rules; read it before you change how documents are written here. The kit in
+  `.agents/skills/` already knows this project: `intake-interview` (define the
+  record with you), `add-sources` (turn source material into governed
+  documents), `make-slides`, `make-summary`, and `format-checker` (the rules,
+  as a program — also what `pnpm check` runs).
+
+**Treat the starters as scratch paper.** They ship approved by
+`ksor-starter/KSOR-STAMP-VERSION` — a tool, not a person. Edit the body and that
+approval stays stamped on text nobody reviewed, and `pnpm check` will not catch
+it, because the frontmatter is still internally consistent. So explore in them
+freely, but start nothing you intend to keep in one of them. Replacing them
+properly is [below](#make-the-record-yours-replace-the-starters).
+
+To see what a build actually produces:
+
+```sh
+pnpm build      # the static site, into system/site/out/
+pnpm preview    # serve exactly those bytes
 ```
 
-`generated` is provenance: it names whatever produced the text — a person, or
-the agent that drafted it — and nothing has to authorise it. `approval.by` is
-authority, so it must name an actor `.ksor/governance.yaml` lists, and its `at`
-may not be earlier than `generated.at` — the text that was approved has to be
-the text that was written. That act is yours, so the record never claims
-authority nobody granted.
+There is no `start` script, and that is not an omission: the site is a static
+export, so nothing serves it at runtime. `pnpm preview` is `node:http` and
+nothing else — no dependency, no network fetch — so it works offline and behind
+a firewall, like the build itself.
 
-### Presenting a document
+---
 
-Ask your coding agent for slides and it writes them, from the document, into
-the record:
+## Serving to agents
 
-```
-make slides for knowledge/expenses/approvals.md
-```
+**This is the point of the whole thing.** The record's other surface is an MCP
+server: the same knowledge, cited, with a measured floor under which it
+declines. An agent connected to it answers from your governed documents or says
+the record does not cover the question — and never quietly fills the gap from
+its training.
 
-The `make-slides` skill reads the document whole, writes the deck into
-`knowledge/expenses/approvals.slides.yaml`, checks every claim and every
-number back against the document, and tells you what it left out because the
-document did not support it — which is usually how you find out a document has
-a gap. The deck then renders on that document's page, straight after its
-introduction: click through it inline, or **Present** for fullscreen.
-Presenter notes stay off the screen.
+It asks for two things `pnpm dev` does not: a Postgres store with pgvector, and
+an embedding provider key. Three steps, and the order is load-bearing — the
+command block is last because it needs both of the things above it.
 
-The slides live in the record, so they are reviewed in the same pull request
-as the document, versioned with it, and withdrawn when it is withdrawn. There
-is no third party and no link to rot. If you already keep a deck in Google
-Slides, Canva or SlideShare you can point at it instead — `slides.url:` rather
-than `deck:` — and the page will offer it as a link with a frame the reader
-loads on click, so nothing is requested from the host until somebody asks.
+### 1. Nothing to configure
 
-### Summarising a document
-
-Long documents get a **Summary** tab beside their own words, and your agent
-writes it the same way:
-
-```
-summarise knowledge/expenses/approvals.md
-```
-
-The `make-summary` skill reads the document whole, writes
-`knowledge/expenses/approvals.summary.md`, and checks every line back against
-the document — every number, every rule, and every `##` section, because a
-summary that covers the opening and trails off is worse than none: a reader who
-used it believes they have the whole document. It reports what it left out
-because the document did not support it.
-
-The summary is part of its document, not a document of its own: no route, no
-sidebar row, no line in `llms.txt`, and it takes its governance from its
-parent. Ask for one only where there is something to compress — under about two
-screens, a summary that restates the page teaches readers the tab is not worth
-opening, and the skill will say so rather than write one.
-
-### Serving to agents
-
-The record's other surface is an MCP server for AI agents — the same
-knowledge, cited, with honest abstention. It is the climbed rung: it needs a
-Postgres store (with pgvector) and an embedding provider key, so it is not
-part of `pnpm dev`. Three steps, and the order is load-bearing: the command
-block is last because it needs both of the things above it. Skip ahead to it
-and `pnpm provision` refuses, naming the config step 1 writes.
-
-**1. Nothing to configure.** `instance.md` already names the VARIABLE holding
-your DSN — never the DSN itself:
+`instance.md` already names the VARIABLE holding your DSN — never the DSN
+itself:
 
 ```yaml
 database:
@@ -136,43 +159,66 @@ database:
 ```
 
 That is the whole required config. `embedding:` defaults to Gemini at 1536
-dimensions, and leaving `retrieval:` out starts you with the abstention gate
-off and honest about it — turn it on with `ksor calibrate` once the record is
-serving. Change the variable name here only if you want a different one.
+dimensions, and `retrieval:` is written for you by step 3's `calibrate`. Change
+the variable name here only if you want a different one.
 
-**2. Copy the environment file**, then fill in `KSOR_DB_URL`, `GEMINI_API_KEY`
-and `KSOR_AUTH=disabled-local`:
+### 2. Fill in the environment
 
 ```sh
 cp .env.example .env
 ```
 
+Then set `KSOR_DB_URL`, `GEMINI_API_KEY` and `KSOR_AUTH=disabled-local`.
+
+**Point `KSOR_DB_URL` at a hosted Postgres now if you intend to deploy** — the
+same one your host will use. [Neon](https://neon.com) is what this project's own
+docs are measured against; pgvector is on every plan including the free one, and
+you enable it once per database with `CREATE EXTENSION IF NOT EXISTS vector;`.
+Anything with pgvector works. [Quick deployment](#quick-deployment) explains why
+one shared database saves you a step.
+
 `ksor` reads `.env` automatically — there is nothing to export, and where a
-refusal tells you to _export_ that variable, putting it in `.env` is the same
+refusal tells you to _export_ a variable, putting it in `.env` is the same
 thing. `KSOR_AUTH=disabled-local` is required for a local run: serve refuses to
 boot unauthenticated on purpose, so a server is never open by accident.
 
-**3. Bring it up.**
+### 3. Bring it up
 
 ```sh
 pnpm provision  # once: apply the schema, authorize ingest
 pnpm refresh    # build, ingest the record, collect retired generations
-pnpm serve      # the MCP server
+pnpm exec ksor calibrate --instance instance.md   # measure the floor; paste the printed block into instance.md
+pnpm serve      # the MCP server, with the gate already on
 ```
 
 `pnpm provision` runs once — it applies the schema (or migrates it forward) and
-authorizes ingest, the two privileged acts that should not happen on every
-boot. After that: `pnpm refresh` publishes what you have edited, and `pnpm serve`
-runs the server. They are separate because publishing is an act, not a side
-effect of starting a process. A rerun on an unchanged record
-costs nothing: no new generation, no embedding, no rows. Edit a document and
-the next run picks up exactly that change. `AGENTS.md` → "Serving to agents" is the
-full runbook; your coding agent reads it first. A public bind needs a
-configured SSO door rather than `disabled-local` — see step 2 and
-"The agent surface deploys separately" below. Any other operation is
+authorizes ingest, the two privileged acts that should not happen on every boot.
+After that, `pnpm refresh` publishes what you have edited and `pnpm serve` runs
+the server. They are separate because **publishing is an act, not a side effect
+of starting a process.**
+
+**`calibrate` is what makes "not in this corpus" a real answer**, and it belongs
+here rather than later: it needs an ingested corpus but no running server, and
+the floor is read when the door boots — so measuring before `pnpm serve` means
+the door comes up gated the first time. It prints a `retrieval:` block for THIS
+corpus in THIS embedding space; paste it into `instance.md` exactly as printed.
+Never copy a floor from another corpus.
+
+It also prints its own caveat, and it is worth reading: the probes it writes are
+derived from your passages, so they share vocabulary a real question will not.
+The floor it reports is an upper bound on separation until you check it against
+questions the corpus did not write (`--queries-file`).
+
+A rerun on an unchanged record costs nothing: no new generation, no embedding,
+no rows. Edit a document and the next run picks up exactly that change.
+
+`AGENTS.md` → "Serving to agents" is the full runbook; your coding agent reads
+it first. A public bind needs a configured SSO door rather than
+`disabled-local` — see [The agent surface deploys
+separately](#the-agent-surface-deploys-separately). Any other operation is
 `pnpm exec ksor <verb>`.
 
-### Test the agent surface with an actual agent
+### Test the door with an actual agent
 
 The MCP door is meant to be read by agents, so check it with one rather than
 with `curl`. With `pnpm serve` running, write `.mcp.json` at the repo root:
@@ -188,6 +234,12 @@ with `curl`. With `pnpm serve` running, write `.mcp.json` at the repo root:
 }
 ```
 
+**If you skipped `calibrate`, expect answers where this test wants refusals** —
+the gate is off until a floor is measured, which the server says at boot
+(`abstain OFF`) and in every search envelope (`gate: "off"`). That is honest,
+not broken: a floor nobody measured would be a number pretending to be a
+guarantee.
+
 Open a new session of your coding agent, confirm it lists the server, then ask
 it three questions **in this order** — the order is the test:
 
@@ -196,241 +248,215 @@ it three questions **in this order** — the order is the test:
    arrive with a citation.
 2. Something **adjacent but not covered** — your record's own subject area, a
    question it genuinely does not answer. It should decline.
-3. Something far outside the record. It should decline, and must not answer
-   from its own knowledge.
+3. Something far outside the record. It should decline, and must not answer from
+   its own knowledge.
 
 Question 2 is the one that matters. Anything can answer questions it has the
 text for; refusing a plausible near-miss is the property that makes a system of
 record worth trusting, and it is the one that breaks quietly.
 
-**On a fresh record, 2 and 3 will not refuse — and that is honest, not broken.**
-The abstention gate is off until you measure a floor for this corpus, which the
-server says out loud at boot (`abstain OFF`) and in every search envelope
-(`gate: "off"`). Run `pnpm exec ksor calibrate --instance instance.md` first if
-you want to test refusal. Delete `.mcp.json`, or keep it — it holds no secret.
+Delete `.mcp.json`, or keep it — it holds no secret.
 
-Then talk to your coding agent — `AGENTS.md` carries the working rules, and
-the agent kit in `.agents/skills/` knows how to interview you
-(`intake-interview`), convert your source material (`add-sources`), and keep
-the record well-formed (`format-checker`, also `pnpm check`).
+---
 
-### A note on the lockfile
+## Quick deployment
 
-<!-- ksor:pm pnpm -->
+Both surfaces on one domain, in about ten minutes:
 
-The committed `pnpm-lock.yaml` covers the site. It cannot cover
-`@panaversity/ksor` itself, because the version pinned in `package.json` is
-stamped by the CLI that scaffolded this project and could not be resolved before
-that happened. So your FIRST `pnpm install` writes it — run it before you push,
-and commit the result.
+1. **Push the repository to GitHub.**
+2. **Import it in Vercel**, then **set Root Directory to `./`.** Vercel
+   auto-fills it with `system/site`, because that is where it finds a framework
+   — and the build then reads `system/site/vercel.json`, which does not exist,
+   and fails with `Project framework is set to "services", but no services are
+declared`. The services ARE declared, in `vercel.json` at the repo root,
+   which is the only place they can be: one builds the site, the other builds a
+   container from the root `Dockerfile`.
+3. **Set three environment variables** in Vercel: `KSOR_DB_URL`,
+   `GEMINI_API_KEY`, and `KSOR_AUTH=disabled-public`.
 
-The deploy config already accounts for this (`vercel.json` installs with
-`--no-frozen-lockfile`), and the shipped `validate.yml` runs no install. If you
-add CI of your own, note that pnpm turns on `--frozen-lockfile` automatically
-whenever `CI` is set.
-<!-- /ksor:pm -->
-<!-- ksor:pm npm -->
+Two things catch people here, and both are the system being deliberate:
 
-No lockfile ships with this scaffold: npm keeps ONE lock for the whole
-workspace, and the `@panaversity/ksor` version pinned in `package.json` was
-stamped by the CLI that scaffolded this project — it could not be resolved
-into a lock before it existed. Your FIRST `npm install` writes
-`package-lock.json`; run it before you push, and COMMIT the result — that
-lock is why two machines build the same site.
+- **`disabled-local` will not deploy.** The container sets `$PORT`, so the door
+  binds `0.0.0.0` — a PUBLIC bind — and refuses that value by design, saying so
+  in as many words. `disabled-public` is you saying you know the door is
+  reachable from outside itself. It belongs in Vercel's environment, not in your
+  `.env`, so your local `pnpm serve` keeps its loopback posture. It is a
+  starting posture, not a destination: [secure it
+  properly](#audiences-decide-what-a-build-contains) with the SSO variables once
+  the thing is up.
+- **Point `KSOR_DB_URL` at a Postgres your host can reach.** Deploying does not
+  publish — the door serves whatever generation is already in the database. If
+  your DSN pointed at a database on your laptop, the site comes up fine and the
+  door comes up empty. Use one hosted Postgres for both and the `pnpm refresh`
+  you already ran is the generation Vercel serves.
 
-One honest difference from the pnpm scaffold: pnpm quarantines newly
-published dependency versions for 48 hours (`minimumReleaseAge`), so a
-routine install never picks up a day-zero compromised release. npm has no
-equivalent — `.npmrc` here carries the install-script denial half of that
-posture, and this sentence is the disclosure of the half it cannot.
-<!-- /ksor:pm -->
-<!-- ksor:pm bun -->
+If you only want readers served, the site is a static export with no database in
+the loop: deploy with no environment variables at all and add the door later.
 
-No lockfile ships with this scaffold: the `@panaversity/ksor` version pinned
-in `package.json` was stamped by the CLI that scaffolded this project — it
-could not be resolved into a lock before it existed. Your FIRST
-`bun install` writes `bun.lock`; run it before you push, and COMMIT the
-result — that lock is why two machines build the same site.
+---
 
-One honest difference from the pnpm scaffold: pnpm quarantines newly
-published dependency versions for 48 hours (`minimumReleaseAge`), so a
-routine install never picks up a day-zero compromised release. bun has no
-equivalent (its default refusal of dependency install scripts covers the
-OTHER half of that posture), and this sentence is the disclosure.
-<!-- /ksor:pm -->
+## Make the record yours: replace the starters
 
-### A note on `audit`
+**Five starter documents publish on the first build.** They ship
+`status: stable`, so `pnpm dev` and `pnpm build` both give you a working record
+straight away — pages, a sidebar, a `/llms.txt` an agent can read — instead of
+an empty shelf. They are approved by `ksor-starter/KSOR-STAMP-VERSION`: the tool
+that wrote them, named as a producer rather than as a person, because no person
+reviewed a word of it. That is what the trust tier _unverified_ on every one of
+those pages says, and it is true.
 
-An audit of this scaffold reports vulnerabilities in `next`, and will keep
-doing so: a framework that large always has open advisories against whatever
-version you have pinned.
-<!-- ksor:pm npm -->
+They also describe KSoR, not your organisation — and a record that describes the
+wrong thing describes it on every surface. So replace them, in this order:
 
-`npm install` prints the count at the end of every install, so you meet it
-before you have run anything, next to an invitation to run
-`npm audit fix --force`.
-<!-- /ksor:pm -->
-<!-- ksor:pm pnpm -->
+1. **Run the intake interview.** Ask your coding agent for it. Three questions —
+   what this record is the final word on, what sits just outside it, and who may
+   approve or withdraw a document — then it writes `instance.md` with you and
+   replaces the `human:you` placeholder in `.ksor/governance.yaml` with your
+   real handle.
+2. **Delete each starter document** as your own knowledge arrives.
+3. **When the last one is gone, delete `ksor-starter/KSOR-STAMP-VERSION` from
+   `approval_authorities` in `.ksor/governance.yaml`.** Nothing of yours should
+   be approved by a tool.
 
-pnpm reports it only when you run `pnpm audit`.
-<!-- /ksor:pm -->
-<!-- ksor:pm bun -->
+---
 
-bun reports it only when you run `bun audit`.
-<!-- /ksor:pm -->
+## Writing knowledge
 
-**Never let an audit tool raise the pin for you.** It moves off the version
-this scaffold was built and tested against, and that pin is the whole reason
-two machines produce the same site. Bump it deliberately instead — take the
-newer pin a newer `ksor init` emits, or raise it yourself and re-run
-`pnpm build` and the deploy check above.
+### A new document publishes nothing
 
-It also reads worse than it is, for one structural reason worth knowing:
-**this site is a static export.** `pnpm build` writes HTML, JS and CSS to
-`system/site/out/`, and no framework server ever runs in front of your
-readers — no middleware, no server actions, no rewrites, no image optimizer.
-Most framework advisories describe exactly those request paths, so they have
-nothing here to reach. Two things that argument does NOT cover, and you should
-treat as real: an advisory in the **build** toolchain, which does run, on your
-machine and in your CI; and any advisory at all if you later add a served route
-and stop exporting. Read what an advisory affects before deciding it is inert —
-the static export is a reason, not a blanket.
+A new document is `status: draft`, and `pnpm build` admits a draft to no surface
+at all: no page, no sidebar row, no `/llms.txt` entry, nothing for an agent to
+read. `pnpm dev` shows it, marked — the preview is where drafts live.
 
-## When something refuses you
+### Publishing adds two keys
 
-This project refuses loudly and on purpose. Most of what looks like a failure
-is a rule doing its job — and every refusal names the fix, so the table is a
-map rather than a substitute.
+Beside `status: stable`, name what produced the text and who approved it. Both,
+or `pnpm check` refuses the document:
 
-| What you see                                                         | What it means                                                                                                   | What to do                                                                |
-| -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| `pnpm check` refuses a document                                      | `status: stable` without both `generated` and `ksor.approval`, or an approval earlier than the text it approves | add both keys; approval cannot precede what it approves                   |
-| `pnpm preview` exits `3`                                             | there is no `system/site/out/` yet                                                                              | run the build first                                                       |
-| `start` — missing script | there is none: the site is a static export, so nothing serves it at runtime                                     | `pnpm preview`, or upload the folder                                      |
-| `pnpm serve` refuses to boot                                         | it will not run unauthenticated by accident                                                                     | `KSOR_AUTH=disabled-local` in `.env` for a loopback run                   |
-| a deployed or containerised door refuses `disabled-local`            | it binds `0.0.0.0` — a public bind                                                                              | set `KSOR_AUTH=disabled-public` in the host environment, or configure SSO |
-| the agent answers a question it should decline                       | the abstention gate is off on a fresh record (`abstain OFF`, `gate: "off"`)                                     | `pnpm exec ksor calibrate --instance instance.md`                         |
-| a deployed door serves an empty record                               | deploying does not publish — and a laptop DSN is unreachable from a host                                        | point both at one hosted Postgres, then `pnpm refresh`                    |
-| the home page and `/llms.txt` are empty                              | every document is still a draft — correct, not broken                                                           | approve one and rebuild                                                   |
-| a new document never appears on the built site                       | drafts reach no built surface at all                                                                            | publish it: `status: stable` plus both governance keys                    |
-| an expired document still shows on the site but not through the door | the static build evaluated `stale_after` at build time                                                          | rebuild and redeploy; schedule a rebuild if you use it                    |
-| Vercel: `no services are declared`                                   | Root Directory was auto-filled with `system/site`                                                               | set it to `./`                                                            |
+```yaml
+status: stable
+generated: { by: "human:you", at: 2026-01-31T09:00:00Z }
+ksor:
+  audience: [public] # already there — every document carries it, drafts too
+  approval: { by: "human:you", at: 2026-01-31T09:00:00Z }
+```
 
-## The files, explained
+`generated` is **provenance**: it names whatever produced the text — a person,
+or the agent that drafted it — and nothing has to authorise it.
 
-Nothing here is decoration, and the dotfiles are not ceremony — each one is a
-different coding agent's way of finding the same working contract.
+`approval.by` is **authority**, so it must name an actor `.ksor/governance.yaml`
+lists, and its `at` may not be earlier than `generated.at` — the text that was
+approved has to be the text that was written. That act is yours.
 
-| Entry                            | What it is                                                                                                                                                                                                                                                                                                                                  |
-| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `knowledge/`                     | **the record** — your governed markdown. The product; everything else serves it.                                                                                                                                                                                                                                                            |
-| `system/`                        | the code that serves the record: the site today, more as you need it.                                                                                                                                                                                                                                                                       |
-| `instance.md`                    | what this record is authoritative for; its `name:` is the identity every surface publishes and its `title:` the display title every page leads with (both read at server/build start — restart `pnpm dev` after changing either). Its BODY is the agent surface's system prompt — `ksor serve` wires it into the MCP server's instructions. |
-| `.ksor/governance.yaml`          | **the root of authority** — which audiences exist, who may approve a document, who may take one down. Committed; every governance act is checked against it.                                                                                                                                                                                |
-| `.ksor/takedowns.yaml`           | the takedown ledger: every withdrawal and every lift, append-only and committed, so the site honours a takedown with no database in the loop. It appears at your first `ksor takedown` — an empty ledger would assert an act nobody performed.                                                                                              |
-| `build.lock.json`                | what the last `ksor build` published — the corpus, the commit, the toolchain — and what every machine surface stamps. Committed; written by `ksor build`, never by hand.                                                                                                                                                                    |
-| `Dockerfile`, `.dockerignore`    | how the agent surface reaches a host. The Dockerfile names no host; `vercel.json` points at it rather than replacing it, so moving hosts is a redeploy.                                                                                                                                                                                     |
-| `vercel.json`                    | one domain, two services — the static site and the MCP door — for the host this scaffold answers the setup interview for. Delete it if you deploy elsewhere.                                                                                                                                                                                |
-| `AGENTS.md`                      | the working contract every coding agent reads first — the rules for writing knowledge here.                                                                                                                                                                                                                                                 |
-| `CLAUDE.md`                      | one line, pointing at `AGENTS.md`. Claude Code looks for this filename, not that one.                                                                                                                                                                                                                                                       |
-| `.agents/skills/`                | the agent kit: `intake-interview` (define the record with you), `add-sources` (turn source material into governed documents), `make-slides` (generate a presentation from a document and attach it), `make-summary` (write a document's summary and attach it), `format-checker` (the rules, as a program).                                 |
-| `.claude/skills/`                | byte-identical copies of the kit — Claude Code discovers skills only here. The checker enforces the mirror, so the two cannot drift.                                                                                                                                                                                                        |
-| `.gemini/settings.json`          | points Gemini CLI at `AGENTS.md`; Gemini does not read that filename on its own.                                                                                                                                                                                                                                                            |
-| `.github/workflows/validate.yml` | your CI: runs the same checker on every pull request and push to main.                                                                                                                                                                                                                                                                      |
-| `.gitattributes`                 | markdown is checked out byte-stable on every platform, so the same commit hashes the same everywhere.                                                                                                                                                                                                                                       |
-| `.env.example`                   | the variables the served rung needs; copy to `.env` (gitignored) and fill in.                                                                                                                                                                                                                                                               |
-| `.gitignore`                     | keeps build output, `node_modules/`, and `.env` out of the record's history — and negates two paths inside `.ksor/`, because the policy and the ledger ARE the record.                                                                                                                                                                      |
-| `package.json`                   | the surface commands — `pnpm dev` (the site) and `pnpm provision` / `pnpm refresh` / `pnpm serve` (the agent surface: set up once, publish, then serve) — plus `pnpm build` / `pnpm check`, the pinned `@panaversity/ksor` tool and the workspace layout the manifest declares.                                                             |
+Run `pnpm check` before you commit. It runs the rules as a program, and every
+failure it reports says what is wrong, why the rule exists, and how to fix it.
 
-<!-- ksor:pm pnpm -->
+### Presenting a document
 
-| `pnpm-workspace.yaml` | where the workspace looks for code (`system/site`, plus reserved `system/gateways/*` and `system/packages/*`), and the supply-chain policy for installs. |
-| `pnpm-lock.yaml` | the exact dependency versions — the reason two machines build the same site. |
-<!-- /ksor:pm -->
-<!-- ksor:pm npm -->
+Ask your coding agent for slides and it writes them, from the document, into the
+record:
 
-| `.npmrc` | dependency install scripts are denied; the comment inside discloses the one protection this scaffold lacks (a 48-hour quarantine on new releases). |
-| `package-lock.json` | the exact dependency versions — written by your FIRST install; commit it, it is the reason two machines build the same site. |
-<!-- /ksor:pm -->
-<!-- ksor:pm bun -->
+```
+make slides for knowledge/expenses/approvals.md
+```
 
-| `bun.lock` | the exact dependency versions — written by your FIRST install; commit it, it is the reason two machines build the same site. |
-<!-- /ksor:pm -->
+The `make-slides` skill reads the document whole, writes the deck into
+`knowledge/expenses/approvals.slides.yaml`, checks every claim and every number
+back against the document, and tells you what it left out because the document
+did not support it — which is usually how you find out a document has a gap. The
+deck then renders on that document's page, straight after its introduction:
+click through it inline, or **Present** for fullscreen. Presenter notes stay off
+the screen.
 
-`format-checker` deliberately contains a program, `check.mjs`, and not only
-prose: rules that are only written down cannot refuse anything. `pnpm check`
-runs it, and every failure it reports says what is wrong, why the rule exists,
-and how to fix it.
+The slides live in the record, so they are reviewed in the same pull request as
+the document, versioned with it, and withdrawn when it is withdrawn. There is no
+third party and no link to rot. If you already keep a deck in Google Slides,
+Canva or SlideShare you can point at it instead — `slides.url:` rather than
+`deck:` — and the page will offer it as a link with a frame the reader loads on
+click, so nothing is requested from the host until somebody asks.
 
-Everything here is yours to change. The kit exists so that any coding agent can
-operate this project without being taught it first.
+### Summarising a document
+
+Long documents get a **Summary** tab beside their own words, written the same
+way:
+
+```
+summarise knowledge/expenses/approvals.md
+```
+
+The `make-summary` skill reads the document whole, writes
+`knowledge/expenses/approvals.summary.md`, and checks every line back against
+the document — every number, every rule, and every `##` section, because a
+summary that covers the opening and trails off is worse than none: a reader who
+used it believes they have the whole document. It reports what it left out
+because the document did not support it.
+
+The summary is part of its document, not a document of its own: no route, no
+sidebar row, no line in `llms.txt`, and it takes its governance from its parent.
+Ask for one only where there is something to compress — under about two screens,
+a summary that restates the page teaches readers the tab is not worth opening,
+and the skill will say so rather than write one.
+
+---
 
 ## Deploying
 
-The built site is a folder of files — 2 MB of HTML, JS and CSS with zero
-host-specific dependencies. `pnpm build` writes it to `system/site/out/`,
-and anything that can serve files can serve it.
+[Quick deployment](#quick-deployment) covers the common path. This is the rest
+of it.
 
-- **Vercel — push, import, and fix one field.**
+### The site
 
-  1. Push the repository to GitHub.
-  2. Import it in Vercel.
-  3. **Set Root Directory to `./`.** Vercel auto-fills it with `system/site`,
-     because that is where it finds a framework — and then the build reads
-     `system/site/vercel.json`, which does not exist, and fails with
-     `Project framework is set to "services", but no services are declared`.
-     The services ARE declared, in `vercel.json` at the repo root, which is
-     the only place they can be: one builds the site, the other builds a
-     container from the root `Dockerfile`.
+`pnpm build` writes HTML, JS and CSS to `system/site/out/` — about 2 MB with
+zero host-specific dependencies. Anything that can serve files can serve it, and
+`pnpm preview` serves exactly those bytes locally.
 
-  That is the whole setup — the shipped `vercel.json` answers the rest, and
-  `/mcp` and the site end up on one domain. The door additionally needs
-  `KSOR_DB_URL`, `GEMINI_API_KEY` and `KSOR_AUTH=disabled-public` in Vercel's
-  environment; the site alone needs none of them.
+**`pnpm build` runs `ksor build` first.** It generates every `index.md`, runs
+the record checker, and writes `build.lock.json` — the committed record of what
+was published, from which commit, with which toolchain — and only then builds
+the site. A checker refusal stops the build before anything is written.
 
-<!-- ksor:pm pnpm -->
+- **Vercel** — the shipped `vercel.json` deploys from the repo root, builds with
+  `pnpm build`, and serves `system/site/out/`. It also declares the MCP **door**
+  as a second service built from the shipped `Dockerfile`, so `/mcp` and the
+  site share one domain.
+  <!-- ksor:pm pnpm -->
+  If the build image's pnpm predates the `packageManager` pin, set the
+  `ENABLE_EXPERIMENTAL_COREPACK=1` build environment variable.
+  <!-- /ksor:pm -->
+- **GitHub Pages, nginx, S3, anything static** — run `pnpm build` and upload
+  `system/site/out/`. Hosted under a sub-path (like `user.github.io/repo`)?
+  Build with `KSOR_BASE_PATH=/repo pnpm build`.
 
-If the build image's pnpm predates the `packageManager` pin, set the
-`ENABLE_EXPERIMENTAL_COREPACK=1` build environment variable.
-<!-- /ksor:pm -->
+**Verify any deploy** the same way: the home page, one document page and
+`/llms.txt` load, and each names the documents this record has approved. On a
+record whose documents are all still drafts, the home page and `/llms.txt` come
+up empty and there is no document page at all — which is the correct answer, not
+a broken deploy. Approve a document and rebuild to see it change.
 
-**`pnpm build` runs `ksor build` first.** It generates every `index.md`,
-runs the record checker, and writes `build.lock.json` — the committed record
-of what was published, from which commit, with which toolchain — and only
-then builds the site. A checker refusal stops the build before anything is
-written. Takedowns reach the site through `.ksor/takedowns.yaml`, the
-committed ledger — a file in this repository, so the site build needs no
-database access at all.
+### Takedowns reach the site through a committed file
 
-That is deliberate. The act that withdraws a document is one merged commit,
-and both surfaces read it: the door refuses immediately, the site at its next
-build. Merge the ledger entry, rebuild, redeploy.
+Takedowns reach the site through `.ksor/takedowns.yaml`, the committed ledger —
+a file in this repository, so the site build needs no database access at all.
+
+That is deliberate. The act that withdraws a document is one merged commit, and
+both surfaces read it: the door refuses immediately, the site at its next build.
+Merge the ledger entry, rebuild, redeploy.
 
 **A withdrawal that arrives on a clock works the same way, and that one has to
 be scheduled.** `stale_after` and `ksor.effective_from` are evaluated once per
 build, at the instant that build ran, and the answer is written into
 `system/site/out/` — static files cannot re-decide themselves. So a document
 whose `stale_after` passes after your last build keeps appearing in `/llms.txt`
-and in its markdown twin, while `ksor serve` — a process, evaluating per
-request — already refuses it. `ksor build` prints the next instant at which
-this happens. Nothing here rebuilds for you: `validate.yml` runs on pull
-requests and `vercel.json` declares no cron. If this record uses either key,
-add a scheduled rebuild and redeploy.
-
-- **GitHub Pages, nginx, S3, anything static** — run `pnpm build` and
-  upload `system/site/out/`. Hosted under a sub-path (like
-  `user.github.io/repo`)? Build with `KSOR_BASE_PATH=/repo pnpm build`.
-- **Verify any deploy** the same way: the home page, one document page and
-  `/llms.txt` load, and each names the documents this record has approved. On a
-  record whose documents are all still drafts, the home page and `/llms.txt`
-  come up empty and there is no document page at all — which is the correct
-  answer, not a broken deploy. Approve a document and rebuild to see it change.
+and in its markdown twin, while `ksor serve` — a process, evaluating per request
+— already refuses it. `ksor build` prints the next instant at which this
+happens. Nothing here rebuilds for you: `validate.yml` runs on pull requests and
+`vercel.json` declares no cron. **If this record uses either key, add a scheduled
+rebuild and redeploy.**
 
 ### The agent surface deploys separately
 
-The site is files; the MCP door is a process. `Dockerfile` and `.dockerignore`
-at the repo root build it, and they name no host — the same image runs on
-Cloud Run, Fly, Render, ECS, Kubernetes or a VPS:
+`Dockerfile` and `.dockerignore` at the repo root build it, and they name no
+host — the same image runs on Cloud Run, Fly, Render, ECS, Kubernetes or a VPS:
 
 ```sh
 docker build -t my-record .
@@ -440,13 +466,13 @@ docker run --rm -p 8080:80 --env-file .env \
 
 **That last flag is not boilerplate, and it is not a workaround.** The image
 sets `$PORT`, so the door binds `0.0.0.0` — a PUBLIC bind — and the
-`KSOR_AUTH=disabled-local` your `.env` carries refuses there by design, saying
-so in as many words. Your laptop is not the exception: a container really is
-reachable from outside itself, and `disabled-public` is you saying you know
-that. It goes on the command rather than into `.env` so your ordinary
-`pnpm serve` keeps the loopback posture — and a real deployment sets it (or,
-better, the SSO variables) in the host's environment, since `.dockerignore`
-keeps `.env` out of the image entirely.
+`KSOR_AUTH=disabled-local` your `.env` carries refuses there by design. Your
+laptop is not the exception: a container really is reachable from outside
+itself, and `disabled-public` is you saying you know that. It goes on the
+command rather than into `.env` so your ordinary `pnpm serve` keeps the loopback
+posture — and a real deployment sets it (or, better, the SSO variables) in the
+host's environment, since `.dockerignore` keeps `.env` out of the image
+entirely.
 
 One thing surprises people: **deploying does not publish.** The door serves
 whatever generation is already in the database, so a first deploy with no
@@ -455,15 +481,16 @@ machine or from CI — and it is deliberately not something a booting container
 does. The full walkthrough, including what a cold start costs and where ingest
 belongs, is in `node_modules/@panaversity/ksor/docs/deploying.md`.
 
-If `.ksor/governance.yaml` registers audiences, what you deploy is a
-**viewer**. Plain `pnpm build` builds for `[public]` — safe for any host.
+### Audiences decide what a build contains
+
+If `.ksor/governance.yaml` registers audiences, what you deploy is a **viewer**.
+Plain `pnpm build` builds for `[public]` — safe for any host.
 `KSOR_AUDIENCE=public,<audience> pnpm build` — a comma list that must always
-include `public` — builds for a wider viewer's own deployment, and that build
-carries an
-"— not for publication" label because it must never reach a public host:
-put it behind access control you already trust (VPN, SSO proxy,
-authenticated host). The tiers govern what a build contains; where each
-build may be served is yours to enforce.
+include `public` — builds for a wider viewer, and that build carries an "— not
+for publication" label because it must never reach a public host: put it behind
+access control you already trust (VPN, SSO proxy, authenticated host). The tiers
+govern what a build contains; where each build may be served is yours to
+enforce.
 
 The site can also show a **sign-in control** that names the reader in the
 navbar. It is off until you set three variables (see `.env.example`), and it
@@ -471,6 +498,156 @@ names people rather than keeping them out — a static export cannot gate itself
 so it is worth having on a record already behind one of the answers above, and
 is not a substitute for them. Setup and the honest limits:
 `node_modules/@panaversity/ksor/docs/deploying.md`.
+
+---
+
+## Reference
+
+### Commands
+
+| Command                 | What it does                                                                                      | When                             |
+| ----------------------- | ------------------------------------------------------------------------------------------------- | -------------------------------- |
+| `pnpm install`          | fetches dependencies and the pinned `ksor` tool                                                   | first — then commit the lockfile |
+| `pnpm dev`              | the site at `:3000`, drafts visible and marked                                                    | while you write                  |
+| `pnpm check`            | runs the record checker as a program                                                              | before every commit              |
+| `pnpm build`            | `ksor build` (index pages, checker, `build.lock.json`), then the static site to `system/site/out/` | before a deploy                  |
+| `pnpm preview`          | serves `system/site/out/` — there is no `start`, the site is a static export                      | to check a build                 |
+| `pnpm provision`        | applies the schema, authorizes ingest                                                             | once, for the agent surface      |
+| `pnpm refresh`          | builds, ingests the record, collects retired generations                                          | every time you publish           |
+| `pnpm serve`            | the MCP server on `:8080`                                                                         | to run the door locally          |
+| `pnpm exec ksor <verb>` | everything else — `calibrate`, `takedown`, …                                                      | as needed                        |
+
+### The files, explained
+
+Nothing here is decoration, and the dotfiles are not ceremony — each one is a
+different coding agent's way of finding the same working contract.
+
+**The record and its authority**
+
+| Entry                   | What it is                                                                                                                                                                                                                                                                                                                                |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `knowledge/`            | **the record** — your governed markdown. The product; everything else serves it.                                                                                                                                                                                                                                                          |
+| `instance.md`           | what this record is authoritative for; its `name:` is the identity every surface publishes and its `title:` the display title every page leads with (both read at server/build start — restart `pnpm dev` after changing either). Its BODY is the agent surface's system prompt — `ksor serve` wires it into the MCP server's instructions. |
+| `.ksor/governance.yaml` | **the root of authority** — which audiences exist, who may approve a document, who may take one down. Committed; every governance act is checked against it.                                                                                                                                                                               |
+| `.ksor/takedowns.yaml`  | the takedown ledger: every withdrawal and every lift, append-only and committed, so the site honours a takedown with no database in the loop. It appears at your first `ksor takedown` — an empty ledger would assert an act nobody performed.                                                                                              |
+| `build.lock.json`       | what the last `ksor build` published — the corpus, the commit, the toolchain — and what every machine surface stamps. Committed; written by `ksor build`, never by hand.                                                                                                                                                                   |
+
+**The system that serves it**
+
+| Entry                         | What it is                                                                                                                                                                                                                                  |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `system/`                     | the code that serves the record: the site today, more as you need it.                                                                                                                                                                       |
+| `package.json`                | the surface commands — `pnpm dev` (the site) and `pnpm provision` / `pnpm refresh` / `pnpm serve` (the agent surface) — plus `pnpm build` / `pnpm preview` / `pnpm check`, the pinned `@panaversity/ksor` tool and the workspace layout.      |
+| `Dockerfile`, `.dockerignore` | how the agent surface reaches a host. The Dockerfile names no host; `vercel.json` points at it rather than replacing it, so moving hosts is a redeploy.                                                                                      |
+| `vercel.json`                 | one domain, two services — the static site and the MCP door. Delete it if you deploy elsewhere.                                                                                                                                              |
+| `.env.example`                | the variables the served rung needs; copy to `.env` (gitignored) and fill in.                                                                                                                                                               |
+
+<!-- ksor:pm pnpm -->
+
+| Entry                 | What it is                                                                                                                                              |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pnpm-workspace.yaml` | where the workspace looks for code (`system/site`, plus reserved `system/gateways/*` and `system/packages/*`), and the supply-chain policy for installs. |
+| `pnpm-lock.yaml`      | the exact dependency versions — the reason two machines build the same site.                                                                            |
+
+<!-- /ksor:pm -->
+<!-- ksor:pm npm -->
+
+| Entry               | What it is                                                                                                                                        |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `.npmrc`            | dependency install scripts are denied; the comment inside discloses the one protection this scaffold lacks (a 48-hour quarantine on new releases). |
+| `package-lock.json` | the exact dependency versions — written by your FIRST install; commit it, it is the reason two machines build the same site.                       |
+
+<!-- /ksor:pm -->
+<!-- ksor:pm bun -->
+
+| Entry      | What it is                                                                                                                  |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `bun.lock` | the exact dependency versions — written by your FIRST install; commit it, it is the reason two machines build the same site. |
+
+<!-- /ksor:pm -->
+
+**The working contract**
+
+| Entry                            | What it is                                                                                                                                                                                              |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `AGENTS.md`                      | the working contract every coding agent reads first — the rules for writing knowledge here.                                                                                                             |
+| `CLAUDE.md`                      | one line, pointing at `AGENTS.md`. Claude Code looks for this filename, not that one.                                                                                                                   |
+| `.agents/skills/`                | the agent kit: `intake-interview` (define the record with you), `add-sources` (turn source material into governed documents), `make-slides`, `make-summary`, `format-checker` (the rules, as a program). |
+| `.claude/skills/`                | byte-identical copies of the kit — Claude Code discovers skills only here. The checker enforces the mirror, so the two cannot drift.                                                                     |
+| `.gemini/settings.json`          | points Gemini CLI at `AGENTS.md`; Gemini does not read that filename on its own.                                                                                                                        |
+| `.github/workflows/validate.yml` | your CI: runs the same checker on every pull request and push to main.                                                                                                                                  |
+| `.gitattributes`                 | markdown is checked out byte-stable on every platform, so the same commit hashes the same everywhere.                                                                                                   |
+| `.gitignore`                     | keeps build output, `node_modules/`, and `.env` out of the record's history — and negates two paths inside `.ksor/`, because the policy and the ledger ARE the record.                                   |
+
+`format-checker` deliberately contains a program, `check.mjs`, and not only
+prose: rules that are only written down cannot refuse anything.
+
+Everything here is yours to change. The kit exists so that any coding agent can
+operate this project without being taught it first.
+
+### When something refuses you
+
+This project refuses loudly and on purpose. Most of what looks like a failure is
+a rule doing its job — and every refusal names its own fix, so this table is a
+map rather than a substitute.
+
+| What you see                                                         | What it means                                                                                              | What to do                                                                             |
+| -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `pnpm check` refuses a document                                      | `status: stable` without both `generated` and `ksor.approval`, or an approval earlier than the text it approves | add both keys; approval cannot precede what it approves                                |
+| `start` — missing script                                             | there is none: the site is a static export, so nothing serves it at runtime                                | `pnpm preview`, or upload the folder                                                   |
+| `pnpm preview` exits `3`                                             | there is no `system/site/out/` yet                                                                         | run the build first                                                                    |
+| `pnpm serve` refuses to boot                                         | it will not run unauthenticated by accident                                                                | `KSOR_AUTH=disabled-local` in `.env` for a loopback run                                |
+| the deployed or containerised door refuses with `disabled-local`     | it binds `0.0.0.0` — a public bind                                                                         | `KSOR_AUTH=disabled-public` in the host environment, or configure the SSO variables    |
+| the agent answers questions 2 and 3 instead of declining             | no floor is measured, so the gate is off (`abstain OFF`, `gate: "off"`) — step 3's `calibrate` was skipped  | `pnpm exec ksor calibrate --instance instance.md`, paste the block, restart             |
+| a deployed door serves an empty record                               | deploying does not publish — and a laptop DSN is unreachable from the host                                 | point both at one hosted Postgres, then `pnpm refresh`                                 |
+| the home page and `/llms.txt` are empty                              | every document is still a draft — correct, not broken                                                      | approve one and rebuild                                                                |
+| a new document never appears on the built site                       | drafts reach no built surface at all                                                                       | publish it — `status: stable` plus both governance keys                                |
+| an expired document still shows on the site but not through the door | the static build evaluated `stale_after` at build time                                                     | rebuild and redeploy; schedule a rebuild if you use it                                 |
+| Vercel: `no services are declared`                                   | Root Directory was auto-filled with `system/site`                                                          | set it to `./`                                                                         |
+
+### Dependencies and advisories
+
+An audit of this scaffold reports vulnerabilities in `next`, and will keep doing
+so: a framework that large always has open advisories against whatever version
+you have pinned.
+
+<!-- ksor:pm npm -->
+
+`npm install` prints the count at the end of every install, so you meet it
+before you have run anything, next to an invitation to run
+`npm audit fix --force`.
+
+<!-- /ksor:pm -->
+<!-- ksor:pm pnpm -->
+
+pnpm reports it only when you run `pnpm audit`.
+
+<!-- /ksor:pm -->
+<!-- ksor:pm bun -->
+
+bun reports it only when you run `bun audit`.
+
+<!-- /ksor:pm -->
+
+**Never let an audit tool raise the pin for you.** It moves off the version this
+scaffold was built and tested against, and that pin is the whole reason two
+machines produce the same site. Bump it deliberately instead — take the newer
+pin a newer `ksor init` emits, or raise it yourself and re-run `pnpm build`.
+
+It also reads worse than it is, for one structural reason worth knowing: **this
+site is a static export.** `pnpm build` writes HTML, JS and CSS to
+`system/site/out/`, and no framework server ever runs in front of your readers —
+no middleware, no server actions, no rewrites, no image optimizer. Most
+framework advisories describe exactly those request paths, so they have nothing
+here to reach.
+
+Two things that argument does NOT cover, and you should treat as real: an
+advisory in the **build** toolchain, which does run, on your machine and in your
+CI; and any advisory at all if you later add a served route and stop exporting.
+Read what an advisory affects before deciding it is inert — the static export is
+a reason, not a blanket.
+
+---
 
 ## Ownership
 

--- a/packages/ksor/templates/scaffold/package.json
+++ b/packages/ksor/templates/scaffold/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "pnpm -C system/site dev",
     "build": "ksor build && pnpm -C system/site build",
+    "preview": "node system/site/preview.mjs",
     "check": "node .agents/skills/format-checker/check.mjs",
     "provision": "pnpm schema && pnpm grant",
     "serve": "ksor serve",

--- a/packages/ksor/templates/scaffold/system/site/preview.mjs
+++ b/packages/ksor/templates/scaffold/system/site/preview.mjs
@@ -1,0 +1,93 @@
+/**
+ * Serve the STATIC EXPORT, so the build has somewhere to land.
+ *
+ * The site is `output: "export"` — there is no server to start, which is what
+ * makes the record hostable anywhere. But it also means the `start` script
+ * every other project has does not exist here, and running one is the first
+ * instinct after a build; the package manager then reports a missing script,
+ * which explains nothing about why there is nothing to start.
+ *
+ * So this is the answer to "and now how do I look at it". It is node:http and
+ * nothing else — no dependency to install and no network fetch, so it works
+ * offline and behind a firewall, for the same reason the build itself
+ * downloads nothing.
+ *
+ * Names no package manager on purpose: this file ships in the npm and bun
+ * scaffolds too, and those must not carry another manager's vocabulary
+ * (asserted by `init-manager.integration.test.ts`).
+ *
+ * It is a PREVIEW, not a deployment: single process, no compression, no
+ * caching headers. Put the directory behind a real web server or a static
+ * host for anything else.
+ */
+import { createReadStream, statSync } from "node:fs";
+import { createServer } from "node:http";
+import path from "node:path";
+import process from "node:process";
+
+const ROOT = path.resolve(import.meta.dirname, "out");
+const PORT = Number(process.env.PORT ?? 3000);
+
+const TYPES = new Map([
+  [".html", "text/html; charset=utf-8"],
+  [".md", "text/markdown; charset=utf-8"],
+  [".txt", "text/plain; charset=utf-8"],
+  [".json", "application/json; charset=utf-8"],
+  [".js", "text/javascript; charset=utf-8"],
+  [".css", "text/css; charset=utf-8"],
+  [".svg", "image/svg+xml"],
+  [".png", "image/png"],
+  [".jpg", "image/jpeg"],
+  [".webp", "image/webp"],
+  [".ico", "image/x-icon"],
+  [".woff2", "font/woff2"],
+]);
+
+try {
+  statSync(ROOT);
+} catch {
+  console.error(`preview: ${ROOT} does not exist — run the build first.`);
+  process.exit(3);
+}
+
+/** The file a request resolves to, or null when it escapes the export. */
+function resolve(urlPath) {
+  const decoded = decodeURIComponent(urlPath.split("?")[0]);
+  // Contain every request inside the export: a `..` that resolves outside it
+  // is refused rather than served, even in a preview.
+  const target = path.resolve(ROOT, `.${decoded}`);
+  if (target !== ROOT && !target.startsWith(ROOT + path.sep)) return null;
+
+  for (const candidate of [target, path.join(target, "index.html"), `${target}.html`]) {
+    try {
+      if (statSync(candidate).isFile()) return candidate;
+    } catch {
+      // Try the next shape.
+    }
+  }
+  return null;
+}
+
+createServer((req, res) => {
+  const file = resolve(req.url ?? "/");
+  if (file === null) {
+    const notFound = path.join(ROOT, "404.html");
+    try {
+      statSync(notFound);
+      res.writeHead(404, { "content-type": "text/html; charset=utf-8" });
+      createReadStream(notFound).pipe(res);
+      return;
+    } catch {
+      res.writeHead(404, { "content-type": "text/plain; charset=utf-8" });
+      res.end("404\n");
+      return;
+    }
+  }
+  res.writeHead(200, {
+    "content-type": TYPES.get(path.extname(file)) ?? "application/octet-stream",
+  });
+  createReadStream(file).pipe(res);
+}).listen(PORT, () => {
+  console.log(`preview: serving ${path.relative(process.cwd(), ROOT)} on http://localhost:${PORT}`);
+  console.log("  this is the STATIC EXPORT — the same bytes a host would serve.");
+});


### PR DESCRIPTION
Three things an adopter hit in one sitting today.

## 1. There was nowhere for a build to land

The site is `output: "export"` — no server to start, which is what makes the record hostable anywhere. But the natural move after `build` is `start`, and the package manager answers `ERR_PNPM_NO_SCRIPT_OR_SERVER`, which explains none of that.

`preview` serves `system/site/out` over **`node:http` and nothing else** — no dependency to install, no network fetch, works offline and behind a firewall, for the same reason the build downloads nothing. Run before a build it says so and exits `3`.

Verified on a real scaffold:

```
/                        200      content-type on llms.txt: text/plain; charset=utf-8
/docs/what-is-a-ksor/    200      /docs/nope/                404
/llms.txt                200      /../../etc/passwd          404  (contained)
/md/what-is-a-ksor.md    200
```

It names **no package manager**, because it ships in the npm and bun scaffolds too. The first draft said `pnpm build` in a comment and `init-manager.integration.test.ts` failed it — decision 25, working exactly as intended.

## 2. The Vercel dashboard import fails, and the cause is ours to document

Vercel auto-detects a root directory by looking for a framework, finds the Next app, and fills the field with **`system/site`**. The build then reads `system/site/vercel.json`, which does not exist:

```
Error: Project framework is set to "services", but no services are declared.
```

The services *are* declared — at the repository root, the only place they can be, since one builds the site and the other builds a container from the root `Dockerfile`. The import screen even lists both, because that step reads the root file; the **build** step uses the Root Directory override instead.

One field fixes it. `docs/deploying.md` now names the error text, the cause, the fix, and the site-only fallback. **It will recur on every dashboard import**, because the layout that triggers it — code under `system/` — is decision 8 and is not moving.

## 3. The intake interview asks three questions, not seven

Seven did not survive contact. An agent running the skill decided five were too many, defaulted them, and reported **"answered: all seven"** — including the authority question, which it filled from the owner's git handle. A process the tool executing it shortcuts is too long.

**Asked**, because none can be defaulted:

| | why |
|---|---|
| **Scope** | the abstention gate needs an edge to be outside of |
| **Boundary** | same — a record authoritative for everything has no outside |
| **Authority** | a governance act names its actor; the tool never guesses one (decision 21) |

**Stated as defaults** in one block, written only if unopposed: read by both · declines firmly · one `public` audience · no sources yet. The audiences wall-of-text moves to where it is needed — after someone says *not* every reader sees every document.

The skill now carries the rule in its own text: **never report a default as an answer**, and name which were which in the write-back.

## Verification

`fmt` `lint` `guard` `check:corpus` `typecheck` `test:unit` clean · `test:integration` **580 passed / 31 skipped**.

Two of my own mistakes were caught by the gates rather than by review: the `pnpm` in `preview.mjs` (manager suite), and an edited `.agents/skills/` copy whose `.claude/` mirror I had not updated (guard rule 9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)