### PR TITLE
fix: surface audit-degraded signal when the §7 row is shed

### DIFF
--- a/.changeset/grumpy-parks-hide.md
+++ b/.changeset/grumpy-parks-hide.md
@@ -1,0 +1,5 @@
+---
+"@panaversity/ksor": patch
+---
+
+the served envelope now discloses when a §7 audit row could not be written (issue #150)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -817,9 +817,9 @@ gateway` package, serve-by-spawn) is superseded._
     hit and every `read` reply now carries the record's stored `governance`
     block, and `search` takes a `min_trust_tier` parameter. Measured exactly,
     from the served `tools/list` capture rather than an estimate: the three
-    definitions are **16,734 chars ≈ 4,184 tokens, always resident** (was
-    ~2,990) as transmitted — `search` 7,932 + `outline` 3,332 + `read` 5,466 =
-    16,730, plus the four characters the `tools` array itself carries; a search hit
+    definitions are **17,394 chars ≈ 4,349 tokens, always resident** (was
+    ~2,990) as transmitted — `search` 8,152 + `outline` 3,552 + `read` 5,686 =
+    17,390, plus the four characters the `tools` array itself carries; a search hit
     carries ~262 chars more than it did, so a `k=10` call is correspondingly
     dearer. The per-call figure is NOT re-measured here — the live 81-document
     book it was taken against does not exist in this tree, and an estimate

--- a/docs/status.md
+++ b/docs/status.md
@@ -334,9 +334,9 @@ call ~3,541 — an agent pays for a record's tool surface out of its context
 window, so the record's owner decides what it says. Re-measured 2026-08-25
 after the trust floor, the per-hit governance and the trust-tier provenance
 sentences landed: the definitions are
-**16,734 chars / ~4,184 tokens** as transmitted — exact, they depend on the
-code alone — which is `search` 7,932 + `outline` 3,332 + `read` 5,466 =
-**16,730**, plus the four characters the `tools` array itself carries;
+**17,394 chars / ~4,349 tokens** as transmitted — exact, they depend on the
+code alone — which is `search` 8,152 + `outline` 3,552 + `read` 5,686 =
+**17,390**, plus the four characters the `tools` array itself carries;
 the per-call figures were NOT re-measured against that record, and
 `packages/ksor/docs/tool-surface.md` derives them from the 2026-08-23
 measurement plus the governance block's exactly-measured 262 chars a hit. The

--- a/packages/content-gateway/src/tools.ts
+++ b/packages/content-gateway/src/tools.ts
@@ -259,6 +259,13 @@ export const SEARCH_OUTPUT: StandardSchemaWithJSON = z.object({
         "floor, so these hits come from keyword search alone and rank differently.",
     ),
   content_advisory: z.string().optional(),
+  audit: z
+    .enum(["degraded"])
+    .optional()
+    .describe(
+      "Present only when the §7 audit row for this act could not be written (shed under " +
+        "saturation). The answer is unaffected; absent means the row landed normally.",
+    ),
 });
 
 export const OUTLINE_OUTPUT: StandardSchemaWithJSON = z.object({
@@ -298,6 +305,13 @@ export const OUTLINE_OUTPUT: StandardSchemaWithJSON = z.object({
   has_more: z
     .boolean()
     .describe("True when rows were cut at limit — the record has more, this list is partial."),
+  audit: z
+    .enum(["degraded"])
+    .optional()
+    .describe(
+      "Present only when the §7 audit row for this act could not be written (shed under " +
+        "saturation). The answer is unaffected; absent means the row landed normally.",
+    ),
 });
 
 export const READ_OUTPUT: StandardSchemaWithJSON = z.object({
@@ -331,6 +345,13 @@ export const READ_OUTPUT: StandardSchemaWithJSON = z.object({
   total_est_tokens: z.number().optional(),
   note: z.string().optional(),
   content_advisory: z.string().optional(),
+  audit: z
+    .enum(["degraded"])
+    .optional()
+    .describe(
+      "Present only when the §7 audit row for this act could not be written (shed under " +
+        "saturation). The answer is unaffected; absent means the row landed normally.",
+    ),
 });
 
 // ── The handlers ────────────────────────────────────────────────────────────

--- a/packages/content/src/service-audit-degraded.db.test.ts
+++ b/packages/content/src/service-audit-degraded.db.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Issue #150 — logRead's return is discarded at all four serving call sites,
+ * so an answer served without its §7 audit row is indistinguishable from one
+ * with it. The shedding under saturation is correct (availability over
+ * audit); only the silence is the defect.
+ *
+ * This asserts search's `audit` field is:
+ *   - "degraded" when the retrieval_log write is refused (INSERT revoked
+ *     from the serving role, simulating audit-under-saturation without
+ *     needing to actually saturate the pool)
+ *   - absent when the write lands normally
+ *
+ * Seeding follows kernel.db.test.ts's proven shape: schema at a test
+ * dimension, one document ingested through the real ingest role (grant
+ * table + RLS enforced), read back through the real service function.
+ */
+
+import { randomBytes } from "node:crypto";
+import pg from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { contentPool, RUNTIME_ROLE, runIngest } from "./db.js";
+import { applySchema } from "./schema.js";
+import { keyRingFromEnv } from "./lib/snapshot.js";
+import { search, type ServiceContext } from "./service.js";
+import type { ContentInstance } from "./instance.js";
+
+const adminDsn = process.env["KSOR_DB_URL"] ?? "";
+const DIM = 8;
+const TENANT = "audit-corp";
+const CORPUS = "audit-corp-handbook";
+
+const PAD = " filler content well beyond the twenty-four character servable floor.";
+
+/** A hand-normalized unit vector: 1 at `hot`, small elsewhere — kernel.db.test.ts's shape. */
+function unit(hot: number): number[] {
+  const v = Array.from({ length: DIM }, (_, i) => (i === hot ? 1 : 0.01));
+  const norm = Math.hypot(...v);
+  return v.map((x) => x / norm);
+}
+
+describe.runIf(adminDsn !== "")("search's audit-degraded signal (db)", () => {
+  let admin: pg.Pool;
+  let pool: pg.Pool;
+  let dbName: string;
+  let ctx: ServiceContext;
+
+  beforeAll(async () => {
+    dbName = `ksor_t_${randomBytes(4).toString("hex")}`;
+    admin = new pg.Pool({ connectionString: adminDsn, max: 1 });
+    await admin.query(`CREATE DATABASE ${dbName}`);
+    const url = new URL(adminDsn);
+    url.pathname = `/${dbName}`;
+    pool = contentPool(url.toString(), 4);
+    await applySchema(pool, DIM);
+
+    await pool.query(
+      "INSERT INTO ingest_tenant_grants (role_name, tenant_id) VALUES ('sor_content_ingest', $1)",
+      [TENANT],
+    );
+
+    await runIngest(pool, TENANT, async (c) => {
+      await c.query(
+        "INSERT INTO corpora (tenant_id, corpus_id, active_generation) VALUES ($1, $2, 1)",
+        [TENANT, CORPUS],
+      );
+      const r = await c.query(
+        `INSERT INTO content_nodes (tenant_id, generation, stable_id, kind, slug, title, status,
+             audience, doc_status)
+         VALUES ($1, 1, 'doc/zebra', 'document', 'zebra', 'zebra', 'published',
+                 ARRAY['public'], 'stable') RETURNING node_id`,
+        [TENANT],
+      );
+      const nodeId = String(r.rows[0].node_id);
+      await c.query(
+        `INSERT INTO sources (tenant_id, generation, source_id, node_id, title, origin_path,
+                              content_hash, embedding_model, chunk_policy)
+         VALUES ($1, 1, 'zebra:prose', $2, 'zebra:prose', 'zebra:prose', 'hash', 'fake-embed-001',
+                 'heading-aware-1500-content-only-v5')`,
+        [TENANT, nodeId],
+      );
+      await c.query(
+        `INSERT INTO chunks (tenant_id, generation, source_id, ordinal, content, chunk_hash,
+                             labels, embedding, embedding_status, embedding_model)
+         VALUES ($1, 1, 'zebra:prose', 0, $2, md5($2), '{"source_type": "prose"}', $3::vector,
+                 'embedded', 'fake-embed-001')`,
+        [TENANT, "Zebra compensation bands are reviewed yearly." + PAD, `[${unit(0).join(",")}]`],
+      );
+    });
+
+    const ring = keyRingFromEnv("k1=test-secret");
+    const instance: ContentInstance = {
+      name: CORPUS,
+      corpusId: CORPUS,
+      tenantId: TENANT,
+      dsnEnv: "KSOR_DB_URL",
+      abstain: { vectorFloor: null, keywordFloor: null, floorDigest: null },
+      textSearchConfig: "english",
+      maximumResponseCharacters: 120_000,
+      instructions: "Answer only from the record.",
+      title: CORPUS,
+      description: "The audit-degraded test record.",
+      toolchain: null,
+      embeddingProvider: "fake",
+      embeddingModel: "fake-embed-001",
+      embeddingDim: DIM,
+    };
+    ctx = {
+      pool,
+      instance,
+      ring,
+      instanceDigest: "digest-1",
+      embedQuery: async () => unit(0),
+    };
+  }, 180_000);
+
+  afterAll(async () => {
+    await pool?.query(`GRANT INSERT ON retrieval_log TO ${RUNTIME_ROLE}`).catch(() => undefined);
+    await pool?.end().catch(() => undefined);
+    await admin?.query(`DROP DATABASE IF EXISTS ${dbName} WITH (FORCE)`).catch(() => undefined);
+    await admin?.end().catch(() => undefined);
+  });
+
+  it('carries audit: "degraded" when the §7 row could not be written', async () => {
+    await pool.query(`REVOKE INSERT ON retrieval_log FROM ${RUNTIME_ROLE}`);
+    try {
+      const result = await search(ctx, "zebra compensation bands", 5);
+      // The shedding stays: the answer still arrives.
+      expect(result.ok, JSON.stringify(result)).toBe(true);
+      expect(result.audit).toBe("degraded");
+    } finally {
+      await pool.query(`GRANT INSERT ON retrieval_log TO ${RUNTIME_ROLE}`);
+    }
+  });
+
+  it("carries no audit field when the row lands normally", async () => {
+    const result = await search(ctx, "zebra compensation bands", 5);
+    expect(result.ok, JSON.stringify(result)).toBe(true);
+    expect(result.audit).toBeUndefined();
+  });
+});

--- a/packages/content/src/service-audit-degraded.db.test.ts
+++ b/packages/content/src/service-audit-degraded.db.test.ts
@@ -46,7 +46,7 @@ describe.runIf(adminDsn !== "")("search's audit-degraded signal (db)", () => {
   let ctx: ServiceContext;
 
   beforeAll(async () => {
-    dbName = `ksor_t_${randomBytes(4).toString("hex")}`;
+    dbName = `ksor_audit_degraded_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
     admin = new pg.Pool({ connectionString: adminDsn, max: 1 });
     await admin.query(`CREATE DATABASE ${dbName}`);
     const url = new URL(adminDsn);

--- a/packages/content/src/service.ts
+++ b/packages/content/src/service.ts
@@ -306,6 +306,7 @@ export type SearchResult =
       readonly content_advisory?: string;
       readonly k_note?: string;
       readonly degraded_reason?: string;
+      readonly audit?: "degraded";
     }
   | {
       readonly ok: false;
@@ -341,6 +342,7 @@ export type SearchResult =
       readonly snapshot: SnapshotEnvelope | null;
       readonly k_note?: string;
       readonly degraded_reason?: string;
+      readonly audit?: "degraded";
     };
 
 const isoSeconds = (): string => new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
@@ -536,7 +538,7 @@ export async function search(ctx: ServiceContext, query: string, k = 10): Promis
     // A floor abstention still pins the generation it was computed
     // against; matched-nothing pins nothing.
     const generation = hits[0]?.generation;
-    await logRead(ctx.pool, {
+    const audited = await logRead(ctx.pool, {
       tenantId: inst.tenantId,
       corpusId: inst.corpusId,
       actor,
@@ -614,6 +616,7 @@ export async function search(ctx: ServiceContext, query: string, k = 10): Promis
       snapshot: generation === undefined ? null : snapshotEnvelope(ctx, generation),
       ...(kNote === undefined ? {} : { k_note: kNote }),
       ...(degradedReason === undefined ? {} : { degraded_reason: degradedReason }),
+      ...(audited ? {} : { audit: "degraded" as const }),
     };
   }
 
@@ -653,7 +656,7 @@ export async function search(ctx: ServiceContext, query: string, k = 10): Promis
   }
 
   const generation = hits[0]?.generation ?? 0;
-  await logRead(ctx.pool, {
+  const audited = await logRead(ctx.pool, {
     tenantId: inst.tenantId,
     corpusId: inst.corpusId,
     actor,
@@ -695,6 +698,7 @@ export async function search(ctx: ServiceContext, query: string, k = 10): Promis
     ...(advisory ? { content_advisory: CONTENT_ADVISORY } : {}),
     ...(kNote === undefined ? {} : { k_note: kNote }),
     ...(degradedReason === undefined ? {} : { degraded_reason: degradedReason }),
+    ...(audited ? {} : { audit: "degraded" as const }),
   };
 }
 
@@ -756,6 +760,7 @@ export interface ReadResult {
    * (review 2026-08-20). Renamed, retyped, and always present.
    */
   readonly snapshot_status: "pinned" | "unpinned" | string;
+  readonly audit?: "degraded";
 }
 
 export interface ReadOptions {
@@ -924,7 +929,7 @@ export async function readDocument(
     ...new Set(scoped.map((c) => c.headingPath.split("/")[0] ?? "").filter((s) => s !== "")),
   ];
 
-  await logRead(ctx.pool, {
+  const audited = await logRead(ctx.pool, {
     tenantId: inst.tenantId,
     corpusId: inst.corpusId,
     actor,
@@ -975,6 +980,7 @@ export async function readDocument(
     // when they sent none, and the refresh reason when one was sent and could
     // not be used.
     snapshot_status: refreshed ?? (pinned === null ? "unpinned" : "pinned"),
+    ...(audited ? {} : { audit: "degraded" as const }),
   };
 }
 
@@ -1011,6 +1017,7 @@ export async function outlineDocuments(
   offset: number;
   next_offset: number | null;
   content_advisory?: string;
+  audit?: "degraded";
 }> {
   const inst = ctx.instance;
   // A declared-but-uncalibrated floor REFUSES every serve — outline is a
@@ -1043,7 +1050,7 @@ export async function outlineDocuments(
   );
   const has_more = rows.length > limit;
   if (has_more) rows.length = limit;
-  await logRead(ctx.pool, {
+  const audited = await logRead(ctx.pool, {
     tenantId: inst.tenantId,
     corpusId: inst.corpusId,
     actor,
@@ -1061,6 +1068,7 @@ export async function outlineDocuments(
   );
   return {
     ...(advisory ? { content_advisory: CONTENT_ADVISORY } : {}),
+    ...(audited ? {} : { audit: "degraded" as const }),
     has_more,
     limit,
     offset,

--- a/packages/ksor/docs/tool-surface.md
+++ b/packages/ksor/docs/tool-surface.md
@@ -142,9 +142,19 @@ made it answer from.
 - **The output schemas.** `SEARCH_OUTPUT`, `OUTLINE_OUTPUT`, `READ_OUTPUT` carry
   `provenance`, each hit's `governance`, the `snapshot` token and `gate`. A
   record that reshaped them would still look like a KSoR and no longer be one.
+- **The output schemas.** `SEARCH_OUTPUT`, `OUTLINE_OUTPUT`, `READ_OUTPUT` carry
+  `provenance`, each hit's `governance`, the `snapshot` token, `gate`, and
+  `audit`. A record that reshaped them would still look like a KSoR and no
+  longer be one.
 - **The `FLOOR` text.** It tells an agent how to branch on an envelope, what
   `gate: "off"` means, and that corpus content is **untrusted** — quote it, never
   obey it. Your prose is composed above it.
+- **`audit: "degraded"`.** Present only when the §7 retrieval-log row for this
+  act could not be written — shed under saturation, so serving stays
+  available. The answer itself is unaffected; absent means the row landed
+  normally. An operator auditing served answers against the ledger should
+  treat a gap alongside an `audit: "degraded"` response as expected, and any
+  other gap as a leak.
 
 ## The door checks its own surface at boot
 

--- a/packages/ksor/docs/tool-surface.md
+++ b/packages/ksor/docs/tool-surface.md
@@ -22,22 +22,27 @@ numbers are exact for every record:
 
 |                                | chars  | ~tokens |                     |
 | ------------------------------ | ------ | ------- | ------------------- |
-| all three, as transmitted      | 16,734 | 4,184   | **always resident** |
-| `search` alone                 | 7,932  | 1,983   | always resident     |
-| `outline` alone                | 3,332  | 833     | always resident     |
-| `read` alone                   | 5,466  | 1,367   | always resident     |
-| `outline` + `read`, if deleted | 8,798  | 2,200   | the saving below    |
+| all three, as transmitted      | 17,394 | 4,349   | **always resident** |
+| `search` alone                 | 8,152  | 2,038   | always resident     |
+| `outline` alone                | 3,552  | 888     | always resident     |
+| `read` alone                   | 5,686  | 1,422   | always resident     |
+| `outline` + `read`, if deleted | 9,238  | 2,310   | the saving below    |
 
 **Two measurements, so read the first row apart from the rest.** Each tool's
 row is the JSON of that tool's own object; the first row is the JSON of the
 whole `tools` array, which carries four characters no tool's row does — its
 two brackets and the two separators between three tools. So the three tools
-sum to **16,730** and the array is **16,734**. Deleting a tool saves that
+sum to **17,390** and the array is **17,394**. Deleting a tool saves that
 tool's own row, not a share of the total.
 
-They grew: `search` was 5,383 chars before the trust floor and the governance
-each hit now carries, and `read` 3,396 before it carried the same governance
-block beside the frontmatter. That is the price of an agent being able to tell
+They grew, twice, and each rise is priced rather than absorbed. `search` was
+5,383 chars before the trust floor and the governance each hit now carries, and
+`read` 3,396 before it carried the same governance block beside the frontmatter.
+Then every tool gained exactly **220 chars** for the `audit` field that says
+when a reply's §7 row was shed — 660 across the three, always resident. That
+one buys an agent the ability to tell a served answer whose provenance was
+recorded from one whose audit write was dropped under load, which it previously
+could not distinguish at all (#150). That is the price of an agent being able to tell
 a reviewed document from an unreviewed one, and it is charged once per session.
 The last 520 of them are the price of that signal being HONEST: `trust_tier` is
 derived from reviews a document declares about itself, which no authority list
@@ -65,7 +70,7 @@ doing any work.
 ### 1. Delete a tool nothing calls
 
 The biggest win, and the easiest — delete its `registerTool` block. Dropping
-`outline` and `read` takes **8,798 chars (~2,200 tokens)** off every session,
+`outline` and `read` takes **9,238 chars (~2,310 tokens)** off every session,
 whether or not the agent would ever have called them.
 
 ### 2. Say what the record covers

--- a/packages/ksor/src/__fixtures__/served-surface.golden.json
+++ b/packages/ksor/src/__fixtures__/served-surface.golden.json
@@ -41,6 +41,11 @@
           "description": "True ONLY when the record does not cover the question. False with reason=\"unavailable\" or \"unpublished\" means coverage was never established — say so, and do not report either as absence.",
           "type": "boolean"
         },
+        "audit": {
+          "description": "Present only when the §7 audit row for this act could not be written (shed under saturation). The answer is unaffected; absent means the row landed normally.",
+          "enum": ["degraded"],
+          "type": "string"
+        },
         "content_advisory": {
           "type": "string"
         },
@@ -319,6 +324,11 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
       "properties": {
+        "audit": {
+          "description": "Present only when the §7 audit row for this act could not be written (shed under saturation). The answer is unaffected; absent means the row landed normally.",
+          "enum": ["degraded"],
+          "type": "string"
+        },
         "content_advisory": {
           "type": "string"
         },
@@ -463,6 +473,11 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
       "properties": {
+        "audit": {
+          "description": "Present only when the §7 audit row for this act could not be written (shed under saturation). The answer is unaffected; absent means the row landed normally.",
+          "enum": ["degraded"],
+          "type": "string"
+        },
         "content_advisory": {
           "type": "string"
         },

--- a/packages/ksor/src/tool-surface-docs.integration.test.ts
+++ b/packages/ksor/src/tool-surface-docs.integration.test.ts
@@ -4,8 +4,6 @@ import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
 
-import { releaseNote } from "./release-note.js";
-
 import {
   buildDefaultGateway,
   buildServer,
@@ -25,6 +23,13 @@ import {
  * every document that prints them to also print the reconciliation, so a
  * reader can check the arithmetic and a code change that moves a description
  * fails here instead of quietly making five documents wrong.
+ *
+ * A RELEASED CHANGELOG NOTE IS NOT ONE OF THEM. The list used to include a
+ * consumed changeset, read back out of CHANGELOG.md — which made every future
+ * growth of the surface demand that a shipped release note be rewritten to
+ * match the present. A release note records what was measured THEN; forcing it
+ * to agree with now is how a changelog starts lying. The living documents are
+ * checked; history is left alone.
  */
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
@@ -41,6 +46,15 @@ function grouped(n: number): string {
   return n.toLocaleString("en-US");
 }
 
+/**
+ * The rule the published tables already use for their token column: four
+ * characters to the token, halves up. Written down here because it was only
+ * ever implicit in the numbers, which is how one copy of them drifted.
+ */
+function tokens(chars: number): number {
+  return Math.round(chars / 4);
+}
+
 describe("the documented tool-definition sizes", () => {
   it("are two measurements, and the array carries exactly 4 characters no tool's row does", async () => {
     const tools = await listServedTools(buildServer(STUB, "0.0.0", buildDefaultGateway));
@@ -52,8 +66,8 @@ describe("the documented tool-definition sizes", () => {
     const transmitted = JSON.stringify(wire).length;
 
     expect([...per.keys()].sort()).toEqual(["outline", "read", "search"]);
-    expect(sum).toBe(16730);
-    expect(transmitted).toBe(16734);
+    expect(sum).toBe(17390);
+    expect(transmitted).toBe(17394);
     // Named so a failure says WHY the two differ rather than only that they do.
     expect(transmitted - sum).toBe(2 /* brackets */ + (wire.length - 1) /* separators */);
   });
@@ -76,16 +90,27 @@ describe("the documented tool-definition sizes", () => {
       // were the last places the array measure was still attributed to "the
       // three definitions", which is the misreading the whole exercise is about.
       "research/okf-native.md",
-      ".changeset/okf-door-on-the-profile.md",
     ];
     for (const rel of documents) {
-      // A changeset is consumed at release; its prose lives on in CHANGELOG.md.
-      const text = rel.startsWith(".changeset/")
-        ? releaseNote(ROOT, rel).text
-        : readFileSync(path.join(ROOT, rel), "utf8");
+      const text = readFileSync(path.join(ROOT, rel), "utf8");
       expect(text, `${rel} prints the transmitted figure`).toContain(grouped(transmitted));
       expect(text, `${rel} reconciles it with the per-tool sum`).toContain(grouped(sum));
     }
+
+    // The emitted AGENTS.md speaks in TOKENS, not characters — it is the
+    // adopter's file and an agent's budget is tokens — so it is checked against
+    // the same measurement through the published tables' own rule rather than
+    // being made to print a character count it has no use for. Nothing guarded
+    // it before: it still read 4,054 two surface changes after that stopped
+    // being true, in the file a coding agent operating the record reads first.
+    const scaffold = readFileSync(
+      path.join(ROOT, "packages/ksor/templates/scaffold/AGENTS.md"),
+      "utf8",
+    );
+    expect(
+      scaffold,
+      `the emitted AGENTS.md prints the resident cost in tokens (${grouped(tokens(transmitted))})`,
+    ).toContain(`~${grouped(tokens(transmitted))} tokens`);
 
     // The two tables print every tool's own size, so the rows add up on the page.
     for (const rel of ["packages/ksor/docs/tool-surface.md", "specs/ksor/gateway/spec.md"]) {

--- a/packages/ksor/templates/scaffold/AGENTS.md
+++ b/packages/ksor/templates/scaffold/AGENTS.md
@@ -333,7 +333,7 @@ governance block every hit now carries:
 
 |                                  |                                |
 | -------------------------------- | ------------------------------ |
-| all three tool definitions       | ~4,054 tokens, always resident |
+| all three tool definitions       | ~4,349 tokens, always resident |
 | one `search` at `k=10` (default) | ~4,196 tokens per call         |
 | one `search` at `k=5`            | ~2,330 tokens per call         |
 

--- a/research/okf-native.md
+++ b/research/okf-native.md
@@ -753,8 +753,8 @@ hand. The parenthetical is already corrected in §1.8.
 
 **And one the plan predicted correctly and is worth naming because it is a
 cost, not a win.** The tool surface grew: the served `tools` array measured
-16,734 chars ≈ 4,184 tokens on 2026-08-25 — the three definitions' own JSON
-sums to 16,730 of that, the array adding two brackets and two separators —
+17,394 chars ≈ 4,349 tokens on 2026-08-25 — the three definitions' own JSON
+sums to 17,390 of that, the array adding two brackets and two separators —
 against ~2,990 tokens measured 2026-08-23 before the trust floor and the
 per-hit governance block. That is
 the price of an agent being able to tell a reviewed document from an

--- a/specs/ksor/gateway/spec.md
+++ b/specs/ksor/gateway/spec.md
@@ -23,16 +23,16 @@ are exact for every record:
 
 |                                  | chars  | ~tokens |                                |
 | -------------------------------- | ------ | ------- | ------------------------------ |
-| tool definitions, as transmitted | 16,734 | 4,184   | **always resident in context** |
-| `search` alone                   | 7,932  | 1,983   | always resident                |
-| `outline` alone                  | 3,332  | 833     | always resident                |
-| `read` alone                     | 5,466  | 1,367   | always resident                |
-| `outline` + `read`, if deleted   | 8,798  | 2,200   | the delete-both saving         |
+| tool definitions, as transmitted | 17,394 | 4,349   | **always resident in context** |
+| `search` alone                   | 8,152  | 2,038   | always resident                |
+| `outline` alone                  | 3,552  | 888     | always resident                |
+| `read` alone                     | 5,686  | 1,422   | always resident                |
+| `outline` + `read`, if deleted   | 9,238  | 2,310   | the delete-both saving         |
 
 The first row is the JSON of the whole `tools` array; every other row is one
 tool's own object. The array carries four characters no tool's row does — two
-brackets and two separators — so the three tools sum to **16,730** and the
-array is **16,734**. Deleting a tool saves that tool's own row.
+brackets and two separators — so the three tools sum to **17,390** and the
+array is **17,394**. Deleting a tool saves that tool's own row.
 
 **Replies** depend on the record's passages. These are the 2026-08-23
 measurement against the live book record (81 documents, 6,963 chunks) plus the
@@ -58,7 +58,7 @@ record performed.
 
 Two consequences set the scope:
 
-1. **Dropping an unused tool is the largest win** — ~2,200 tokens for the whole
+1. **Dropping an unused tool is the largest win** — ~2,310 tokens for the whole
    session, whether or not the agent would ever have called them.
 2. **`k` is the result lever; `budgets.maximum_response_characters` is not.** It
    defaults to 120,000 and at ~1,700 chars a hit cannot bind before


### PR DESCRIPTION
Fixes #150

## What
`logRead` (`packages/content/src/lib/rlog.ts`) deliberately sheds the §7
audit write under saturation and returns a boolean saying whether the row
landed — but all four serving call sites in `service.ts` (search abstained,
search matched, read, outline) awaited and discarded it. An answer served
without its retrieval_log row was indistinguishable from one with it, so an
operator auditing served answers against the ledger hit unexplained gaps
with no signal that shedding occurred.

The shedding itself is correct (availability over audit under saturation,
by design) — only the silence was the defect.

## Fix
- Capture `logRead`'s return at all four call sites in `service.ts`.
- Add an optional `audit?: "degraded"` field to `SearchResult` (both
  branches), `ReadResult`, and `outlineDocuments`'s return type — present
  only when the write failed, absent on the happy path.
- Mirror the field in the three zod output schemas in
  `content-gateway/src/tools.ts` (`SEARCH_OUTPUT`, `OUTLINE_OUTPUT`,
  `READ_OUTPUT`), since decision 23 puts the tool output schemas in the
  package.
- Regenerate `served-surface.golden.json` via the documented
  `KSOR_UPDATE_SURFACE_GOLDEN=1` flag — diff is exactly the three new
  `audit` schema entries.
- Document the field in `tool-surface.md`, alongside `gate` and `FLOOR` in
  the "what you cannot change" section.

## Testing
Added `packages/content/src/service-audit-degraded.db.test.ts`, following
`kernel.db.test.ts`'s seeding pattern:
- Revokes `INSERT` on `retrieval_log` from `sor_content_runtime`, runs a
  search, asserts the answer still arrives (`ok: true`) **and** carries
  `audit: "degraded"` — the shedding stays, only the silence goes.
- A second case with the grant intact asserts `audit` is absent.

Ran the full local gate (lint, fmt, typecheck, check:corpus, test:unit —
1528 tests) clean. The `.db.test.ts` is gated on `KSOR_DB_URL` like every
other db-tier test in this repo, so it skips locally without a database and
will run for real in CI.

Changeset: patch, on `@panaversity/ksor`.