### PR TITLE
Correct what the reading-measure comment claimed, and link the concepts deck

### DIFF
--- a/.changeset/tighter-page-gutter.md
+++ b/.changeset/tighter-page-gutter.md
@@ -1,0 +1,8 @@
+---
+"@panaversity/ksor": patch
+---
+
+A document page gives its text 16px more room: the horizontal padding drops
+from 32px to 24px. The reading measure itself is unchanged — widening it was
+tried and reverted, because measuring what the column already is showed it is
+wider than the comment beside it claimed, not narrower.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ The result is not merely a documentation site, knowledge base, vector database, 
 
 > **KSoR is an open knowledge infrastructure framework for the AI-native organization.**
 
+**New to the idea?** [**KSoR in eight concepts**](https://docs.google.com/presentation/d/1lLF3PZBQ3vbeSdCKqPbMDTN9a6bgP6msDvbBIrEdeko/edit?usp=sharing) is a 17-slide walkthrough that follows a single hospital through the eight ideas behind a Knowledge System of Record: one authoritative record, what belongs in it, provenance, the governance boundary, abstention, citation, how new knowledge gets approved, and the many open projections that read it. Plain language, no code — the deck to open when you are introducing KSoR to a team.
+
 ---
 
 ## Start here

--- a/packages/ksor/templates/scaffold/system/site/app/global.css
+++ b/packages/ksor/templates/scaffold/system/site/app/global.css
@@ -228,20 +228,37 @@
 }
 
 /* ── The reading measure ─────────────────────────────────────────────────────
-   The shell caps the article at 900px, which at the body's 16px puts 78
-   characters on a line (measured) — half again the 45–75 that reading research
-   and every typographic manual settle on, and the reason the page read as a
-   slab. 46rem holds the text to 672px, about 66 characters, and the article
-   still centres itself in the main column.
+   The shell caps the article at 900px, which puts far more than the 45–75 that
+   reading research and every typographic manual settle on a line, and is the
+   reason the page read as a slab. 46rem holds the text to 688px and the
+   article still centres itself in the main column. (The character counts this
+   paragraph used to give were wrong in both directions — see below.)
 
    It is also half of what stops the column moving: the other half is holding
    the table-of-contents column on every page (app/docs/[[...slug]]/page.tsx).
    Sidebar and rail are both 268px, so main is centred in the viewport and this
    measure is centred in main — the same place on a document with headings and
    one without. `data-full` is the shell's own escape hatch for a page that
-   asked for the whole width; it keeps it. */
+   asked for the whole width; it keeps it.
+
+   The measure STAYS at 46rem, and the number above is corrected here rather
+   than trusted: asked for a wider column, the honest thing was to measure what
+   this one already is. Simulating the browser's own line-breaking over this
+   record's prose in its real font gives 89 characters at 46rem — not 66 — and
+   the shell's 900px gives 122, not 78. Both figures in the paragraph above
+   were wrong; the CONCLUSION they supported was right, and by a wider margin
+   than it claimed.
+
+   So widening was tried and reverted: 49rem counts 95 and 52rem counts 104,
+   each further from the 45–75 the research settles on, not closer. What is
+   left is a real gain that costs nothing — the horizontal padding drops from
+   32px to 24px, which gives the text 16px more without touching the measure.
+
+   The white space either side of a bounded column on a 1728px screen is the
+   price of the column being bounded. It is not a bug to be tuned away. */
 #nd-page:not([data-full="true"]) {
   max-width: 46rem;
+  padding-inline: 1.5rem;
 }
 
 html {


### PR DESCRIPTION
Two unrelated changes rode this branch; both are small and both are described here.

## The reading measure (`4883d2c`)

**Problem.** Asked to reduce the space either side of a document, the first move was to measure the column rather than trust the number in the comment beside it. The comment claimed 66 characters at `46rem` and 78 at the shell's 900px. Simulating the browser's own line-breaking over this record's prose, in its real font, gives:

| width | characters |
| --- | --- |
| 46rem (today) | 89 |
| 49rem | 95 |
| 52rem | 104 |
| 900px (shell) | 122 |

Both figures were wrong, in both directions.

**Solution.** The comment's *conclusion* survives, and by a wider margin than it argued: `46rem` is already above the 45–75 that reading research settles on, so every step wider moves away from it. `52rem` was written and reverted. The measure stays; the real figures are now recorded in the comment, so the next person to ask this question starts from a measurement instead of repeating one.

What is left is the part that costs nothing: horizontal padding drops 32px → 24px.

**Behavior.** A document page gives its text 16px more room. The measure itself does not move. `data-full` still opts a page out. Changeset included (`@panaversity/ksor`, patch) — the file is under `packages/ksor/templates/scaffold`.

## The concepts deck (`55e2676`)

**Problem.** The README explains KSoR to a reader who has already committed to a long page. There was nothing for someone who has not.

**Solution.** A one-line link in the opening block, before `## Start here`, to a 17-slide plain-language walkthrough — one hospital, the eight ideas, no code. The eight are named in the README's own vocabulary so the line connects to the sections below rather than introducing parallel terms.

**Reviewer note:** the deck is a Google Slides link. It must be shared "anyone with the link" or README readers will hit a permission wall; worth confirming before this merges.

No changeset — the change is outside `packages/ksor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKrMizThDKWVgQrKPQb7ei