### PR TITLE
Record the decision to stay on gemini-embedding-001/1536

### DIFF
--- a/.changeset/dimension-ceiling-holds.md
+++ b/.changeset/dimension-ceiling-holds.md
@@ -1,0 +1,24 @@
+---
+"@panaversity/ksor": patch
+---
+
+**The embedding dimension ceiling is now held equal in both places it is
+declared.**
+
+`EMBED_DIM_MAX` is declared twice — in the instance parser, so a bad `dim:` is
+refused when `instance.md` is READ, and in the DDL renderer, so it is refused
+again before any schema is rendered. The split is deliberate and the comment
+beside one calls it a mirror of the other. Nothing held them equal: before this,
+the constant appeared in no test anywhere in the repository, so raising the
+ceiling in one place alone would have left the parser and the renderer refusing
+at different dimensions with nothing going red.
+
+The test asserts EQUALITY and never the number, so the ceiling can still move —
+which is the point, because the decision that records why it sits at 2000 prices
+raising it rather than forbidding it.
+
+Also documentation-only, in the same area: the measurement behind the shipped
+embedding default — the dimensionality table's flat top, its missing 3072 row,
+and the halfvec lead — now lives in exactly one place, beside the constant it
+constrains, with its source URL and retrieval date rather than as figures copied
+into two files with nothing holding them equal.

--- a/.changeset/dimension-ceiling-holds.md
+++ b/.changeset/dimension-ceiling-holds.md
@@ -11,14 +11,15 @@ again before any schema is rendered. The split is deliberate and the comment
 beside one calls it a mirror of the other. Nothing held them equal: before this,
 the constant appeared in no test anywhere in the repository, so raising the
 ceiling in one place alone would have left the parser and the renderer refusing
-at different dimensions with nothing going red.
+at different dimensions — one of the two would still have reddened an existing
+wording assertion, and an instance-only edit would have passed everything.
 
 The test asserts EQUALITY and never the number, so the ceiling can still move —
 which is the point, because the decision that records why it sits at 2000 prices
 raising it rather than forbidding it.
 
-Also documentation-only, in the same area: the measurement behind the shipped
-embedding default — the dimensionality table's flat top, its missing 3072 row,
-and the halfvec lead — now lives in exactly one place, beside the constant it
-constrains, with its source URL and retrieval date rather than as figures copied
-into two files with nothing holding them equal.
+Also in the same area: the emitted `AGENTS.md` carried the benchmark figures
+behind that default with no source and no date, shipped to every adopter. It
+states the constraint an adopter acts on and points at the decision that holds
+the numbers, so the measurement now lives beside the constant it constrains,
+with its provenance, in one place.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1328,48 +1328,65 @@ gateway` package, serve-by-spawn) is superseded._
     not a forecast, and when it arrives the change is a default flip plus a
     migration note, not new machinery.
 
-30. **We stay on `gemini-embedding-001` at 1536 dimensions** (owner,
-    2026-08-27, closing issue #49). Two questions arrived together — the model
-    has a successor, and the 2000-dimension ceiling turned out not to be a wall
-    — and they resolve the same way: nothing measured argues for moving.
+30. **The shipped DEFAULT stays `gemini-embedding-001` at 1536 dimensions**
+    (2026-08-27, closing issue #49). Recorded from the evidence in #49 rather
+    than by owner direction — **merging this entry is what adopts it**, and it
+    is written to be edited or rejected rather than ratified by inattention.
+    It binds the defaults in `packages/content/src/config.ts` and nothing else:
+    `embedding.model` and `embedding.dim` remain per-instance keys an adopter
+    may override, and raising `EMBED_DIM_MAX` is a change this entry costs
+    rather than forbids.
 
-    **The quality curve is flat where we sit.** Google's published MTEB table
-    for this model runs 128–2048 and scores **1536 at 68.17 against 2048's
-    68.16** — 1536 is fractionally HIGHER, which is not a real difference but is
-    proof there is no gradient to climb between them. The table carries no 3072
-    row, so the cost of the truncation itself is unpublished and must not be
-    inferred. MRL is why 1536 was chosen and the table is why it stays.
+    **The quality curve is flat where we sit.** Google's dimensionality table
+    for this model — <https://ai.google.dev/gemini-api/docs/embeddings>,
+    retrieved 2026-08-27 — scores **1536 at 68.17 against 2048's 68.16**, and
+    its highest row IS 2048: there is no 3072 row, so the cost of the
+    truncation itself is unpublished and cannot be read off the table either
+    way. 1536 being fractionally higher is not a real difference; it is proof
+    there is no gradient to climb between them.
 
-    **The ceiling is ours, not pgvector's, and the code already says so.**
-    `EMBED_DIM_MAX = 2000` is the limit of the shape we USE: `schema.sql`
-    declares `VECTOR(dim)` columns and indexes one directly, and pgvector takes
-    a `vector` to 2000. It takes a `halfvec` to **4000** through an expression
-    index on the cast, verified live against a real database (2026-08-21:
-    `hnsw ((embedding::halfvec(3072)) halfvec_cosine_ops)` plans an Index Scan).
-    That correction shipped in 0.0.x as its own change and is pinned by
-    `schema.integration.test.ts`; this entry records the DECISION the corrected
-    message left open.
+    **The 2000 ceiling is ours, not pgvector's.** `EMBED_DIM_MAX` limits the
+    shape we USE: `schema.sql` declares `VECTOR(dim)` columns and indexes one
+    directly, and pgvector takes a `vector` to 2000. That correction shipped in
+    **0.0.12** (`1dd6211`), and `schema.integration.test.ts` pins the refusal at
+    2000 and pins its WORDING. What no test covers is the halfvec claim — that
+    pgvector reaches 4000 through an expression index on the cast — which rests
+    on one manual check against a real database (2026-08-21,
+    `hnsw ((embedding::halfvec(3072)) halfvec_cosine_ops)` planning an Index
+    Scan) and has no artifact in the tree. Treat it as a lead, not a guarantee.
 
-    **What moving would actually cost**, recorded because "just bump the model"
-    is the reading to prevent. `gemini-embedding-2`'s space is incompatible with
-    `-001`'s, so it is a re-embed of the whole corpus rather than a version bump
-    — and because a floor is a threshold INSIDE one space, it invalidates every
-    calibrated `vector_floor`, on our records and on every adopter's. The
-    product invariant already says so ("never copy a calibrated constant between
-    corpora"); across embedding spaces is the same argument. Going to 3072 on
-    halfvec additionally puts float16 rounding under the score the abstention
-    gate reads, on a gold set whose in-corpus/near-miss decision turns on about
-    one hundredth (0.730 / 0.671 against 0.683 — decision 20 cites the same
-    numbers). The rounding is probably far under that margin, and "probably" is
-    not the standard for the number that decides whether a record abstains.
+    **What staying costs, recorded rather than argued away.** `-001` accepts
+    2048 input tokens, and `HARD_MAX_CHARS = 4000` at `CHARS_PER_TOKEN = 4` can
+    exceed that for CJK — surfacing as failed chunks rather than an error
+    (`research/i18n.md`). So for a non-Latin record chunk sizing is **already**
+    binding and already silent, and `-2`'s 8192-token window addresses it
+    directly. `-001` also requires the manual L2 normalization `lib/embedding.ts`
+    exists for, which `-2` makes a no-op. And staying on a superseded model
+    means the eventual re-embed happens on Google's retirement timetable rather
+    than on ours.
 
-    **Reversed by a measurement, not by a release announcement**: MTEB or our
-    own gold showing a real gain at a higher dimension or on `-2`, taken
-    BEFORE the migration, with the re-embed and recalibration costs stated. A
-    successor model shipping is not, by itself, evidence. `-2`'s 8192-token
-    input is the one property that would force the question on different
-    grounds, and only if chunk sizing ever becomes the binding constraint
-    (`HARD_MAX_CHARS` is sized against `-001`'s 2048).
+    **What moving would cost**, because "just bump the model" is the reading to
+    prevent: `-2`'s space is incompatible with `-001`'s, so it is a re-embed of
+    the whole corpus, and because a floor is a threshold INSIDE one space it
+    invalidates every calibrated `vector_floor` — ours and every adopter's. The
+    product invariant already says never to copy a calibrated constant between
+    corpora; across embedding spaces is the same argument. Going to 3072 on
+    halfvec would additionally put float16 rounding under the score the
+    abstention gate reads, and this record's gold has no margin to spend: the
+    near-miss at 0.683 OUTSCORES the weaker in-corpus question at 0.671, so no
+    single cosine floor separates them and `ksor calibrate` reports "NOT
+    separable" and refuses to emit one (`behavioural.db.test.ts`; decision 20
+    cites the same numbers for a different argument). Rounding into a set with
+    no separation is not a risk anyone can bound in advance.
+
+    **Reversed by a measurement taken BEFORE any migration** — on this record's
+    own gold or a published table — showing a higher dimension or `-2` beating
+    the current default **by more than the 0.01 this entry calls noise**, with
+    the re-embed and recalibration costs stated. A successor model shipping is
+    not evidence. The CJK case above is the one route that reverses this without
+    a quality measurement at all: if failed chunks on a non-Latin record are
+    reproduced, `-2` is the fix and this entry should not be read as deferring
+    it.
 
 **Open questions — decide independently when the work arrives:** ~~how
 retrieval and abstention are implemented for `serve`~~ — decided 2026-08-19,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1331,68 +1331,46 @@ gateway` package, serve-by-spawn) is superseded._
 30. **The shipped DEFAULT stays `gemini-embedding-001` at 1536 dimensions**
     (2026-08-27, from the evidence in issue #49). Serves the claim that a
     surface offers "a measured floor under which it declines": that floor is a
-    threshold INSIDE one embedding space, so which space is the default decides
-    what every adopter must re-measure when it changes.
+    threshold INSIDE one embedding space, so which space ships decides what
+    every adopter must re-measure when it changes.
 
-    It binds `EMBED_MODEL` and `EMBED_DIM` in `packages/content/src/config.ts`
-    and nothing else. `embedding.model` and `embedding.dim` remain per-instance
-    keys an adopter may override, and raising the ceiling is a change this entry
-    PRICES rather than forbids — `instance.test.ts` holds the two
-    `EMBED_DIM_MAX` declarations equal, so it says where they are and this entry
-    does not have to.
+    Binds `EMBED_MODEL` and `EMBED_DIM` in `packages/content/src/config.ts` and
+    nothing else — `embedding.model` and `embedding.dim` stay per-instance keys,
+    and raising `EMBED_DIM_MAX` is priced here, not forbidden
+    (`instance.test.ts` holds its two declarations equal). The measurement
+    behind it lives beside the constant it constrains, in
+    `packages/content/src/schema.ts`, with its source and retrieval date; this
+    entry does not restate it.
 
-    **The measurement lives beside the constant it constrains**, in
-    `packages/content/src/schema.ts`, with its source URL and retrieval date:
-    the dimensionality table's flat top, the absence of a 3072 row, and the
-    halfvec-to-4000 lead with its one live check and no test. Repeating those
-    figures here would be two hand-kept copies with nothing holding them equal,
-    which is what a drift test exists to prevent and prose cannot.
-
-    **What staying costs.** `-001` accepts 2048 input tokens, and
-    `HARD_MAX_CHARS = 4000` can exceed that for CJK, surfacing as failed chunks
-    rather than an error. Bounded, not silent: `MAX_FAILED_FRACTION = 0.02`
-    withholds readiness above 2%, so a genuinely CJK-heavy record trips the loud
-    path and only a marginal one stays quiet — that band is visible in
-    `chunks.embed_error` and in the run's failed count, which is where to look.
-    (The mechanism is described in `research/i18n.md`, whose own frontmatter
-    says nothing in it is implemented or decided; the failure has not been
-    reproduced here.) `-001` also makes the unconditional `l2Normalize` in
-    `lib/embedding.ts` necessary rather than merely harmless — every embed pays
-    it, and a natively normalized model would make it a no-op it still runs.
-
-    **What moving would cost**, because a model bump reads cheaper than it is. A
-    different model is a different embedding space: a re-embed of the whole
-    corpus, and the invalidation of every calibrated `vector_floor` — ours and
-    every adopter's — by the same argument the product invariant makes about
-    copying a constant between corpora. Going to 3072 on halfvec would further
-    put float16 rounding under the score the abstention gate reads, and this
-    record's gold has no margin to spend: the near-miss at 0.683 outscores the
-    weaker in-corpus question at 0.671 (`behavioural.db.test.ts`), the
-    NOT-separable shape `ksor calibrate` refuses to emit a floor for
-    (`calibrate/math.test.ts`). Rounding into a set with no separation cannot be
-    bounded in advance.
+    **Moving is not a version bump.** A different model is a different embedding
+    space: a re-embed of the whole corpus, and every calibrated `vector_floor`
+    invalidated — ours and every adopter's — by the same argument the product
+    invariant makes about copying a constant between corpora. And this record's
+    gold has no margin to spend on quantisation: the near-miss at 0.683
+    outscores the weaker in-corpus question at 0.671
+    (`evals/behavioural.db.test.ts`), the NOT-separable shape `ksor calibrate`
+    refuses to emit a floor for (`calibrate/math.test.ts`).
 
     **Reversed by either of two things.**
 
-    1. **A quality measurement of 0.1 MTEB points or more** — ten times the 0.01
-       that separates 1536 from 2048, so the trigger is a difference rather than
-       the noise this entry rests on. Both numbers must come from ONE table or
-       one benchmark revision: differencing a successor model's published score
-       against a truncation table's row is not a comparison at this resolution.
-       Stated in MTEB and never in cosine, because decision 20 uses a hundredth
-       of a cosine to mean something load-bearing and the two must not be
-       confused.
-    2. **A reproduced CJK failure** — failed chunks on a non-Latin record, in
-       the column named above. This route needs no quality measurement, and it
-       does NOT pre-authorise a model migration: the failure is a chunk-size
-       failure, and `HARD_MAX_CHARS` is a constant with a `CHUNK_POLICY` bump
-       behind it, costing one record's re-ingest rather than every adopter's
-       recalibration. `-2`'s 8192-token window is the answer only once lowering
-       the chunk ceiling has been tried and found insufficient.
+    1. **0.1 MTEB points or more**, with both numbers from ONE table or one
+       benchmark revision — differencing a successor's published score against a
+       truncation table's row is not a comparison at this resolution. Ten times
+       the 0.01 the default rests on. Stated in MTEB and never in cosine:
+       decision 20 uses a hundredth of a cosine to mean something load-bearing.
+    2. **A reproduced CJK failure.** `-001` takes 2048 input tokens and
+       `HARD_MAX_CHARS = 4000` can exceed that, surfacing as failed chunks
+       rather than an error — bounded by `MAX_FAILED_FRACTION = 0.02`, and
+       visible below that in `chunks.embed_error` and the run's failed count.
+       Reproduce it before choosing a remedy: `HARD_MAX_CHARS` and `MAX_CHARS`
+       bound different paths, both are eval-locked globals rather than
+       per-instance knobs, so re-chunking is not the cheap local fix it looks
+       like — and `-2`'s 8192-token window is a different embedding space with
+       the price above.
 
     A successor model shipping is not, by itself, evidence for either. The `-2`
-    figures this entry cites come from `research/i18n.md` and have not been
-    checked against Google's documentation by anyone here; check them first.
+    figures cited above come from `research/i18n.md`, whose own frontmatter says
+    nothing in it is implemented or decided; check them before acting.
 
 **Open questions — decide independently when the work arrives:** ~~how
 retrieval and abstention are implemented for `serve`~~ — decided 2026-08-19,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1328,6 +1328,49 @@ gateway` package, serve-by-spawn) is superseded._
     not a forecast, and when it arrives the change is a default flip plus a
     migration note, not new machinery.
 
+30. **We stay on `gemini-embedding-001` at 1536 dimensions** (owner,
+    2026-08-27, closing issue #49). Two questions arrived together — the model
+    has a successor, and the 2000-dimension ceiling turned out not to be a wall
+    — and they resolve the same way: nothing measured argues for moving.
+
+    **The quality curve is flat where we sit.** Google's published MTEB table
+    for this model runs 128–2048 and scores **1536 at 68.17 against 2048's
+    68.16** — 1536 is fractionally HIGHER, which is not a real difference but is
+    proof there is no gradient to climb between them. The table carries no 3072
+    row, so the cost of the truncation itself is unpublished and must not be
+    inferred. MRL is why 1536 was chosen and the table is why it stays.
+
+    **The ceiling is ours, not pgvector's, and the code already says so.**
+    `EMBED_DIM_MAX = 2000` is the limit of the shape we USE: `schema.sql`
+    declares `VECTOR(dim)` columns and indexes one directly, and pgvector takes
+    a `vector` to 2000. It takes a `halfvec` to **4000** through an expression
+    index on the cast, verified live against a real database (2026-08-21:
+    `hnsw ((embedding::halfvec(3072)) halfvec_cosine_ops)` plans an Index Scan).
+    That correction shipped in 0.0.x as its own change and is pinned by
+    `schema.integration.test.ts`; this entry records the DECISION the corrected
+    message left open.
+
+    **What moving would actually cost**, recorded because "just bump the model"
+    is the reading to prevent. `gemini-embedding-2`'s space is incompatible with
+    `-001`'s, so it is a re-embed of the whole corpus rather than a version bump
+    — and because a floor is a threshold INSIDE one space, it invalidates every
+    calibrated `vector_floor`, on our records and on every adopter's. The
+    product invariant already says so ("never copy a calibrated constant between
+    corpora"); across embedding spaces is the same argument. Going to 3072 on
+    halfvec additionally puts float16 rounding under the score the abstention
+    gate reads, on a gold set whose in-corpus/near-miss decision turns on about
+    one hundredth (0.730 / 0.671 against 0.683 — decision 20 cites the same
+    numbers). The rounding is probably far under that margin, and "probably" is
+    not the standard for the number that decides whether a record abstains.
+
+    **Reversed by a measurement, not by a release announcement**: MTEB or our
+    own gold showing a real gain at a higher dimension or on `-2`, taken
+    BEFORE the migration, with the re-embed and recalibration costs stated. A
+    successor model shipping is not, by itself, evidence. `-2`'s 8192-token
+    input is the one property that would force the question on different
+    grounds, and only if chunk sizing ever becomes the binding constraint
+    (`HARD_MAX_CHARS` is sized against `-001`'s 2048).
+
 **Open questions — decide independently when the work arrives:** ~~how
 retrieval and abstention are implemented for `serve`~~ — decided 2026-08-19,
 decision 11: the predecessor kernel converts (revision trail: recorded as

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1329,77 +1329,70 @@ gateway` package, serve-by-spawn) is superseded._
     migration note, not new machinery.
 
 30. **The shipped DEFAULT stays `gemini-embedding-001` at 1536 dimensions**
-    (2026-08-27, from the evidence in issue #49). Serves the claim that a record
-    can be trusted: the abstention floor is a threshold inside one embedding
-    space, so which space is the default decides what every adopter has to
-    re-measure when it changes.
+    (2026-08-27, from the evidence in issue #49). Serves the claim that a
+    surface offers "a measured floor under which it declines": that floor is a
+    threshold INSIDE one embedding space, so which space is the default decides
+    what every adopter must re-measure when it changes.
 
-    It binds the defaults — `EMBED_MODEL` and `EMBED_DIM` in
-    `packages/content/src/config.ts` — and nothing else. `embedding.model` and
-    `embedding.dim` stay per-instance keys an adopter may override, and raising
-    the ceiling is a change this entry PRICES rather than forbids. If you raise
-    it, `EMBED_DIM_MAX` is declared twice, in `schema.ts` and `instance.ts`;
-    `schema.integration.test.ts` now holds them equal, so moving one alone goes
-    red instead of refusing at two different dims.
+    It binds `EMBED_MODEL` and `EMBED_DIM` in `packages/content/src/config.ts`
+    and nothing else. `embedding.model` and `embedding.dim` remain per-instance
+    keys an adopter may override, and raising the ceiling is a change this entry
+    PRICES rather than forbids — `instance.test.ts` holds the two
+    `EMBED_DIM_MAX` declarations equal, so it says where they are and this entry
+    does not have to.
 
-    **The evidence lives in the code, not here.** `packages/content/src/schema.ts`
-    carries the ceiling's reasoning at the constant it constrains — that 2000 is
-    the shape we USE rather than pgvector's limit, that `halfvec` reaches 4000
-    through an expression index (one live check, 2026-08-21, with no test in the
-    tree — a lead, not a guarantee), and the dimensionality figures. This entry
-    does not restate them; two hand-kept copies of five numbers is decision 18's
-    failure mode written in prose.
-
-    **What decides it.** Google's dimensionality table
-    (<https://ai.google.dev/gemini-api/docs/embeddings>, retrieved 2026-08-27)
-    scores 1536 at **68.17 MTEB** against 2048's **68.16**, and its highest row
-    is 2048. Two adjacent rows a hundredth apart is evidence of LOCAL flatness
-    on one benchmark — not proof about 3072, which the table does not carry and
-    from which nothing may be inferred. What it does establish is that there is
-    no gradient to climb toward the ceiling from where we sit, which is the only
-    question the default has to answer.
+    **The measurement lives beside the constant it constrains**, in
+    `packages/content/src/schema.ts`, with its source URL and retrieval date:
+    the dimensionality table's flat top, the absence of a 3072 row, and the
+    halfvec-to-4000 lead with its one live check and no test. Repeating those
+    figures here would be two hand-kept copies with nothing holding them equal,
+    which is what a drift test exists to prevent and prose cannot.
 
     **What staying costs.** `-001` accepts 2048 input tokens, and
-    `HARD_MAX_CHARS = 4000` can exceed that for CJK — surfacing as failed chunks
-    rather than an error (`research/i18n.md`, which is intent rather than a
-    measurement: the failure has not been reproduced here, and `CHARS_PER_TOKEN`
-    is justification in `config.ts`'s comment, not something the chunker
-    consults). The silence is bounded: `MAX_FAILED_FRACTION = 0.02` withholds
-    readiness above 2%, so a genuinely CJK-heavy record trips the loud path and
-    only a marginal one stays quiet. `-001` also requires the L2 re-normalization
-    branch of `lib/embedding.ts` — one of that module's four jobs, not its
-    reason for existing. And staying on a superseded model means the eventual
-    re-embed happens on Google's retirement timetable rather than ours.
+    `HARD_MAX_CHARS = 4000` can exceed that for CJK, surfacing as failed chunks
+    rather than an error. Bounded, not silent: `MAX_FAILED_FRACTION = 0.02`
+    withholds readiness above 2%, so a genuinely CJK-heavy record trips the loud
+    path and only a marginal one stays quiet — that band is visible in
+    `chunks.embed_error` and in the run's failed count, which is where to look.
+    (The mechanism is described in `research/i18n.md`, whose own frontmatter
+    says nothing in it is implemented or decided; the failure has not been
+    reproduced here.) `-001` also makes the unconditional `l2Normalize` in
+    `lib/embedding.ts` necessary rather than merely harmless — every embed pays
+    it, and a natively normalized model would make it a no-op it still runs.
 
-    **What moving would cost**, because "just bump the model" is the reading to
-    prevent. A different model is a different embedding space, so it is a
-    re-embed of the whole corpus AND it invalidates every calibrated
-    `vector_floor` — ours and every adopter's — by the same argument the product
-    invariant makes about copying a constant between corpora. Going to 3072 on
-    halfvec would additionally put float16 rounding under the score the
-    abstention gate reads, and this record's gold has no margin to spend: the
-    near-miss at 0.683 outscores the weaker in-corpus question at 0.671
-    (`behavioural.db.test.ts`), which is the NOT-separable shape `ksor calibrate`
-    refuses to emit a floor for (`calibrate/math.test.ts`). Rounding into a set
-    with no separation cannot be bounded in advance.
+    **What moving would cost**, because a model bump reads cheaper than it is. A
+    different model is a different embedding space: a re-embed of the whole
+    corpus, and the invalidation of every calibrated `vector_floor` — ours and
+    every adopter's — by the same argument the product invariant makes about
+    copying a constant between corpora. Going to 3072 on halfvec would further
+    put float16 rounding under the score the abstention gate reads, and this
+    record's gold has no margin to spend: the near-miss at 0.683 outscores the
+    weaker in-corpus question at 0.671 (`behavioural.db.test.ts`), the
+    NOT-separable shape `ksor calibrate` refuses to emit a floor for
+    (`calibrate/math.test.ts`). Rounding into a set with no separation cannot be
+    bounded in advance.
 
-    **Reversed by either of two things, and the units matter.**
+    **Reversed by either of two things.**
 
-    1. **A quality measurement, in MTEB points**: a published table showing a
-       higher dimension or a successor model beating 1536 by more than 0.1 MTEB
-       — ten times the 0.01 that separates 1536 from 2048, so the trigger is a
-       real difference rather than the noise this entry is built on. Deliberately
-       NOT stated in cosine: decision 20 uses a hundredth of a cosine to mean
-       something load-bearing, and the two units must not be confused.
-    2. **A reproduced CJK failure**: failed chunks on a non-Latin record, which
-       `-2`'s 8192-token window would fix. This route needs no quality
-       measurement at all — but it does not waive the paragraph above. Moving is
-       a full re-embed and a recalibration for every adopter either way, and
-       that price is part of the decision rather than an exception to it.
+    1. **A quality measurement of 0.1 MTEB points or more** — ten times the 0.01
+       that separates 1536 from 2048, so the trigger is a difference rather than
+       the noise this entry rests on. Both numbers must come from ONE table or
+       one benchmark revision: differencing a successor model's published score
+       against a truncation table's row is not a comparison at this resolution.
+       Stated in MTEB and never in cosine, because decision 20 uses a hundredth
+       of a cosine to mean something load-bearing and the two must not be
+       confused.
+    2. **A reproduced CJK failure** — failed chunks on a non-Latin record, in
+       the column named above. This route needs no quality measurement, and it
+       does NOT pre-authorise a model migration: the failure is a chunk-size
+       failure, and `HARD_MAX_CHARS` is a constant with a `CHUNK_POLICY` bump
+       behind it, costing one record's re-ingest rather than every adopter's
+       recalibration. `-2`'s 8192-token window is the answer only once lowering
+       the chunk ceiling has been tried and found insufficient.
 
     A successor model shipping is not, by itself, evidence for either. The `-2`
-    figures cited above come from `research/i18n.md` and have not been checked
-    against Google's documentation by anyone here; check them before acting.
+    figures this entry cites come from `research/i18n.md` and have not been
+    checked against Google's documentation by anyone here; check them first.
 
 **Open questions — decide independently when the work arrives:** ~~how
 retrieval and abstention are implemented for `serve`~~ — decided 2026-08-19,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1329,64 +1329,77 @@ gateway` package, serve-by-spawn) is superseded._
     migration note, not new machinery.
 
 30. **The shipped DEFAULT stays `gemini-embedding-001` at 1536 dimensions**
-    (2026-08-27, closing issue #49). Recorded from the evidence in #49 rather
-    than by owner direction — **merging this entry is what adopts it**, and it
-    is written to be edited or rejected rather than ratified by inattention.
-    It binds the defaults in `packages/content/src/config.ts` and nothing else:
-    `embedding.model` and `embedding.dim` remain per-instance keys an adopter
-    may override, and raising `EMBED_DIM_MAX` is a change this entry costs
-    rather than forbids.
+    (2026-08-27, from the evidence in issue #49). Serves the claim that a record
+    can be trusted: the abstention floor is a threshold inside one embedding
+    space, so which space is the default decides what every adopter has to
+    re-measure when it changes.
 
-    **The quality curve is flat where we sit.** Google's dimensionality table
-    for this model — <https://ai.google.dev/gemini-api/docs/embeddings>,
-    retrieved 2026-08-27 — scores **1536 at 68.17 against 2048's 68.16**, and
-    its highest row IS 2048: there is no 3072 row, so the cost of the
-    truncation itself is unpublished and cannot be read off the table either
-    way. 1536 being fractionally higher is not a real difference; it is proof
-    there is no gradient to climb between them.
+    It binds the defaults — `EMBED_MODEL` and `EMBED_DIM` in
+    `packages/content/src/config.ts` — and nothing else. `embedding.model` and
+    `embedding.dim` stay per-instance keys an adopter may override, and raising
+    the ceiling is a change this entry PRICES rather than forbids. If you raise
+    it, `EMBED_DIM_MAX` is declared twice, in `schema.ts` and `instance.ts`;
+    `schema.integration.test.ts` now holds them equal, so moving one alone goes
+    red instead of refusing at two different dims.
 
-    **The 2000 ceiling is ours, not pgvector's.** `EMBED_DIM_MAX` limits the
-    shape we USE: `schema.sql` declares `VECTOR(dim)` columns and indexes one
-    directly, and pgvector takes a `vector` to 2000. That correction shipped in
-    **0.0.12** (`1dd6211`), and `schema.integration.test.ts` pins the refusal at
-    2000 and pins its WORDING. What no test covers is the halfvec claim — that
-    pgvector reaches 4000 through an expression index on the cast — which rests
-    on one manual check against a real database (2026-08-21,
-    `hnsw ((embedding::halfvec(3072)) halfvec_cosine_ops)` planning an Index
-    Scan) and has no artifact in the tree. Treat it as a lead, not a guarantee.
+    **The evidence lives in the code, not here.** `packages/content/src/schema.ts`
+    carries the ceiling's reasoning at the constant it constrains — that 2000 is
+    the shape we USE rather than pgvector's limit, that `halfvec` reaches 4000
+    through an expression index (one live check, 2026-08-21, with no test in the
+    tree — a lead, not a guarantee), and the dimensionality figures. This entry
+    does not restate them; two hand-kept copies of five numbers is decision 18's
+    failure mode written in prose.
 
-    **What staying costs, recorded rather than argued away.** `-001` accepts
-    2048 input tokens, and `HARD_MAX_CHARS = 4000` at `CHARS_PER_TOKEN = 4` can
-    exceed that for CJK — surfacing as failed chunks rather than an error
-    (`research/i18n.md`). So for a non-Latin record chunk sizing is **already**
-    binding and already silent, and `-2`'s 8192-token window addresses it
-    directly. `-001` also requires the manual L2 normalization `lib/embedding.ts`
-    exists for, which `-2` makes a no-op. And staying on a superseded model
-    means the eventual re-embed happens on Google's retirement timetable rather
-    than on ours.
+    **What decides it.** Google's dimensionality table
+    (<https://ai.google.dev/gemini-api/docs/embeddings>, retrieved 2026-08-27)
+    scores 1536 at **68.17 MTEB** against 2048's **68.16**, and its highest row
+    is 2048. Two adjacent rows a hundredth apart is evidence of LOCAL flatness
+    on one benchmark — not proof about 3072, which the table does not carry and
+    from which nothing may be inferred. What it does establish is that there is
+    no gradient to climb toward the ceiling from where we sit, which is the only
+    question the default has to answer.
+
+    **What staying costs.** `-001` accepts 2048 input tokens, and
+    `HARD_MAX_CHARS = 4000` can exceed that for CJK — surfacing as failed chunks
+    rather than an error (`research/i18n.md`, which is intent rather than a
+    measurement: the failure has not been reproduced here, and `CHARS_PER_TOKEN`
+    is justification in `config.ts`'s comment, not something the chunker
+    consults). The silence is bounded: `MAX_FAILED_FRACTION = 0.02` withholds
+    readiness above 2%, so a genuinely CJK-heavy record trips the loud path and
+    only a marginal one stays quiet. `-001` also requires the L2 re-normalization
+    branch of `lib/embedding.ts` — one of that module's four jobs, not its
+    reason for existing. And staying on a superseded model means the eventual
+    re-embed happens on Google's retirement timetable rather than ours.
 
     **What moving would cost**, because "just bump the model" is the reading to
-    prevent: `-2`'s space is incompatible with `-001`'s, so it is a re-embed of
-    the whole corpus, and because a floor is a threshold INSIDE one space it
-    invalidates every calibrated `vector_floor` — ours and every adopter's. The
-    product invariant already says never to copy a calibrated constant between
-    corpora; across embedding spaces is the same argument. Going to 3072 on
+    prevent. A different model is a different embedding space, so it is a
+    re-embed of the whole corpus AND it invalidates every calibrated
+    `vector_floor` — ours and every adopter's — by the same argument the product
+    invariant makes about copying a constant between corpora. Going to 3072 on
     halfvec would additionally put float16 rounding under the score the
     abstention gate reads, and this record's gold has no margin to spend: the
-    near-miss at 0.683 OUTSCORES the weaker in-corpus question at 0.671, so no
-    single cosine floor separates them and `ksor calibrate` reports "NOT
-    separable" and refuses to emit one (`behavioural.db.test.ts`; decision 20
-    cites the same numbers for a different argument). Rounding into a set with
-    no separation is not a risk anyone can bound in advance.
+    near-miss at 0.683 outscores the weaker in-corpus question at 0.671
+    (`behavioural.db.test.ts`), which is the NOT-separable shape `ksor calibrate`
+    refuses to emit a floor for (`calibrate/math.test.ts`). Rounding into a set
+    with no separation cannot be bounded in advance.
 
-    **Reversed by a measurement taken BEFORE any migration** — on this record's
-    own gold or a published table — showing a higher dimension or `-2` beating
-    the current default **by more than the 0.01 this entry calls noise**, with
-    the re-embed and recalibration costs stated. A successor model shipping is
-    not evidence. The CJK case above is the one route that reverses this without
-    a quality measurement at all: if failed chunks on a non-Latin record are
-    reproduced, `-2` is the fix and this entry should not be read as deferring
-    it.
+    **Reversed by either of two things, and the units matter.**
+
+    1. **A quality measurement, in MTEB points**: a published table showing a
+       higher dimension or a successor model beating 1536 by more than 0.1 MTEB
+       — ten times the 0.01 that separates 1536 from 2048, so the trigger is a
+       real difference rather than the noise this entry is built on. Deliberately
+       NOT stated in cosine: decision 20 uses a hundredth of a cosine to mean
+       something load-bearing, and the two units must not be confused.
+    2. **A reproduced CJK failure**: failed chunks on a non-Latin record, which
+       `-2`'s 8192-token window would fix. This route needs no quality
+       measurement at all — but it does not waive the paragraph above. Moving is
+       a full re-embed and a recalibration for every adopter either way, and
+       that price is part of the decision rather than an exception to it.
+
+    A successor model shipping is not, by itself, evidence for either. The `-2`
+    figures cited above come from `research/i18n.md` and have not been checked
+    against Google's documentation by anyone here; check them before acting.
 
 **Open questions — decide independently when the work arrives:** ~~how
 retrieval and abstention are implemented for `serve`~~ — decided 2026-08-19,

--- a/docs/status.md
+++ b/docs/status.md
@@ -27,7 +27,9 @@ table rows alternate, and a callout carries a rule down its left edge; **0.0.41
 released the OKF-native record** — the profile, `ksor build`, `ksor migrate`,
 schema 2.5 and the governed door described below; **0.0.42** filled in
 `database.dsn_env` in the emitted `instance.md` so climbing to the served rung
-needs no edit, and recorded decision 29.
+needs no edit, and recorded decision 29. Decision 30 records the shipped
+embedding default staying at `gemini-embedding-001`/1536, with the two ways it
+reverses.
 
 Everything under the next heading is RELEASED and in adopters' hands as of
 0.0.41. It was developed on the `okf-native-spec` branch, which merged in

--- a/docs/status.md
+++ b/docs/status.md
@@ -27,9 +27,7 @@ table rows alternate, and a callout carries a rule down its left edge; **0.0.41
 released the OKF-native record** — the profile, `ksor build`, `ksor migrate`,
 schema 2.5 and the governed door described below; **0.0.42** filled in
 `database.dsn_env` in the emitted `instance.md` so climbing to the served rung
-needs no edit, and recorded decision 29. Decision 30 records the shipped
-embedding default staying at `gemini-embedding-001`/1536, with the two ways it
-reverses.
+needs no edit, and recorded decision 29.
 
 Everything under the next heading is RELEASED and in adopters' hands as of
 0.0.41. It was developed on the `okf-native-spec` branch, which merged in

--- a/packages/content/src/instance.test.ts
+++ b/packages/content/src/instance.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { InstanceParseError, NoDatabaseDeclared, parseInstanceText } from "./instance.js";
+import {
+  EMBED_DIM_MAX,
+  InstanceParseError,
+  NoDatabaseDeclared,
+  parseInstanceText,
+} from "./instance.js";
+import { EMBED_DIM_MAX as SCHEMA_EMBED_DIM_MAX } from "./schema.js";
 
 /** The slug a refusal CARRIES — it is no longer spelled inside the message (see below). */
 function refusalOf(fn: () => unknown): InstanceParseError {
@@ -206,5 +212,31 @@ database:`,
     expect(refusalOf(() => parseInstanceText("---\nformat: 2\n")).slug).toBe(
       "ksor-frontmatter-invalid",
     );
+  });
+});
+
+/**
+ * The dimension ceiling is declared twice — here and in `schema.ts` — and the
+ * comment beside this one says it "mirrors" the other. This is what makes that
+ * true.
+ *
+ * The split is deliberate: the parser refuses a bad `dim:` when `instance.md`
+ * is READ, so an adopter hears about it before any DDL is rendered. Two
+ * constants that must agree with nothing between them is how decision 18's
+ * failure mode starts. Raising the ceiling is priced by decision 30 and not
+ * forbidden — so this asserts EQUALITY, never the number, and both may move
+ * together.
+ *
+ * It is load-bearing in one direction. A `schema.ts`-only edit already reddens
+ * the `/1\.\.2000/` assertion in `schema.integration.test.ts`; an
+ * `instance.ts`-only edit reddens nothing else.
+ */
+describe("the embedding dimension ceiling", () => {
+  it("is the same number in the instance parser and in the DDL renderer", () => {
+    expect(
+      EMBED_DIM_MAX,
+      `instance.ts declares ${EMBED_DIM_MAX}, schema.ts declares ${SCHEMA_EMBED_DIM_MAX} — ` +
+        "the parser and the DDL renderer would refuse at different dims",
+    ).toBe(SCHEMA_EMBED_DIM_MAX);
   });
 });

--- a/packages/content/src/schema.integration.test.ts
+++ b/packages/content/src/schema.integration.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 import {
+  EMBED_DIM_MAX,
   renderSchema,
   renderSchemaText,
   schemaCompatibleFrom,
@@ -62,7 +63,7 @@ describe("renderSchema against the shipped DDL", () => {
     // The refusal must say WHICH shape 2000 applies to. It used to read
     // "(pgvector vector + HNSW ceiling)", which reads as pgvector's own limit —
     // and pgvector indexes a `halfvec` to 4000 via an expression index on the
-    // cast, verified live against a real database (2026-08-21, issue #49). An
+    // cast, verified live against a real database (2026-08-21; decision 30). An
     // adopter reading the old wording could conclude their model was
     // unusable over a wall that is not one.
     expect(message, `the ceiling must be scoped to the vector column: ${message}`).toMatch(
@@ -76,5 +77,29 @@ describe("renderSchema against the shipped DDL", () => {
   it("refuses a drifted template, naming the counts it saw", () => {
     const drifted = readFileSync(schemaSqlPath(), "utf8") + "\nembedding vector(1536)";
     expect(() => renderSchemaText(drifted, 768)).toThrowError(/expected the vector\(1536\)/);
+  });
+});
+
+/**
+ * The dimension ceiling is declared TWICE — `schema.ts` and `instance.ts` — and
+ * the comment beside the second says it "mirrors" the first. Nothing held them
+ * equal: before this, `EMBED_DIM_MAX` appeared in no test in the repository.
+ *
+ * The split is deliberate and worth keeping, because the two refuse at
+ * different moments on purpose: the parser rejects a bad `dim:` when
+ * `instance.md` is READ, so an adopter hears about it before any DDL is
+ * rendered. But two constants that must agree with no assertion between them is
+ * how decision 18's failure mode starts. Whoever raises the ceiling — decision
+ * 30 prices that and does not forbid it — has to move both, and this is what
+ * says so.
+ */
+describe("the embedding dimension ceiling", () => {
+  it("is the same number in the instance parser and in the DDL renderer", async () => {
+    const instance = await import("./instance.js");
+    expect(
+      instance.EMBED_DIM_MAX,
+      `instance.ts declares ${instance.EMBED_DIM_MAX}, schema.ts declares ${EMBED_DIM_MAX} — ` +
+        "the parser and the DDL renderer would refuse at different dims",
+    ).toBe(EMBED_DIM_MAX);
   });
 });

--- a/packages/content/src/schema.integration.test.ts
+++ b/packages/content/src/schema.integration.test.ts
@@ -3,7 +3,6 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 import {
-  EMBED_DIM_MAX,
   renderSchema,
   renderSchemaText,
   schemaCompatibleFrom,
@@ -77,29 +76,5 @@ describe("renderSchema against the shipped DDL", () => {
   it("refuses a drifted template, naming the counts it saw", () => {
     const drifted = readFileSync(schemaSqlPath(), "utf8") + "\nembedding vector(1536)";
     expect(() => renderSchemaText(drifted, 768)).toThrowError(/expected the vector\(1536\)/);
-  });
-});
-
-/**
- * The dimension ceiling is declared TWICE — `schema.ts` and `instance.ts` — and
- * the comment beside the second says it "mirrors" the first. Nothing held them
- * equal: before this, `EMBED_DIM_MAX` appeared in no test in the repository.
- *
- * The split is deliberate and worth keeping, because the two refuse at
- * different moments on purpose: the parser rejects a bad `dim:` when
- * `instance.md` is READ, so an adopter hears about it before any DDL is
- * rendered. But two constants that must agree with no assertion between them is
- * how decision 18's failure mode starts. Whoever raises the ceiling — decision
- * 30 prices that and does not forbid it — has to move both, and this is what
- * says so.
- */
-describe("the embedding dimension ceiling", () => {
-  it("is the same number in the instance parser and in the DDL renderer", async () => {
-    const instance = await import("./instance.js");
-    expect(
-      instance.EMBED_DIM_MAX,
-      `instance.ts declares ${instance.EMBED_DIM_MAX}, schema.ts declares ${EMBED_DIM_MAX} — ` +
-        "the parser and the DDL renderer would refuse at different dims",
-    ).toBe(EMBED_DIM_MAX);
   });
 });

--- a/packages/content/src/schema.ts
+++ b/packages/content/src/schema.ts
@@ -31,7 +31,7 @@ import { ContentStoreError } from "./db.js";
  * Raising it is a decision, not a constant: every query site would have to use
  * the same cast as the index or fall silently back to a sequential scan, and
  * the halfvec arm's float16 rounding lands on the score the abstention gate
- * reads. Recorded in issue #49, along with the evidence for staying at 1536 —
+ * reads. Recorded in AGENTS.md decision 30 (issue #49), with the evidence for staying at 1536 —
  * Google's published MTEB table runs 128..2048 and is FLAT at the top of that
  * range (1536 scores 68.17, 2048 scores 68.16), so there is no gradient to
  * climb toward the ceiling. It carries no 3072 row, so the cost of the

--- a/packages/content/src/schema.ts
+++ b/packages/content/src/schema.ts
@@ -31,11 +31,15 @@ import { ContentStoreError } from "./db.js";
  * Raising it is a decision, not a constant: every query site would have to use
  * the same cast as the index or fall silently back to a sequential scan, and
  * the halfvec arm's float16 rounding lands on the score the abstention gate
- * reads. Recorded in AGENTS.md decision 30 (issue #49), with the evidence for staying at 1536 —
- * Google's published MTEB table runs 128..2048 and is FLAT at the top of that
- * range (1536 scores 68.17, 2048 scores 68.16), so there is no gradient to
- * climb toward the ceiling. It carries no 3072 row, so the cost of the
- * truncation itself is unpublished; do not infer one.
+ * reads. AGENTS.md decision 30 records the choice; the measurement behind it
+ * lives HERE, beside the constant it constrains, and this is its only copy.
+ *
+ * Google's per-dimension table
+ * (https://ai.google.dev/gemini-api/docs/embeddings, retrieved 2026-08-27)
+ * runs 128..2048 and is FLAT at the top of that range: 1536 scores 68.17 MTEB
+ * against 2048's 68.16. So there is no gradient to climb toward the ceiling
+ * from where we sit. It carries no 3072 row, so the cost of the truncation
+ * itself is unpublished; do not infer one.
  */
 export const EMBED_DIM_MAX = 2000;
 

--- a/packages/ksor/templates/scaffold/AGENTS.md
+++ b/packages/ksor/templates/scaffold/AGENTS.md
@@ -76,10 +76,10 @@ Stand it up in this order (each step's errors explain how to fix themselves):
    later means re-embedding the whole corpus. Keep `dim` at or below 2000 — the
    schema indexes a `vector` column directly and pgvector's HNSW takes a
    `vector` to 2000. `gemini-embedding-001` emits 3072 by default, so ksor asks
-   it for 1536. Google's published MTEB table runs 128–2048 and is flat at the
-   top of it — 1536 scores 68.17 against 2048's 68.16 — so there is no gradient
-   to climb toward the ceiling; going the other way, 768 costs 0.18 if you want
-   the storage back.
+   it for 1536, which the provider's own dimensionality table shows costs
+   nothing measurable against the ceiling — going the other way trades a little
+   quality for storage. Whether to move is priced in ksor's decision 30, which
+   carries the figures and their source.
 
    Leave `retrieval:` out for now — the gate is off and the server says so.
    Turning it on is step 4, AFTER the record is serving.


### PR DESCRIPTION
Closes #49.

## This is drafted, not taken

Recording a decision is an owner act. **Merging this is what takes it** — edit
it, or close it, if the reasoning is not yours. Nothing else in the PR depends
on it.

## What I got wrong first

I recommended this PR as "correct the `EMBED_DIM_MAX` prose, which is wrong
today, plus a decision entry". **The prose half is already done**, and I
repeated #49's claim without checking it — which is the exact failure #201 is
about, made while queueing #201.

It was corrected in `1dd6211` and shipped: the message no longer reads
"(pgvector vector + HNSW ceiling)", it names the vector COLUMN the ceiling
belongs to, and `schema.integration.test.ts` pins both halves — that the message
matches `/vector column/i` and that it does NOT match the old wording. The
comment above `EMBED_DIM_MAX` already carries the halfvec-to-4000 correction and
the live verification.

So there is no code left in #49. Only the entry.

## What the entry records

**The quality curve is flat where we sit.** Google's MTEB table for this model
runs 128–2048; 1536 scores **68.17** against 2048's **68.16** — fractionally
higher, which is not a real difference but is proof there is no gradient to
climb. The table carries no 3072 row, so the cost of the truncation itself is
unpublished and must not be inferred.

**The ceiling is ours, not pgvector's.** `EMBED_DIM_MAX = 2000` limits the shape
we use — `VECTOR(dim)` columns with one indexed directly. pgvector takes a
`halfvec` to 4000 through an expression index on the cast, verified live
(2026-08-21). The decision this entry takes is the one that correction left
open.

**What moving would cost**, recorded because "just bump the model" is the
reading to prevent: `gemini-embedding-2`'s space is incompatible, so it is a
re-embed of the whole corpus, and it invalidates every calibrated `vector_floor`
— ours and every adopter's — because a floor is a threshold *inside* one space.
Going to 3072 on halfvec additionally puts float16 rounding under the score the
abstention gate reads, on a gold whose in-corpus/near-miss decision turns on
about one hundredth (0.730 / 0.671 against 0.683). Probably far under that
margin; "probably" is not the standard for the number deciding whether a record
abstains.

**Reversed by a measurement taken before the migration**, not by a successor
model shipping. `-2`'s 8192-token input is the one property that would force the
question on other grounds, and only if chunk sizing ever becomes binding.

## Behavior

Prose only. Guard and corpus clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)