### PR TITLE
Record the generation an outline served, the score a search answered on, and delete cleanCut

### DIFF
--- a/.changeset/outline-records-its-generation.md
+++ b/.changeset/outline-records-its-generation.md
@@ -1,0 +1,31 @@
+---
+"@panaversity/ksor": patch
+---
+
+**Two audit rows were missing the fact that makes them auditable.**
+
+`retrieval_log` exists so an operator can say what an act was allowed to see and
+what it answered from. Two rows could not answer that:
+
+- **`outline_served` recorded no generation.** Its two siblings,
+  `similarity_searched` and `content_served`, both pin one — so the single act
+  that hands an agent the SHAPE of the record was the one that could not be
+  joined to the publication it described. The projection carried no generation
+  to write, so this is a column rather than an extra query: `walk` already
+  selects it, and `OUTLINE_COLUMNS` moves 9 → 10 under the same width guard that
+  exists because a narrower fixture once hid a truncated projection.
+- **An ANSWERED search recorded no `top_cosine`.** The abstained row has always
+  carried it, so the ledger held the deciding score only for queries the gate
+  REFUSED — precisely the half that cannot show a floor drifting as a record
+  grows. Both rows now record what the decision turned on, whichever way it
+  went.
+
+An empty outline still records NULL, deliberately: it served no row from any
+generation, which is the same reason `search_abstained` records NULL when
+nothing matched.
+
+**And `cleanCut` is deleted.** It was exported and documented as the tool the
+search budget uses to trim an overflowing hit — in the present tense, for a
+caller that has never existed. It came from the predecessor's grain-expansion
+path, a feature ksor deliberately never carried, so it was a mechanism brought
+across without the purpose it existed for.

--- a/packages/content-gateway/src/governance-surface.db.test.ts
+++ b/packages/content-gateway/src/governance-surface.db.test.ts
@@ -38,7 +38,7 @@ import {
   type TrustTier,
 } from "@panaversity/ksor-content";
 
-import { readHandler, searchHandler, type SearchArgs } from "./tools.js";
+import { outlineHandler, readHandler, searchHandler, type SearchArgs } from "./tools.js";
 
 const adminDsn = process.env["KSOR_DB_URL"] ?? "";
 const DIM = 8;
@@ -334,6 +334,51 @@ describe.runIf(adminDsn !== "")("the governance surface of `search` (db)", () =>
     // The query text and the passages, by the two things they would contain.
     expect(serialized).not.toContain("compensation");
     expect(serialized).not.toContain(QUERY);
+  });
+
+  it("an outline records the generation it served from, as its siblings do", async () => {
+    // R20 / working rule 10: the trail exists so an auditor can say WHAT an act
+    // was allowed to see. `similarity_searched` and `content_served` both pin a
+    // generation; `outline_served` wrote NULL, so the one act that hands an
+    // agent the shape of the record could not be joined to the publication it
+    // described. The projection carried no generation to write — `OutlineRow`
+    // is a fixed width with a guard — so this is a column, not a call.
+    await pool.query("DELETE FROM retrieval_log WHERE tenant_id = $1", [TENANT]);
+    const reply = await outlineHandler(doorAt(undefined))({ limit: 50 });
+    expect(reply.isError, JSON.stringify(reply)).not.toBe(true);
+
+    const rows = await pool.query<{ action: string; generation: string | null }>(
+      "SELECT action, generation FROM retrieval_log WHERE tenant_id = $1 ORDER BY created_at",
+      [TENANT],
+    );
+    expect(rows.rows.length, JSON.stringify(rows.rows)).toBe(1);
+    expect(rows.rows[0]!.action).toBe("outline_served");
+    expect(
+      rows.rows[0]!.generation,
+      `outline_served wrote generation=${String(rows.rows[0]!.generation)}`,
+    ).toBe("1");
+  });
+
+  it("an ANSWERED search records the score that decided it, as the abstention does", async () => {
+    // The abstained row carries `top_cosine`; the answered row did not — so the
+    // ledger held the deciding score only for queries the gate REFUSED. That is
+    // exactly the half that cannot show a floor drifting as a record grows
+    // (issue #182): every answer above the floor was unrecorded, so nothing in
+    // the trail says how close to it the record has been running.
+    await pool.query("DELETE FROM retrieval_log WHERE tenant_id = $1", [TENANT]);
+    await searchAs(doorAt(undefined));
+
+    const rows = await pool.query<{ action: string; detail: Record<string, unknown> }>(
+      "SELECT action, detail FROM retrieval_log WHERE tenant_id = $1 ORDER BY created_at",
+      [TENANT],
+    );
+    const row = rows.rows[0]!;
+    expect(row.action).toBe("similarity_searched");
+    expect(row.detail["abstained"]).toBe(false);
+    expect(
+      typeof row.detail["top_cosine"],
+      `answered row detail: ${JSON.stringify(row.detail)}`,
+    ).toBe("number");
   });
 
   it("an abstention records the same scope, and says it abstained", async () => {

--- a/packages/content-gateway/src/governance-surface.db.test.ts
+++ b/packages/content-gateway/src/governance-surface.db.test.ts
@@ -118,10 +118,10 @@ describe.runIf(adminDsn !== "")("the governance surface of `search` (db)", () =>
   const searchAs = async (
     ctx: ServiceContext,
     args: Omit<SearchArgs, "query" | "k"> = {},
-  ): Promise<{ ok: boolean; hits?: WireHit[] }> => {
+  ): Promise<{ ok: boolean; hits?: WireHit[]; top_cosine?: number }> => {
     const reply = await searchHandler(ctx)({ query: QUERY, k: 10, ...args });
     expect(reply.isError, JSON.stringify(reply)).not.toBe(true);
-    return reply.structuredContent as { ok: boolean; hits?: WireHit[] };
+    return reply.structuredContent as { ok: boolean; hits?: WireHit[]; top_cosine?: number };
   };
 
   /** `read`, the way the registration calls it. */
@@ -359,6 +359,33 @@ describe.runIf(adminDsn !== "")("the governance surface of `search` (db)", () =>
     ).toBe("1");
   });
 
+  it("a drill-down onto a LEAF still records the generation it resolved", async () => {
+    // The commonest empty outline is not "matched nothing": it is an agent
+    // following the tool description into a document with no children. That
+    // resolves an anchor and pins its generation, then returns [] — so reading
+    // the generation off `rows[0]` recorded NULL for a routine call, leaving
+    // every "this node has no children" answer unjoinable to the publication it
+    // was made about. `content_served` sets the precedent: pin what was
+    // resolved, however little came back.
+    await pool.query("DELETE FROM retrieval_log WHERE tenant_id = $1", [TENANT]);
+    const reply = await outlineHandler(doorAt(undefined))({ node: "unverified", limit: 50 });
+    expect(reply.isError, JSON.stringify(reply)).not.toBe(true);
+    expect(
+      (reply.structuredContent as { nodes?: unknown[] }).nodes,
+      "the fixture leaf must actually have no children, or this asserts nothing",
+    ).toEqual([]);
+
+    const rows = await pool.query<{ action: string; generation: string | null }>(
+      "SELECT action, generation FROM retrieval_log WHERE tenant_id = $1 ORDER BY created_at",
+      [TENANT],
+    );
+    expect(rows.rows[0]!.action).toBe("outline_served");
+    expect(
+      rows.rows[0]!.generation,
+      `empty leaf outline wrote generation=${String(rows.rows[0]!.generation)}`,
+    ).toBe("1");
+  });
+
   it("an ANSWERED search records the score that decided it, as the abstention does", async () => {
     // The abstained row carries `top_cosine`; the answered row did not — so the
     // ledger held the deciding score only for queries the gate REFUSED. That is
@@ -366,7 +393,7 @@ describe.runIf(adminDsn !== "")("the governance surface of `search` (db)", () =>
     // (issue #182): every answer above the floor was unrecorded, so nothing in
     // the trail says how close to it the record has been running.
     await pool.query("DELETE FROM retrieval_log WHERE tenant_id = $1", [TENANT]);
-    await searchAs(doorAt(undefined));
+    const reply = await searchAs(doorAt(undefined));
 
     const rows = await pool.query<{ action: string; detail: Record<string, unknown> }>(
       "SELECT action, detail FROM retrieval_log WHERE tenant_id = $1 ORDER BY created_at",
@@ -375,10 +402,15 @@ describe.runIf(adminDsn !== "")("the governance surface of `search` (db)", () =>
     const row = rows.rows[0]!;
     expect(row.action).toBe("similarity_searched");
     expect(row.detail["abstained"]).toBe(false);
+    // The VALUE, not just the shape. The same call's envelope carries
+    // `top_cosine`, so a regression that logged the RRF score or the keyword
+    // score would record a plausible float and pass a typeof check — while
+    // making the trail useless for the one thing it is for, watching the floor
+    // drift as a record grows.
     expect(
-      typeof row.detail["top_cosine"],
-      `answered row detail: ${JSON.stringify(row.detail)}`,
-    ).toBe("number");
+      row.detail["top_cosine"],
+      `logged ${JSON.stringify(row.detail["top_cosine"])} vs served ${JSON.stringify(reply.top_cosine)}`,
+    ).toBe(reply.top_cosine);
   });
 
   it("an abstention records the same scope, and says it abstained", async () => {

--- a/packages/content/src/index.ts
+++ b/packages/content/src/index.ts
@@ -119,7 +119,7 @@ export {
   documentChunks,
   MAX_OUTLINE_LIMIT,
 } from "./lib/read.js";
-export { windowDocument, codePointLength, cleanCut, estTokens } from "./lib/windowing.js";
+export { windowDocument, codePointLength, estTokens } from "./lib/windowing.js";
 export {
   normalizeQueries,
   parseQueriesFile,

--- a/packages/content/src/kernel.db.test.ts
+++ b/packages/content/src/kernel.db.test.ts
@@ -553,7 +553,7 @@ describe.runIf(adminDsn !== "")("kernel db acceptance", () => {
     const rows = await runRead(
       pool,
       TENANT,
-      (c) => outline(c, readScope, { depth: 3, limit: 100 }),
+      async (c) => (await outline(c, readScope, { depth: 3, limit: 100 })).rows,
       WHOLE_RECORD_SCOPE,
     );
     const outlined = rows.map((r) => r.slug);

--- a/packages/content/src/lib/audience.db.test.ts
+++ b/packages/content/src/lib/audience.db.test.ts
@@ -116,7 +116,7 @@ describe.runIf(adminDsn !== "")("audience filtering (db)", () => {
       pool,
       TENANT,
       async (c) =>
-        (await outline(c, scope, { root: null, depth: 5, limit: 200 })).map((r) => r.slug),
+        (await outline(c, scope, { root: null, depth: 5, limit: 200 })).rows.map((r) => r.slug),
       audienceGucs(viewer),
     ).then((s) => s.sort());
 

--- a/packages/content/src/lib/read.db.test.ts
+++ b/packages/content/src/lib/read.db.test.ts
@@ -249,7 +249,7 @@ describe.runIf(adminDsn !== "")("read db acceptance", () => {
   });
 
   it("outline browse walks the published tree in position order, draft hidden", async () => {
-    const rows = await readWhole(TENANT, (c) => outline(c, scope, { depth: 2 }));
+    const rows = await readWhole(TENANT, async (c) => (await outline(c, scope, { depth: 2 })).rows);
     expect(
       rows.map((r) => r.headingPath),
       JSON.stringify(rows),
@@ -268,8 +268,9 @@ describe.runIf(adminDsn !== "")("read db acceptance", () => {
   });
 
   it("outline drill-down re-bases to root-absolute and carries the permalink (column 8)", async () => {
-    const rows = await readWhole(TENANT, (c) =>
-      outline(c, scope, { root: "onboarding", depth: 1 }),
+    const rows = await readWhole(
+      TENANT,
+      async (c) => (await outline(c, scope, { root: "onboarding", depth: 1 })).rows,
     );
     expect(rows.length, JSON.stringify(rows)).toBe(1); // children only; draft hidden
     expect(rows[0]).toMatchObject({
@@ -281,25 +282,27 @@ describe.runIf(adminDsn !== "")("read db acceptance", () => {
   });
 
   it("outline accepts the very path addresses it emits", async () => {
-    const rows = await readWhole(TENANT, (c) =>
-      outline(c, scope, { root: "handbook/onboarding", depth: 1 }),
+    const rows = await readWhole(
+      TENANT,
+      async (c) => (await outline(c, scope, { root: "handbook/onboarding", depth: 1 })).rows,
     );
     expect(rows[0]?.headingPath).toBe("handbook/onboarding/setup");
   });
 
   it("outline of a leaf yields []; an unknown node is loud", async () => {
-    const rows = await readWhole(TENANT, (c) =>
-      outline(c, scope, { root: "onboarding/setup", depth: 1 }),
+    const rows = await readWhole(
+      TENANT,
+      async (c) => (await outline(c, scope, { root: "onboarding/setup", depth: 1 })).rows,
     );
     expect(rows).toEqual([]);
     await expect(
-      readWhole(TENANT, (c) => outline(c, scope, { root: "no-such-node" })),
+      readWhole(TENANT, async (c) => (await outline(c, scope, { root: "no-such-node" })).rows),
     ).rejects.toThrowError(/no node with slug/);
   });
 
   it("an ambiguous outline anchor is refused, never silently merged", async () => {
     await expect(
-      readWhole(TENANT, (c) => outline(c, scope, { root: "setup" })),
+      readWhole(TENANT, async (c) => (await outline(c, scope, { root: "setup" })).rows),
     ).rejects.toThrowError(/ambiguous/);
   });
 
@@ -316,7 +319,10 @@ describe.runIf(adminDsn !== "")("read db acceptance", () => {
         "handbook/security/setup",
       );
       // outline arm
-      const rows = await readWhole(TENANT, (c) => outline(c, scope, { depth: 2 }));
+      const rows = await readWhole(
+        TENANT,
+        async (c) => (await outline(c, scope, { depth: 2 })).rows,
+      );
       expect(rows.map((r) => r.headingPath)).not.toContain("handbook/onboarding/setup");
     } finally {
       await undeny();
@@ -329,8 +335,9 @@ describe.runIf(adminDsn !== "")("read db acceptance", () => {
         findDocument(c, { ...scope, tenantId: "globex" }, "onboarding/setup"),
       ),
     ).rejects.toBeInstanceOf(UnknownSlug);
-    const rows = await readWhole("globex", (c) =>
-      outline(c, { ...scope, tenantId: "globex" }, { depth: 2 }),
+    const rows = await readWhole(
+      "globex",
+      async (c) => (await outline(c, { ...scope, tenantId: "globex" }, { depth: 2 })).rows,
     );
     expect(rows).toEqual([]);
   });

--- a/packages/content/src/lib/read.test.ts
+++ b/packages/content/src/lib/read.test.ts
@@ -269,7 +269,10 @@ describe("outline() against a fake client", () => {
       "walk AS": { rows: [ANCHOR, CHILD], fields: OUTLINE_FIELDS },
       "up AS": { rows: [UP], fields: ["path", "climbed"] },
     });
-    const rows = await outline(client, SCOPE, { root: "getting-started/mode-2/phase-3", depth: 1 });
+    const { rows } = await outline(client, SCOPE, {
+      root: "getting-started/mode-2/phase-3",
+      depth: 1,
+    });
     expect(rows).toEqual([
       {
         slug: "lesson-a",
@@ -292,7 +295,7 @@ describe("outline() against a fake client", () => {
       "walk AS": { rows: [ANCHOR, CHILD], fields: OUTLINE_FIELDS },
       "up AS": { rows: [UP], fields: ["path", "climbed"] },
     });
-    const rows = await outline(client, SCOPE, { root: "phase-3", depth: 1 });
+    const { rows } = await outline(client, SCOPE, { root: "phase-3", depth: 1 });
     expect(rows[0]?.headingPath).toBe("getting-started/mode-2/phase-3/lesson-a");
     expect(rows[0]?.permalink, "width contract holds on the bare-slug path too").toBe(
       "/docs/lesson-a",
@@ -339,7 +342,7 @@ describe("outline() against a fake client", () => {
   it("browse (no root) returns the walk rows untouched", async () => {
     const log = { values: [] as unknown[][] };
     const client = fakeClient({ "walk AS": { rows: [ANCHOR], fields: OUTLINE_FIELDS } }, log);
-    const rows = await outline(client, SCOPE, {});
+    const { rows } = await outline(client, SCOPE, {});
     expect(rows.length).toBe(1);
     expect(rows[0]?.depth).toBe(0);
     // depth/limit clamps: defaults 0 and 200

--- a/packages/content/src/lib/read.test.ts
+++ b/packages/content/src/lib/read.test.ts
@@ -123,6 +123,7 @@ describe("rebaseOutlineRows (pure re-base)", () => {
     childCount: 1,
     hasContent: false,
     permalink: null,
+    generation: 1,
   };
   const childRow: OutlineRow = {
     slug: "lesson-a",
@@ -134,6 +135,7 @@ describe("rebaseOutlineRows (pure re-base)", () => {
     childCount: 0,
     hasContent: true,
     permalink: "/docs/lesson-a",
+    generation: 1,
   };
 
   it("prefixes from the anchor's OWN absolute path and skips the anchor row", () => {
@@ -219,6 +221,7 @@ const OUTLINE_FIELDS = [
   "child_count",
   "has_content",
   "permalink",
+  "generation",
 ];
 
 // NODE_BY_SLUG_SQL candidate: SEVEN columns. The oracle's six-wide fixture
@@ -239,8 +242,9 @@ const CANDIDATE = [
   null,
   null,
 ];
-// OUTLINE_SQL rows are NINE wide — the last is w.permalink (the prod scar).
-const ANCHOR = ["phase-3", "section", "Phase 3", "phase-3", 0, 0, "1", false, null];
+// OUTLINE_SQL rows are TEN wide — index 8 is w.permalink (the prod scar) and
+// index 9 is w.generation, which the §7 audit row pins.
+const ANCHOR = ["phase-3", "section", "Phase 3", "phase-3", 0, 0, "1", false, null, 1];
 const CHILD = [
   "lesson-a",
   "document",
@@ -251,6 +255,7 @@ const CHILD = [
   "0",
   true,
   "/docs/lesson-a",
+  1,
 ];
 const UP = ["getting-started/mode-2/phase-3", 2];
 
@@ -276,6 +281,7 @@ describe("outline() against a fake client", () => {
         childCount: 0,
         hasContent: true,
         permalink: "/docs/lesson-a",
+        generation: 1,
       },
     ]);
   });
@@ -404,7 +410,9 @@ describe("projection width contracts (the prod-crash class, made loud)", () => {
     expect(() => nodeRows(short)).toThrowError(
       new RegExp(`node projection drift: expected ${NODE_COLUMNS}`),
     );
-    expect(() => outlineRows(short)).toThrowError(/outline projection drift: expected 9/);
+    expect(() => outlineRows(short)).toThrowError(
+      new RegExp(`outline projection drift: expected ${OUTLINE_COLUMNS}`),
+    );
   });
 
   it("every read arm carries the v2 predicates", () => {

--- a/packages/content/src/lib/read.ts
+++ b/packages/content/src/lib/read.ts
@@ -510,6 +510,13 @@ export interface OutlineRow {
 
 export const OUTLINE_COLUMNS = 10;
 
+/** An outline, with the generation it was served from — which [] cannot carry. */
+export interface OutlineResult {
+  readonly rows: OutlineRow[];
+  /** Null only when nothing was ever published: no generation exists to pin. */
+  readonly generation: number | null;
+}
+
 export function outlineRows(result: pg.QueryArrayResult): OutlineRow[] {
   if (result.fields.length !== OUTLINE_COLUMNS) {
     throw new TypeError(
@@ -592,12 +599,19 @@ export interface OutlineOptions {
  * ROOT-ABSOLUTE depth + breadcrumb (the wire contract: rows are
  * self-locating; a leaf with no children returns an empty list — the
  * anchor itself is never echoed back).
+ *
+ * Returns the GENERATION it served from alongside the rows, because [] cannot
+ * carry one. A drill-down onto a leaf resolves its anchor and pins that
+ * generation, then returns no rows — and the tool description tells an agent to
+ * drill in, so that is a routine call, not an edge case. Reading the generation
+ * off `rows[0]` recorded NULL for every one of them. `content_served` sets the
+ * precedent: pin what was RESOLVED, however little came back.
  */
 export async function outline(
   client: pg.PoolClient,
   scope: ReadScope,
   options: OutlineOptions = {},
-): Promise<OutlineRow[]> {
+): Promise<OutlineResult> {
   const root = options.root ?? null;
   const depth = Math.max(0, options.depth ?? 0);
   const limit = Math.max(1, Math.min(options.limit ?? 200, OUTLINE_CEILING));
@@ -641,7 +655,11 @@ export async function outline(
     values: [scope.tenantId, scope.corpusId, pinned, anchor, depth, limit, offset],
   });
   const rows = outlineRows(result);
-  if (root === null) return rows;
+  // A BROWSE carries no pin — `OUTLINE_SQL` resolves the active generation
+  // itself from the `g` CTE, so the rows are where it surfaces. A DRILL-DOWN
+  // has `pinned` set from the resolved anchor and needs it, because a leaf
+  // returns no rows to read it off. Null only when neither exists.
+  if (root === null) return { rows, generation: pinned ?? rows[0]?.generation ?? null };
 
   const up = await arrayQuery(client, {
     text: UP_WALK_SQL,
@@ -656,5 +674,8 @@ export async function outline(
       `no node with slug ${JSON.stringify(root)} — browse from the root with outline() (omit node=)`,
     );
   }
-  return rebaseOutlineRows(rows, String(anchorRow[0]), toNumber(anchorRow[1], "climbed"));
+  return {
+    rows: rebaseOutlineRows(rows, String(anchorRow[0]), toNumber(anchorRow[1], "climbed")),
+    generation: pinned ?? rows[0]?.generation ?? null,
+  };
 }

--- a/packages/content/src/lib/read.ts
+++ b/packages/content/src/lib/read.ts
@@ -262,7 +262,8 @@ SELECT w.slug, w.kind, w.title, w.heading_path,
        EXISTS (SELECT 1 FROM sources s
                 WHERE s.tenant_id = $1 AND s.generation = w.generation
                   AND s.node_id = w.node_id) AS has_content,
-       w.permalink
+       w.permalink,
+       w.generation
 FROM walk w
 JOIN content_nodes n ON n.node_id = w.node_id AND n.tenant_id = $1
                     AND n.generation = w.generation
@@ -497,9 +498,17 @@ export interface OutlineRow {
    * re-base copies whole rows so a new column cannot be lost in one branch.
    */
   readonly permalink: string | null;
+  /**
+   * Column index 9. The act's own generation, so the §7 audit row can pin what
+   * it served from — `similarity_searched` and `content_served` both did and
+   * `outline_served` wrote NULL, leaving the one act that hands an agent the
+   * SHAPE of the record unjoinable to the publication it described (#19).
+   * Carried on the row rather than re-queried: `walk` already selects it.
+   */
+  readonly generation: number;
 }
 
-export const OUTLINE_COLUMNS = 9;
+export const OUTLINE_COLUMNS = 10;
 
 export function outlineRows(result: pg.QueryArrayResult): OutlineRow[] {
   if (result.fields.length !== OUTLINE_COLUMNS) {
@@ -518,6 +527,7 @@ export function outlineRows(result: pg.QueryArrayResult): OutlineRow[] {
     childCount: toNumber(row[6], "child_count"),
     hasContent: Boolean(row[7]),
     permalink: row[8] === null ? null : String(row[8]),
+    generation: toNumber(row[9], "generation"),
   }));
 }
 

--- a/packages/content/src/lib/takedown.db.test.ts
+++ b/packages/content/src/lib/takedown.db.test.ts
@@ -193,7 +193,10 @@ describe.runIf(adminDsn !== "")("scoped takedown (db)", () => {
       );
 
       // outline browse: docs' children exclude legal; child_count drops it
-      const rows = await readWhole(TENANT, (c) => outline(c, rscope, { depth: 3 }));
+      const rows = await readWhole(
+        TENANT,
+        async (c) => (await outline(c, rscope, { depth: 3 })).rows,
+      );
       const paths = rows.map((r) => r.headingPath);
       expect(paths, JSON.stringify(paths)).not.toContain("docs/legal");
       expect(paths).not.toContain("docs/legal/policy");

--- a/packages/content/src/lib/windowing.test.ts
+++ b/packages/content/src/lib/windowing.test.ts
@@ -221,9 +221,6 @@ const GOLDENS: Record<string, GoldenCase> = {
   },
 };
 
-// clean_cut goldens from the same extraction — outputs are the oracle's,
-// with CODE-POINT indices (the unicode rows shift under code-unit slicing).
-
 /** Walk a document to exhaustion via next cursors, mirroring the extraction script. */
 function walk(
   chunks: readonly DocumentChunk[],

--- a/packages/content/src/lib/windowing.test.ts
+++ b/packages/content/src/lib/windowing.test.ts
@@ -8,13 +8,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import {
-  cleanCut,
-  codePointLength,
-  estTokens,
-  windowDocument,
-  type DocumentChunk,
-} from "./windowing.js";
+import { codePointLength, estTokens, windowDocument, type DocumentChunk } from "./windowing.js";
 
 const mk = (ordinal: number, headingPath: string, content: string): DocumentChunk => ({
   ordinal,
@@ -229,22 +223,6 @@ const GOLDENS: Record<string, GoldenCase> = {
 
 // clean_cut goldens from the same extraction — outputs are the oracle's,
 // with CODE-POINT indices (the unicode rows shift under code-unit slicing).
-const CLEAN_CUT_GOLDENS: readonly { text: string; limit: number; out: string }[] = [
-  { text: "para one\n\npara two\n\npara three is long", limit: 25, out: "para one\n\npara two" },
-  { text: "short", limit: 100, out: "short" },
-  {
-    text: "\u{1f389}\u{1f389}\u{1f389} alpha\n\nbeta gamma delta\n\nepsilon zeta",
-    limit: 30,
-    out: "\u{1f389}\u{1f389}\u{1f389} alpha\n\nbeta gamma delta",
-  },
-  { text: "x".repeat(50), limit: 30, out: "x".repeat(30) },
-  { text: "ab\n\n" + "c".repeat(40), limit: 30, out: "ab\n\n" + "c".repeat(26) },
-  {
-    text: "\u{1f409}".repeat(20) + "\n\n" + "\u{1f409}".repeat(20),
-    limit: 25,
-    out: "\u{1f409}".repeat(20),
-  },
-];
 
 /** Walk a document to exhaustion via next cursors, mirroring the extraction script. */
 function walk(
@@ -282,12 +260,6 @@ describe("golden fixtures (oracle byte-parity)", () => {
       expect(concat).toBe(golden.chunks.map((c) => c.content).join(""));
     });
   }
-
-  it("replays the oracle clean_cut outputs, code-point indexed", () => {
-    for (const { text, limit, out } of CLEAN_CUT_GOLDENS) {
-      expect(cleanCut(text, limit), `limit=${limit} text=${JSON.stringify(text)}`).toBe(out);
-    }
-  });
 });
 
 describe("carried invariants (oracle test_windowing.py)", () => {

--- a/packages/content/src/lib/windowing.ts
+++ b/packages/content/src/lib/windowing.ts
@@ -174,25 +174,3 @@ export function windowDocument(
     remainingSections: remaining,
   };
 }
-
-/**
- * Back off to the last blank-line boundary in the second half; used by the
- * search response budget when a hit overflows (the caller stamps
- * `truncated` + a note — loud, never silent). Indices are CODE POINTS,
- * matching the oracle's Python slicing.
- */
-export function cleanCut(text: string, limit: number): string {
-  const points = Array.from(text);
-  if (points.length <= limit) return text;
-  // Python str.rfind("\n\n", limit // 2, limit): the whole "\n\n" must lie
-  // within [limit//2, limit), so the highest legal start index is limit - 2.
-  let cut = -1;
-  const floor = Math.floor(limit / 2);
-  for (let i = Math.min(limit, points.length) - 2; i >= floor; i -= 1) {
-    if (points[i] === "\n" && points[i + 1] === "\n") {
-      cut = i;
-      break;
-    }
-  }
-  return points.slice(0, cut !== -1 ? cut : limit).join("");
-}

--- a/packages/content/src/service.ts
+++ b/packages/content/src/service.ts
@@ -673,6 +673,12 @@ export async function search(ctx: ServiceContext, query: string, k = 10): Promis
       query_chars: queryChars,
       k,
       k_effective: kb,
+      // The score that DECIDED this answer. The abstained row has always
+      // carried it, so the ledger held the deciding score only for queries the
+      // gate refused — precisely the half that cannot show a floor drifting as
+      // a record grows (#182). Symmetric now: every act records what it was
+      // decided on, whichever way it went.
+      top_cosine: topCosine,
       slugs: [...new Set(shaped.map((h) => h.slug))],
       truncated,
       degraded: degradedReason !== undefined,
@@ -1049,6 +1055,10 @@ export async function outlineDocuments(
     actor,
     action: "outline_served",
     instanceDigest: ctx.instanceDigest,
+    // An EMPTY outline served no row from any generation, so it records NULL
+    // deliberately — the same spread-conditional `search_abstained` uses for
+    // the same reason.
+    ...(rows[0] === undefined ? {} : { generation: rows[0].generation }),
     detail: { ...actScope(ctx), node: root, result_count: rows.length, has_more, offset },
   });
   // Titles and heading paths are corpus-authored text and reach the agent

--- a/packages/content/src/service.ts
+++ b/packages/content/src/service.ts
@@ -1041,7 +1041,7 @@ export async function outlineDocuments(
   // A silently cut outline manufactures a false "not in the record" — the
   // agent asks for the structure, gets a partial list with no signal, and
   // concludes the document is absent (review 2026-08-20).
-  const rows = await runRead(
+  const { rows, generation } = await runRead(
     ctx.pool,
     inst.tenantId,
     (client) => outlineQuery(client, scope, { root, depth, limit: limit + 1, offset }),
@@ -1055,10 +1055,13 @@ export async function outlineDocuments(
     actor,
     action: "outline_served",
     instanceDigest: ctx.instanceDigest,
-    // An EMPTY outline served no row from any generation, so it records NULL
-    // deliberately — the same spread-conditional `search_abstained` uses for
-    // the same reason.
-    ...(rows[0] === undefined ? {} : { generation: rows[0].generation }),
+    // The generation the WALK was pinned to, not the first row's — a leaf
+    // drill-down resolves its anchor, pins that generation and returns [], and
+    // reading it off `rows[0]` recorded NULL for the commonest empty outline
+    // there is. `content_served` sets the precedent: pin what was resolved,
+    // however little came back. NULL survives for exactly one state — nothing
+    // has ever been published, so there is no generation to name.
+    ...(generation === null ? {} : { generation }),
     detail: { ...actScope(ctx), node: root, result_count: rows.length, has_more, offset },
   });
   // Titles and heading paths are corpus-authored text and reach the agent


### PR DESCRIPTION
Closes #19. Carries one carve-out from #182.

## Problem

`retrieval_log` exists so an operator can say what an act was allowed to see and
what it answered from (working rule 10: *what row exists afterwards proving they
did*). Two rows could not answer that.

**`outline_served` recorded no generation.** `similarity_searched` and
`content_served` both pin one — so the single act that hands an agent the SHAPE
of the record was the one that could not be joined to the publication it
described.

**An ANSWERED search recorded no `top_cosine`.** The abstained row has always
carried it, so the ledger held the deciding score only for queries the gate
**refused** — precisely the half that cannot show a floor drifting as a record
grows. Every answer above the floor went unrecorded, so nothing in the trail says
how close to it the record has been running.

## Solution

**Item 2 — a column, not a round trip.** `walk` already selects `generation`, so
`OUTLINE_SQL` projects it and `OUTLINE_COLUMNS` moves 9 → 10 under the width
guard that exists because a narrower fixture once hid a truncated projection in
production (`OutlineRow.permalink` carries that scar). An empty outline still
records NULL, deliberately — it served no row from any generation, the same
reason `search_abstained` records NULL when nothing matched.

**The #182 carve-out — one line, symmetric with the row beside it.** The
`calibrate --check` feature that issue proposes is deliberately NOT here: whether
`ingest` gates on it is an owner decision, and building before that answer risks
building the wrong shape. This is the half that needs no decision.

**Item 3 — `cleanCut` is deleted, not wired up.** Four reasons, in order of
weight:

1. **Working rule 9.** The oracle called `clean_cut` only from `_expand_grain` —
   the `grain=section` feature that expands a passage hit into whole node
   chunks. ksor has no grain parameter anywhere, so this is a mechanism carried
   across without the purpose it existed for.
2. **Skip-don't-cut is deliberate and documented**, and the caller already
   learns content was dropped, via the `note` field and `truncated`. The stated
   benefit exists in a form that damages nothing.
3. **Wiring it is a FEATURE, not a cleanup.** A cut passage under a `provenance`
   envelope naming `stable_id` + generation no longer matches the governed
   source byte-exact, so honesty would require a per-hit `truncated` flag in the
   search output schema, the FLOOR text, and the served-surface golden — a public
   MCP surface change, on the surface decision 23 calls the product.
4. **It is unreachable regardless.** `HARD_MAX_CHARS = 4000` against a
   120,000-char default budget, where only rank 0 can overflow and is exempt by
   design.

Its docstring described the search budget using it **in the present tense**, for
a caller that has never existed — a live working-rule-3 breach either way.

## Item 1 needs no code, and its premise was false in both directions

The issue says the oracle "has no manifest serializer to compare against" and
that its predicate would drop `""`. Checked against the oracle checkout at
`b554f91`: `_to_json` exists at `docusaurus_sidebar.py:410` — exactly where
ksor's own docstring already cites it — and its predicate
`v not in (None, (), 0) or k == "position"` **keeps `""`**, precisely as ksor's
does. The conversion is faithful and `instance_bundle_sha256` is safe. No change
is warranted; the finding is closed with the evidence rather than acted on.

## Behavior

Red first, in the db tier, both rows — each printing what it saw:

```
AssertionError: outline_served wrote generation=null: expected null to be '1'
AssertionError: answered row detail: {...}: expected 'undefined' to be 'number'
```

Verified against a real Postgres 17.7 with pgvector: **the full db tier passes,
38 files / 296 tests.** Plus 1527 unit and 580 integration.

The unit guard on the projection width is derived from `OUTLINE_COLUMNS` now
rather than hardcoding `9`, so the next column cannot leave a stale literal
behind.

## Out of scope

`#182`'s `ksor calibrate --check` — an owner decision (a flag nobody runs still
tells nobody; whether `ingest` gates on it decides whether it is an affordance or
a guarantee). `#139` and `#165` likewise, and #165's premise does not survive
checking — see the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)