### PR TITLE
Read the embed tuning knobs at use, not at module load (#149)

### DIFF
--- a/.changeset/embed-tuning-knobs-take-effect.md
+++ b/.changeset/embed-tuning-knobs-take-effect.md
@@ -1,0 +1,12 @@
+---
+"@panaversity/ksor": patch
+---
+
+The three embed tuning variables now take effect when set in `.env`.
+`KSOR_EMBED_TIMEOUT_S`, `KSOR_QUERY_EMBED_TIMEOUT_S` and `KSOR_EMBED_CACHE_MAX`
+were read once at module load — before the CLI applies `.env` in `main()` — so
+a value set there was silently ignored and the default stood. An adopter who
+set `KSOR_EMBED_CACHE_MAX` to fit a small runtime, for instance, still got the
+~250 MB default cache and could OOM in production with nothing pointing at why.
+The reads now happen at use. Exported shell variables were unaffected and still
+are.

--- a/packages/content/src/lib/embedding.ts
+++ b/packages/content/src/lib/embedding.ts
@@ -87,11 +87,18 @@ import { envFloat, envInt } from "../env.js";
 
 export { envFloat, envInt };
 
-export const EMBED_TIMEOUT_S: number = envFloat("KSOR_EMBED_TIMEOUT_S", 60.0, 1.0);
+// Read at USE, never bound to a module-scope const: every static import
+// evaluates before `loadDotEnv()` runs inside `main()`, so a module-load read
+// froze the default and silently ignored a value set in `.env` (kernel review
+// finding A2). Both call sites are inside `buildShippedProvider`, which every
+// composition root builds through after `main()` has loaded the env.
+/** The per-request HTTP timeout for a document (ingest/batch) embed. */
+export const EMBED_TIMEOUT_S = (): number => envFloat("KSOR_EMBED_TIMEOUT_S", 60.0, 1.0);
 /** Oracle env var: SOR_QUERY_EMBED_TIMEOUT_S. Note: query-embed.ts reads the
  * SAME variable with a different default (5.0) as its hard wall clock — two
  * deliberate reads, carried from the oracle (embedding.py:62 vs query_embed.py:44). */
-export const QUERY_EMBED_TIMEOUT_S: number = envFloat("KSOR_QUERY_EMBED_TIMEOUT_S", 10.0, 1.0);
+export const QUERY_EMBED_TIMEOUT_S = (): number =>
+  envFloat("KSOR_QUERY_EMBED_TIMEOUT_S", 10.0, 1.0);
 
 // ---------------------------------------------------------------------------
 // Pure helpers (eval-locked; the embed_input recipe won the bake-off —

--- a/packages/content/src/lib/env-read-timing.test.ts
+++ b/packages/content/src/lib/env-read-timing.test.ts
@@ -1,0 +1,84 @@
+/**
+ * The embed tuning knobs must take effect when set in `.env`, which the CLI
+ * applies via `loadDotEnv()` inside `main()` — AFTER every static import has
+ * evaluated. A module-scope `const = envFloat(…)` therefore froze the default
+ * and silently ignored the adopter's value (kernel review finding A2). The
+ * user-visible failure: an adopter sets `KSOR_EMBED_CACHE_MAX` to fit a small
+ * runtime exactly as documented, the cap stays at the 250 MB default, and the
+ * process OOMs in production with nothing pointing at why.
+ *
+ * These assert each knob is read at use. `env-read-timing.integration.test.ts`
+ * guards the class — a fifth module-scope `env(Int|Float)` read fails there.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { EMBED_TIMEOUT_S, QUERY_EMBED_TIMEOUT_S } from "./embedding.js";
+import type { EmbeddingProvider } from "./embedding.js";
+import { _testing, EMBED_WALL_TIMEOUT_S, embedQueryVlit } from "./query-embed.js";
+
+const KNOBS = [
+  "KSOR_EMBED_TIMEOUT_S",
+  "KSOR_QUERY_EMBED_TIMEOUT_S",
+  "KSOR_EMBED_CACHE_MAX",
+] as const;
+
+afterEach(() => {
+  for (const name of KNOBS) delete process.env[name];
+  _testing.reset();
+});
+
+/** A dim-4 provider that counts transport calls; both retry predicates false. */
+function countingProvider(): { provider: EmbeddingProvider; calls: () => number } {
+  let calls = 0;
+  const provider: EmbeddingProvider = {
+    providerId: "stub",
+    modelId: "stub-model",
+    dim: 4,
+    documentTaskLabel: "DOC",
+    queryTaskLabel: "QRY",
+    recipe: "stub-model/d4/DOC",
+    embed(_texts, _opts) {
+      calls += 1;
+      return Promise.resolve([[3, 4, 0, 0]]);
+    },
+    isRetryable: () => false,
+    isRetryableQuery: () => false,
+    reset() {},
+  };
+  return { provider, calls: () => calls };
+}
+
+describe("embed tuning knobs are read at use, not frozen at import", () => {
+  it("KSOR_EMBED_TIMEOUT_S set after import is honored", () => {
+    expect(EMBED_TIMEOUT_S(), "the shipped default").toBe(60);
+    process.env.KSOR_EMBED_TIMEOUT_S = "30";
+    expect(EMBED_TIMEOUT_S(), "the value now set in the environment").toBe(30);
+  });
+
+  it("KSOR_QUERY_EMBED_TIMEOUT_S set after import is honored on both reads of it", () => {
+    expect(QUERY_EMBED_TIMEOUT_S(), "embedding.ts default").toBe(10);
+    expect(EMBED_WALL_TIMEOUT_S(), "query-embed.ts default for the same var").toBe(5);
+    process.env.KSOR_QUERY_EMBED_TIMEOUT_S = "12";
+    expect(QUERY_EMBED_TIMEOUT_S(), "the HTTP timeout read").toBe(12);
+    expect(EMBED_WALL_TIMEOUT_S(), "the wall-clock read").toBe(12);
+  });
+
+  it("KSOR_EMBED_CACHE_MAX set after import caps the query cache", async () => {
+    process.env.KSOR_EMBED_CACHE_MAX = "1";
+    _testing.reset(); // clear the memo so the new value is read
+    const { provider, calls } = countingProvider();
+    await embedQueryVlit("q1", { provider }); // miss (1)
+    await embedQueryVlit("q2", { provider }); // miss (2) — evicts q1 at cap 1
+    await embedQueryVlit("q1", { provider }); // evicted → miss (3)
+    expect(calls(), "provider calls: " + calls()).toBe(3);
+  });
+
+  it("without the env var the cache keeps its generous default", async () => {
+    _testing.reset();
+    const { provider, calls } = countingProvider();
+    await embedQueryVlit("q1", { provider }); // miss (1)
+    await embedQueryVlit("q2", { provider }); // miss (2)
+    await embedQueryVlit("q1", { provider }); // still cached — default cap is 10k
+    expect(calls(), "provider calls: " + calls()).toBe(2);
+  });
+});

--- a/packages/content/src/lib/providers/registry.ts
+++ b/packages/content/src/lib/providers/registry.ts
@@ -115,7 +115,7 @@ export function buildShippedProvider(
     dim: opts.dim ?? EMBED_DIM,
     documentTaskLabel: EMBED_TASK_DOCUMENT,
     queryTaskLabel: EMBED_TASK_QUERY,
-    documentTimeoutS: EMBED_TIMEOUT_S,
-    queryTimeoutS: QUERY_EMBED_TIMEOUT_S,
+    documentTimeoutS: EMBED_TIMEOUT_S(),
+    queryTimeoutS: QUERY_EMBED_TIMEOUT_S(),
   });
 }

--- a/packages/content/src/lib/query-embed.ts
+++ b/packages/content/src/lib/query-embed.ts
@@ -37,9 +37,19 @@ import type { EmbeddingProvider } from "./embedding.js";
 // Each L1 entry is a ~1536-float pgvector literal (~25 KB), so 10k entries
 // ≈ 250 MB — the dominant in-process footprint. Env-tunable (fail-soft) so
 // an operator can shrink it to fit a smaller memory allocation.
+//
+// Read LAZILY and memoized, never at module load: static imports evaluate
+// before `loadDotEnv()` runs in `main()`, so a module-load read ignored every
+// `.env` value (kernel review finding A2 — an adopter who set this to fit a
+// small runtime still got the 250 MB default and could OOM). `_testing.reset()`
+// clears the memo.
 /** Oracle env var: SOR_EMBED_CACHE_MAX. */
-const CACHE_MAX_INITIAL: number = envInt("KSOR_EMBED_CACHE_MAX", 10000, 1);
-let cacheMax: number = CACHE_MAX_INITIAL;
+let memoizedCacheMax: number | undefined;
+/** A `_testing.setCacheMax()` override; `undefined` = follow the env-derived value. */
+let cacheMaxOverride: number | undefined;
+function currentCacheMax(): number {
+  return cacheMaxOverride ?? (memoizedCacheMax ??= envInt("KSOR_EMBED_CACHE_MAX", 10_000, 1));
+}
 
 export const BREAKER_COOLDOWN_S = 10.0;
 
@@ -49,8 +59,9 @@ export const BREAKER_COOLDOWN_S = 10.0;
 // both (oracle E2E review SB8). Deliberately the SAME env var embedding.ts
 // reads with default 10.0 as the per-request HTTP timeout — two reads, two
 // defaults, carried from the oracle (query_embed.py:44 vs embedding.py:62).
-/** Oracle env var: SOR_QUERY_EMBED_TIMEOUT_S. */
-export const EMBED_WALL_TIMEOUT_S: number = envFloat("KSOR_QUERY_EMBED_TIMEOUT_S", 5.0, 0.1);
+/** Oracle env var: SOR_QUERY_EMBED_TIMEOUT_S. Read at use, not at module load
+ * — see the cache-max note above. */
+export const EMBED_WALL_TIMEOUT_S = (): number => envFloat("KSOR_QUERY_EMBED_TIMEOUT_S", 5.0, 0.1);
 
 // L1 (insertion-ordered Map → LRU), the in-flight map, and the breaker are
 // MODULE-GLOBAL: one embedding space per process is the deployed shape. A
@@ -102,16 +113,17 @@ export function breakerOpenUntil(provider: EmbeddingProvider): number {
 }
 
 function withWallClock(work: Promise<number[][]>): Promise<number[][]> {
+  const wallTimeoutS = EMBED_WALL_TIMEOUT_S();
   return new Promise((resolve, reject) => {
     const timer = setTimeout(() => {
       // The losing embed cannot be cancelled (module note); its settlement is
       // already observed by the handlers below, so nothing goes unhandled.
       reject(
         new QueryEmbedTimeoutError(
-          `query embed exceeded the ${EMBED_WALL_TIMEOUT_S}s wall clock — treated as a provider failure (degrade to keyword-only)`,
+          `query embed exceeded the ${wallTimeoutS}s wall clock — treated as a provider failure (degrade to keyword-only)`,
         ),
       );
-    }, EMBED_WALL_TIMEOUT_S * 1000);
+    }, wallTimeoutS * 1000);
     work.then(
       (value) => {
         clearTimeout(timer);
@@ -151,7 +163,7 @@ async function embedMiss(
     const literal = vlit(vec);
     cache.delete(key);
     cache.set(key, literal); // insert at the LRU tail
-    while (cache.size > cacheMax) {
+    while (cache.size > currentCacheMax()) {
       const oldest = cache.keys().next().value;
       if (oldest === undefined) break;
       cache.delete(oldest);
@@ -215,9 +227,10 @@ export const _testing: { reset(): void; setCacheMax(n: number): void } = {
     cache.clear();
     inflight.clear();
     breakerOpenUntilByMs.clear();
-    cacheMax = CACHE_MAX_INITIAL;
+    cacheMaxOverride = undefined;
+    memoizedCacheMax = undefined; // the next read re-consults KSOR_EMBED_CACHE_MAX
   },
   setCacheMax(n: number): void {
-    cacheMax = n;
+    cacheMaxOverride = n;
   },
 };

--- a/packages/ksor/src/env-read-timing.integration.test.ts
+++ b/packages/ksor/src/env-read-timing.integration.test.ts
@@ -1,0 +1,68 @@
+/**
+ * A tuning knob read with `env(Int|Float)(…)` bound straight to a module-scope
+ * `const`/`let` is read at IMPORT time — before the CLI runs `loadDotEnv()`
+ * inside `main()` — so the value freezes at the default and every `.env`
+ * setting is silently ignored. This repo has paid for that ESM-ordering trap
+ * four times; the fourth (kernel review finding A2) was `KSOR_EMBED_TIMEOUT_S`,
+ * `KSOR_QUERY_EMBED_TIMEOUT_S` and `KSOR_EMBED_CACHE_MAX`.
+ *
+ * The rule this guards: a knob is read inside a function
+ * (`const X = () => envInt(…)`, the shape `db.ts` and `http.ts` already use),
+ * never `const X = envInt(…)` at module scope. A fifth instance is a red light
+ * here instead of a fifth review round.
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
+
+/** The kernel packages — the ones that carry env-tunable knobs. */
+const KERNEL_PACKAGES = ["postgres", "content", "gateway-kit", "content-gateway"];
+
+/**
+ * `const NAME = envInt(` / `export let NAME: T = envFloat(` — a direct
+ * module-scope binding. `const NAME = () => envInt(` does NOT match: after `=`
+ * comes `(`, not `env`, so a read-at-use wrapper is allowed. An indented line
+ * (a read inside a function body) does not match either — `const` must sit at
+ * column 0.
+ */
+const MODULE_SCOPE_ENV_READ =
+  /^(?:export\s+)?(?:const|let)\s+[A-Za-z_$][\w$]*\s*(?::[^=]+)?=\s*env(?:Int|Float)\s*\(/;
+
+function sourceFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === "node_modules" || entry.name === "dist" || entry.name.startsWith(".")) {
+      continue;
+    }
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) sourceFiles(full, out);
+    else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) out.push(full);
+  }
+  return out;
+}
+
+describe("env tuning knobs are read at use, never frozen at module load", () => {
+  it("no kernel source binds env(Int|Float) straight to a module-scope const", () => {
+    const offenders: string[] = [];
+    for (const pkg of KERNEL_PACKAGES) {
+      for (const file of sourceFiles(path.join(repoRoot, "packages", pkg, "src"))) {
+        readFileSync(file, "utf8")
+          .split("\n")
+          .forEach((line, i) => {
+            if (MODULE_SCOPE_ENV_READ.test(line)) {
+              offenders.push(`${path.relative(repoRoot, file)}:${i + 1}  ${line.trim()}`);
+            }
+          });
+      }
+    }
+    expect(
+      offenders,
+      "these read the environment at import time, before loadDotEnv() runs — wrap each in a " +
+        "read-at-use function (see db.ts's READ_RETRY_ATTEMPTS):\n" +
+        offenders.join("\n"),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #149.

## Problem

`KSOR_EMBED_TIMEOUT_S`, `KSOR_QUERY_EMBED_TIMEOUT_S` and
`KSOR_EMBED_CACHE_MAX` are documented in the scaffold's `env.example`, but
setting them in `.env` did nothing. They were bound to module-scope `const`s:

- `packages/content/src/lib/embedding.ts` — `EMBED_TIMEOUT_S`, `QUERY_EMBED_TIMEOUT_S`
- `packages/content/src/lib/query-embed.ts` — `CACHE_MAX_INITIAL`, `EMBED_WALL_TIMEOUT_S`

Every static import evaluates before `loadDotEnv()` runs inside `main()`, so
the read happened first and froze the default. Exported shell variables worked;
`.env` values were silently ignored — which is what made it undiagnosable. The
user-facing failure in the issue: an adopter sets `KSOR_EMBED_CACHE_MAX` to fit
a 512 MB runtime, the cap stays at ~250 MB of cached vectors, and the process
OOMs in production with nothing pointing at why.

This is the fourth instance of the ESM-ordering trap the repo has already paid
for three times.

## Change

- Convert the four reads to read-at-use functions, matching the shape
  `db.ts` (`READ_RETRY_ATTEMPTS`) and `http.ts` (`drainTimeoutMs`) already use.
  `EMBED_TIMEOUT_S()` / `QUERY_EMBED_TIMEOUT_S()` are consumed only inside
  `buildShippedProvider`; `EMBED_WALL_TIMEOUT_S()` is captured once at the top
  of `withWallClock`.
- `KSOR_EMBED_CACHE_MAX` is read lazily and **memoized**; `_testing.reset()`
  clears the memo and `_testing.setCacheMax()` still overrides it, so that seam
  is unchanged (the existing LRU-eviction test passes untouched).
- **Unit test per knob** (`env-read-timing.test.ts`): set `process.env` after
  import, assert the new value is honored — impossible before.
- **Class guard** (`env-read-timing.integration.test.ts`): fails, naming
  `file:line`, on any `env(Int|Float)` bound straight to a module-scope
  `const`/`let` in the kernel packages. Verified **red** before this change
  (it lists exactly these four reads) and **green** after — a fifth recurrence
  is a red light rather than a fifth review round.
- Changeset: `patch`.

`env.example` already documents all three variables, so no change there.

## Verification (local, Windows checkout)

`pnpm -r build`, `pnpm -r typecheck`, the full unit suite (1532 passed), and
the new integration test all pass; `oxlint` / `oxfmt --check` clean. `pnpm guard`
shows only pre-existing `.claude/skills` symlink noise from the Windows
checkout, unrelated to this change. The DB tier was not run (no local Postgres);
nothing here touches SQL.