### PR TITLE
Make role creation survive two concurrent schema applies

### DIFF
--- a/.changeset/schema-roles-survive-a-race.md
+++ b/.changeset/schema-roles-survive-a-race.md
@@ -1,0 +1,24 @@
+---
+"@panaversity/ksor": patch
+---
+
+**`ksor schema --apply` no longer fails when two run at once.**
+
+`schema.sql` creates three roles, and Postgres roles are CLUSTER-GLOBAL — so
+`IF NOT EXISTS ... THEN CREATE ROLE` is check-then-act across every database on
+the instance. Two concurrent applies both see the role absent and both create
+it. Measured on Postgres 17.7 against an empty cluster: **six concurrent applies,
+five failed.**
+
+The SQLSTATE that surfaces is `unique_violation` (23505) on
+`pg_authid_rolname_index`, **not** `duplicate_object` (42710) — catching only the
+latter is the obvious fix and does not work. Both are caught now.
+
+And each role is created in its **own** `DO` block. A `DO` block is a single
+statement, so an exception anywhere in it rolls the whole block back: three
+roles in one block meant a loser on the first never created the other two, and
+the apply then granted against roles that did not exist.
+
+This is not only a test-tier problem, which is why it lives in the DDL: two
+operators provisioning at once, or a deploy step racing a developer, hit it
+identically.

--- a/.changeset/schema-roles-survive-a-race.md
+++ b/.changeset/schema-roles-survive-a-race.md
@@ -2,7 +2,7 @@
 "@panaversity/ksor": patch
 ---
 
-**`ksor schema --apply` no longer fails when two run at once.**
+**`ksor schema --apply` no longer loses a ROLE when two run at once.**
 
 `schema.sql` creates three roles, and Postgres roles are CLUSTER-GLOBAL — so
 `IF NOT EXISTS ... THEN CREATE ROLE` is check-then-act across every database on
@@ -19,6 +19,15 @@ statement, so an exception anywhere in it rolls the whole block back: three
 roles in one block meant a loser on the first never created the other two, and
 the apply then granted against roles that did not exist.
 
+The same check-then-act sat in the 2.2 → 2.3 migration, which `ksor schema
+--apply` also reaches, and is fixed with it.
+
 This is not only a test-tier problem, which is why it lives in the DDL: two
 operators provisioning at once, or a deploy step racing a developer, hit it
 identically.
+
+**Scoped honestly:** what is fixed is role creation, which is the part that
+raced across SEPARATE databases — the shape two concurrent runs actually have.
+Two applies against the SAME database still race, on `CREATE EXTENSION` and then
+on table creation; `applySchema`'s contract is a fresh database and that is
+unchanged here.

--- a/packages/content/schema/migrations/2.2-2.3__takedown-writes-and-a-readable-ledger.sql
+++ b/packages/content/schema/migrations/2.2-2.3__takedown-writes-and-a-readable-ledger.sql
@@ -32,11 +32,14 @@ CREATE POLICY takedown_write ON takedown_denylist FOR ALL TO sor_content_ingest
                         AND g.tenant_id = takedown_denylist.tenant_id));
 
 -- ── retrieval_log: a role that can actually read the ledger ──────────────────
-DO $$
-BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'sor_content_auditor') THEN
-    CREATE ROLE sor_content_auditor NOLOGIN;
-  END IF;
+-- Concurrency-tolerant for the same reason `schema.sql` is: roles are
+-- CLUSTER-GLOBAL, so `IF NOT EXISTS` is check-then-act across every database on
+-- the instance, and the loser raises `unique_violation` (23505) on
+-- pg_authid_rolname_index — not `duplicate_object` (42710). Two `ksor schema
+-- --apply` runs reach this migration exactly as they reach the fresh DDL.
+DO $$ BEGIN
+  CREATE ROLE sor_content_auditor NOLOGIN;
+EXCEPTION WHEN duplicate_object OR unique_violation THEN NULL;
 END $$;
 
 GRANT USAGE ON SCHEMA public TO sor_content_auditor;

--- a/packages/content/schema/schema.sql
+++ b/packages/content/schema/schema.sql
@@ -324,12 +324,36 @@ CREATE TABLE ingest_tenant_grants (
     PRIMARY KEY (role_name, tenant_id)
 );
 
+-- Roles are CLUSTER-GLOBAL, so `IF NOT EXISTS` is check-then-act across every
+-- database on the instance: two concurrent applies both see the role absent and
+-- both create it. Measured on Postgres 17.7 — six concurrent runs against an
+-- empty cluster, FIVE failed. Two `ksor schema --apply` runs, or two `pnpm
+-- test:db` runs, are all it takes.
+--
+-- The raised SQLSTATE is `unique_violation` (23505) on pg_authid_rolname_index,
+-- NOT `duplicate_object` (42710) — catching only the latter is the intuitive
+-- fix and does not work. Both are caught, because which one surfaces depends on
+-- where in the create the loser lands.
+--
+-- ONE BLOCK PER ROLE, deliberately: a `DO` block is a single statement, so an
+-- exception anywhere in it rolls back the whole block. Three roles in one block
+-- means a loser on the first role never creates the other two, and the apply
+-- continues to GRANT against roles that do not exist.
 DO $$ BEGIN
-  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'sor_content_runtime') THEN CREATE ROLE sor_content_runtime NOLOGIN; END IF;
-  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'sor_content_ingest')  THEN CREATE ROLE sor_content_ingest NOLOGIN;  END IF;
-  -- The ledger's READER (2.3). Without it retrieval_log was write-only under
-  -- every credential ksor ships: FORCE RLS, an INSERT policy, and no way back in.
-  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'sor_content_auditor') THEN CREATE ROLE sor_content_auditor NOLOGIN; END IF;
+  CREATE ROLE sor_content_runtime NOLOGIN;
+EXCEPTION WHEN duplicate_object OR unique_violation THEN NULL;
+END $$;
+
+DO $$ BEGIN
+  CREATE ROLE sor_content_ingest NOLOGIN;
+EXCEPTION WHEN duplicate_object OR unique_violation THEN NULL;
+END $$;
+
+-- The ledger's READER (2.3). Without it retrieval_log was write-only under
+-- every credential ksor ships: FORCE RLS, an INSERT policy, and no way back in.
+DO $$ BEGIN
+  CREATE ROLE sor_content_auditor NOLOGIN;
+EXCEPTION WHEN duplicate_object OR unique_violation THEN NULL;
 END $$;
 
 -- Explicit in-schema membership for the APPLYING role, so SET LOCAL ROLE works from day one

--- a/packages/content/src/schema-concurrency.db.test.ts
+++ b/packages/content/src/schema-concurrency.db.test.ts
@@ -19,14 +19,20 @@
  */
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
+import { randomBytes } from "node:crypto";
 import pg from "pg";
 
 import { applySchema } from "./schema.js";
 
 const adminDsn = process.env["KSOR_DB_URL"] ?? "";
 
-/** Scratch databases for this suite, named so a leaked one is obviously ours. */
-const SCRATCH_PREFIX = "ksor_role_race_";
+/**
+ * Scratch databases for this suite: named so a leaked one is obviously ours,
+ * and UNIQUE per run. Fixed names would have made this suite the thing it is
+ * testing for — two concurrent `pnpm test:db` runs force-dropping each other's
+ * databases mid-apply, which is issue #166's own symptom.
+ */
+const SCRATCH_PREFIX = `ksor_role_race_${randomBytes(4).toString("hex")}_`;
 
 /** The admin DSN with its database swapped — `pg` has no API for this. */
 function dsnFor(dsn: string, database: string): string {
@@ -74,10 +80,11 @@ describe.runIf(adminDsn !== "")("applying the schema concurrently (db)", () => {
     // Six SEPARATE DATABASES, one apply each — which is the real shape: two
     // `pnpm test:db` runs, or two operators provisioning, each own their
     // database and share only the cluster-global roles. Racing six applies
-    // against ONE database instead would collide on `pg_type_typname_nsp_index`
-    // (every CREATE TABLE makes a row type), which is a different race and not
-    // one `applySchema` promises to survive — its contract is "a fresh
-    // database".
+    // against ONE database instead races too — on `pg_extension_name_index`
+    // first (`CREATE EXTENSION IF NOT EXISTS vector` is check-then-act as well),
+    // then on `pg_type_typname_nsp_index`, since every CREATE TABLE makes a row
+    // type. Those are different races and not ones `applySchema` promises to
+    // survive: its contract is "a fresh database".
     const names = Array.from({ length: 6 }, (_unused, i) => `${SCRATCH_PREFIX}${i}`);
     for (const name of names) {
       await admin.query(`DROP DATABASE IF EXISTS ${name} WITH (FORCE)`);
@@ -112,7 +119,11 @@ describe.runIf(adminDsn !== "")("applying the schema concurrently (db)", () => {
       ).toEqual([...ROLES].sort());
     } finally {
       await Promise.all(pools.map((pool) => pool.end()));
-      for (const name of names) await admin.query(`DROP DATABASE IF EXISTS ${name} WITH (FORCE)`);
+      for (const name of names) {
+        // Guarded like every other drop in this tier: a failed cleanup must not
+        // replace the assertion's own failure with its own.
+        await admin.query(`DROP DATABASE IF EXISTS ${name} WITH (FORCE)`).catch(() => undefined);
+      }
     }
   }, 120_000);
 });

--- a/packages/content/src/schema-concurrency.db.test.ts
+++ b/packages/content/src/schema-concurrency.db.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Two applies at once must both succeed.
+ *
+ * `schema.sql` creates three roles, and roles are CLUSTER-GLOBAL — so
+ * `IF NOT EXISTS ... THEN CREATE ROLE` is check-then-act across every database
+ * on the instance. Two concurrent runs both see the role absent and both create
+ * it. Measured on Postgres 17.7 before the fix: six concurrent applies against
+ * an empty cluster, FIVE failed.
+ *
+ * It is not only a test-tier problem, which is why this lives beside the schema
+ * rather than in a harness: `ksor schema --apply` runs the same DDL, so two
+ * operators provisioning at once, or a deploy step racing a developer, hit it
+ * identically (issue #166).
+ *
+ * The SQLSTATE that surfaces is `unique_violation` (23505) on
+ * `pg_authid_rolname_index`, NOT `duplicate_object` (42710). That matters
+ * because catching only `duplicate_object` is the obvious fix and does not
+ * work — which is what this test is here to keep true.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import pg from "pg";
+
+import { applySchema } from "./schema.js";
+
+const adminDsn = process.env["KSOR_DB_URL"] ?? "";
+
+/** Scratch databases for this suite, named so a leaked one is obviously ours. */
+const SCRATCH_PREFIX = "ksor_role_race_";
+
+/** The admin DSN with its database swapped — `pg` has no API for this. */
+function dsnFor(dsn: string, database: string): string {
+  const url = new URL(dsn);
+  url.pathname = `/${database}`;
+  return url.toString();
+}
+
+/** The roles `schema.sql` creates, in the order it creates them. */
+const ROLES = ["sor_content_runtime", "sor_content_ingest", "sor_content_auditor"] as const;
+
+describe.runIf(adminDsn !== "")("applying the schema concurrently (db)", () => {
+  let admin: pg.Pool;
+  /** Set when the roles could not be removed, which makes the race unreachable. */
+  let unreachable = "";
+
+  beforeAll(async () => {
+    admin = new pg.Pool({ connectionString: adminDsn, max: 1 });
+    try {
+      // The race only exists while the roles are ABSENT. Dropping them fails if
+      // anything in the cluster still holds a grant, which is a real state on a
+      // shared instance — so it is a skip with a stated reason, never a silent
+      // pass on a test that proved nothing.
+      await admin.query(`DROP ROLE IF EXISTS ${ROLES.join(", ")}`);
+    } catch (error) {
+      unreachable = error instanceof Error ? error.message : String(error);
+    }
+  }, 60_000);
+
+  afterAll(async () => {
+    await admin?.end();
+  });
+
+  it("six simultaneous applies all succeed, and every role exists after", async (ctx) => {
+    if (unreachable !== "") {
+      // A REAL skip, not a passing assertion. The race only exists while the
+      // roles are absent, and they cannot be dropped while any database in the
+      // cluster holds a grant — which is the normal state on a developer box
+      // that has run this tier before. Reported as skipped so it can never read
+      // as "the fix works"; CI gets a fresh service container, where it runs.
+      ctx.skip(`the roles could not be dropped, so the race is unreachable: ${unreachable}`);
+      return;
+    }
+
+    // Six SEPARATE DATABASES, one apply each — which is the real shape: two
+    // `pnpm test:db` runs, or two operators provisioning, each own their
+    // database and share only the cluster-global roles. Racing six applies
+    // against ONE database instead would collide on `pg_type_typname_nsp_index`
+    // (every CREATE TABLE makes a row type), which is a different race and not
+    // one `applySchema` promises to survive — its contract is "a fresh
+    // database".
+    const names = Array.from({ length: 6 }, (_unused, i) => `${SCRATCH_PREFIX}${i}`);
+    for (const name of names) {
+      await admin.query(`DROP DATABASE IF EXISTS ${name} WITH (FORCE)`);
+      await admin.query(`CREATE DATABASE ${name}`);
+    }
+    const pools = names.map(
+      (name) => new pg.Pool({ connectionString: dsnFor(adminDsn, name), max: 1 }),
+    );
+    try {
+      const results = await Promise.allSettled(pools.map((pool) => applySchema(pool, 1536)));
+      const rejected = results.flatMap((r) =>
+        r.status === "rejected"
+          ? [r.reason instanceof Error ? r.reason.message : String(r.reason)]
+          : [],
+      );
+      expect(
+        rejected,
+        `${rejected.length}/${pools.length} applies failed: ${rejected.join(" | ")}`,
+      ).toEqual([]);
+
+      // The apply that LOST the race must still have created the roles it did
+      // not create itself — three separate blocks, so a loser on the first does
+      // not abandon the other two and leave the GRANTs below pointing at
+      // nothing.
+      const present = await admin.query<{ rolname: string }>(
+        "SELECT rolname FROM pg_roles WHERE rolname = ANY($1) ORDER BY rolname",
+        [[...ROLES]],
+      );
+      expect(
+        present.rows.map((r) => r.rolname),
+        "every role the DDL grants against must exist after the race",
+      ).toEqual([...ROLES].sort());
+    } finally {
+      await Promise.all(pools.map((pool) => pool.end()));
+      for (const name of names) await admin.query(`DROP DATABASE IF EXISTS ${name} WITH (FORCE)`);
+    }
+  }, 120_000);
+});

--- a/packages/content/src/schema.integration.test.ts
+++ b/packages/content/src/schema.integration.test.ts
@@ -1,4 +1,5 @@
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
 
 import { describe, expect, it } from "vitest";
 
@@ -80,50 +81,95 @@ describe("renderSchema against the shipped DDL", () => {
 });
 
 /**
- * Role creation must survive two applies at once — asserted on the DDL's SHAPE,
- * because the live race is unreachable wherever the roles already exist.
+ * Role creation must survive two applies at once — on EVERY path that creates a
+ * role, asserted on the DDL's shape because the live race is unreachable
+ * wherever the roles already exist.
  *
  * Roles are CLUSTER-GLOBAL, so `IF NOT EXISTS ... THEN CREATE ROLE` is
  * check-then-act across every database on the instance. Measured on Postgres
- * 17.7 against an empty cluster: six concurrent applies, FIVE failed. Two
- * `ksor schema --apply` runs, or two `pnpm test:db` runs, are all it takes
- * (issue #166).
+ * 17.7 against an empty cluster: six concurrent applies, FIVE failed, raising
+ * `unique_violation` (23505) on pg_authid_rolname_index — NOT
+ * `duplicate_object` (42710), which is the intuitive one to catch and is not
+ * sufficient alone (issue #166).
  *
- * `schema-concurrency.db.test.ts` races it for real, and SKIPS wherever the
- * roles cannot be dropped — which is most developer machines. So this is the
- * guard that always runs: it pins the two properties the fix depends on, and
- * both are easy to undo by tidying.
+ * It scans `schema.sql` AND `schema/migrations/`, because the first version of
+ * this guard read only the fresh DDL and the identical race survived in the
+ * 2.2 -> 2.3 migration — `ksor schema --apply` reaches both.
+ *
+ * `schema-concurrency.db.test.ts` races it for real and SKIPS wherever the roles
+ * cannot be dropped, which is most developer machines. This is the guard that
+ * always runs.
  */
 describe("concurrent applies cannot lose a role", () => {
-  const roleBlocks = (): string[] =>
-    [...readFileSync(schemaSqlPath(), "utf8").matchAll(/DO \$\$[\s\S]*?END \$\$;/g)]
-      .map((m) => m[0])
-      .filter((block) => /CREATE ROLE/.test(block));
+  /** Every DDL file that can create a role, by path. */
+  const ddlFiles = (): { path: string; text: string }[] => {
+    const schema = schemaSqlPath();
+    const migrations = path.join(path.dirname(schema), "migrations");
+    return [
+      { path: schema, text: readFileSync(schema, "utf8") },
+      ...readdirSync(migrations)
+        .filter((name) => name.endsWith(".sql"))
+        .map((name) => ({
+          path: path.join(migrations, name),
+          text: readFileSync(path.join(migrations, name), "utf8"),
+        })),
+    ];
+  };
+
+  /** Every `DO $$ ... END $$;` block that creates a role, with its file. */
+  const roleBlocks = (): { path: string; block: string }[] =>
+    ddlFiles().flatMap(({ path: file, text }) =>
+      [...text.matchAll(/DO \$\$[\s\S]*?END \$\$;/g)]
+        .map((m) => m[0])
+        .filter((block) => /CREATE ROLE/.test(block))
+        .map((block) => ({ path: file, block })),
+    );
+
+  /**
+   * Every CREATE ROLE in the tree must be INSIDE one of those blocks. Without
+   * this, a role created by a bare statement — or inside a block shaped so the
+   * regex misses it — is simply not seen, and the two assertions below pass
+   * over an empty list.
+   */
+  it("every CREATE ROLE is inside a block this guard can see", () => {
+    const declared = ddlFiles().flatMap(({ path: file, text }) =>
+      [...text.matchAll(/CREATE ROLE/g)].map(() => file),
+    );
+    const covered = roleBlocks().flatMap(({ path: file, block }) =>
+      [...block.matchAll(/CREATE ROLE/g)].map(() => file),
+    );
+    expect(
+      covered.length,
+      `${declared.length} CREATE ROLE statements exist, ${covered.length} are inside a matched ` +
+        `DO block — unmatched files: ${[...new Set(declared)].join(", ")}`,
+    ).toBe(declared.length);
+    // ...and there is at least one, so a refactor that moves role creation out
+    // of SQL entirely fails loudly here rather than making this suite vacuous.
+    expect(declared.length, "no CREATE ROLE found at all").toBeGreaterThan(0);
+  });
 
   it("creates each role in its OWN block", () => {
     // One block per role, because a `DO` block is a single statement: an
     // exception anywhere in it rolls the whole block back, so a loser on the
-    // first role would never create the other two — and the GRANTs below would
-    // then name roles that do not exist.
-    const blocks = roleBlocks();
-    for (const block of blocks) {
+    // first role would never create the other two — and the GRANTs that follow
+    // would then name roles that do not exist. Verified live: with one role
+    // pre-existing, the one-block form created ONLY that role.
+    for (const { path: file, block } of roleBlocks()) {
       const created = [...block.matchAll(/CREATE ROLE/g)].length;
-      expect(created, `a block creates ${created} roles:\n${block}`).toBe(1);
+      expect(created, `${file}: a block creates ${created} roles:\n${block}`).toBe(1);
     }
-    expect(blocks.length, "one block per role the DDL grants against").toBe(3);
   });
 
-  it("tolerates BOTH SQLSTATEs a lost race raises", () => {
-    // `unique_violation` (23505) on pg_authid_rolname_index is what Postgres
-    // 17.7 actually raised in the measured run — NOT `duplicate_object`
-    // (42710), which is the intuitive one to catch and is not sufficient on its
-    // own. Which surfaces depends on where the loser lands, so both are named.
-    for (const block of roleBlocks()) {
-      expect(block, `role block without an exception handler:\n${block}`).toMatch(/EXCEPTION/);
-      expect(block, `role block does not tolerate unique_violation:\n${block}`).toMatch(
+  it("tolerates BOTH SQLSTATEs a lost race raises, in the handler itself", () => {
+    // Asserted on the EXCEPTION clause rather than on the block, so the words
+    // cannot be satisfied by a comment mentioning them.
+    for (const { path: file, block } of roleBlocks()) {
+      const handler = /EXCEPTION\s+WHEN([\s\S]*?)THEN/.exec(block)?.[1] ?? "";
+      expect(handler, `${file}: role block has no EXCEPTION handler:\n${block}`).not.toBe("");
+      expect(handler, `${file}: handler does not tolerate unique_violation: ${handler}`).toMatch(
         /unique_violation/,
       );
-      expect(block, `role block does not tolerate duplicate_object:\n${block}`).toMatch(
+      expect(handler, `${file}: handler does not tolerate duplicate_object: ${handler}`).toMatch(
         /duplicate_object/,
       );
     }

--- a/packages/content/src/schema.integration.test.ts
+++ b/packages/content/src/schema.integration.test.ts
@@ -78,3 +78,54 @@ describe("renderSchema against the shipped DDL", () => {
     expect(() => renderSchemaText(drifted, 768)).toThrowError(/expected the vector\(1536\)/);
   });
 });
+
+/**
+ * Role creation must survive two applies at once — asserted on the DDL's SHAPE,
+ * because the live race is unreachable wherever the roles already exist.
+ *
+ * Roles are CLUSTER-GLOBAL, so `IF NOT EXISTS ... THEN CREATE ROLE` is
+ * check-then-act across every database on the instance. Measured on Postgres
+ * 17.7 against an empty cluster: six concurrent applies, FIVE failed. Two
+ * `ksor schema --apply` runs, or two `pnpm test:db` runs, are all it takes
+ * (issue #166).
+ *
+ * `schema-concurrency.db.test.ts` races it for real, and SKIPS wherever the
+ * roles cannot be dropped — which is most developer machines. So this is the
+ * guard that always runs: it pins the two properties the fix depends on, and
+ * both are easy to undo by tidying.
+ */
+describe("concurrent applies cannot lose a role", () => {
+  const roleBlocks = (): string[] =>
+    [...readFileSync(schemaSqlPath(), "utf8").matchAll(/DO \$\$[\s\S]*?END \$\$;/g)]
+      .map((m) => m[0])
+      .filter((block) => /CREATE ROLE/.test(block));
+
+  it("creates each role in its OWN block", () => {
+    // One block per role, because a `DO` block is a single statement: an
+    // exception anywhere in it rolls the whole block back, so a loser on the
+    // first role would never create the other two — and the GRANTs below would
+    // then name roles that do not exist.
+    const blocks = roleBlocks();
+    for (const block of blocks) {
+      const created = [...block.matchAll(/CREATE ROLE/g)].length;
+      expect(created, `a block creates ${created} roles:\n${block}`).toBe(1);
+    }
+    expect(blocks.length, "one block per role the DDL grants against").toBe(3);
+  });
+
+  it("tolerates BOTH SQLSTATEs a lost race raises", () => {
+    // `unique_violation` (23505) on pg_authid_rolname_index is what Postgres
+    // 17.7 actually raised in the measured run — NOT `duplicate_object`
+    // (42710), which is the intuitive one to catch and is not sufficient on its
+    // own. Which surfaces depends on where the loser lands, so both are named.
+    for (const block of roleBlocks()) {
+      expect(block, `role block without an exception handler:\n${block}`).toMatch(/EXCEPTION/);
+      expect(block, `role block does not tolerate unique_violation:\n${block}`).toMatch(
+        /unique_violation/,
+      );
+      expect(block, `role block does not tolerate duplicate_object:\n${block}`).toMatch(
+        /duplicate_object/,
+      );
+    }
+  });
+});

--- a/vitest.db.config.ts
+++ b/vitest.db.config.ts
@@ -12,9 +12,14 @@ export default defineConfig({
     testTimeout: 60_000,
     hookTimeout: 180_000,
     // Suites get their own DATABASE, but Postgres ROLES are cluster-global:
-    // two suites applying schema.sql concurrently raced its idempotent
+    // two suites applying schema.sql concurrently raced its check-then-act
     // CREATE ROLE into a pg_authid duplicate-key error (found live in CI,
-    // 2026-08-19). The tier runs files serially.
+    // 2026-08-19). That cause is GONE — the DDL tolerates the race now, on
+    // both paths that create a role (issue #166) — and the setting stays,
+    // because it was never the only reason: 27 of these suites still bootstrap
+    // a scratch database under a FIXED name and drop it `WITH (FORCE)`, so two
+    // files running at once still terminate each other's connections. Removing
+    // this is that half of #166, not this one.
     fileParallelism: false,
   },
 });


### PR DESCRIPTION
Refs #166. This is that issue's blocker, and it turned out to be **product-facing
rather than test-only**.

## Problem

Postgres roles are **cluster-global**, so `IF NOT EXISTS ... THEN CREATE ROLE` is
check-then-act across every database on the instance. Two concurrent applies both
see the role absent and both create it.

Reproduced before fixing, Postgres 17.7, empty cluster — **six concurrent runs,
five failed**:

```
ERROR:  duplicate key value violates unique constraint "pg_authid_rolname_index"
DETAIL:  Key (rolname)=(sor_content_runtime) already exists.
  FAILED: 5 of 6
```

Two `ksor schema --apply` runs, two operators provisioning, or a deploy step
racing a developer all reach it — not just two `pnpm test:db` runs.

## Solution

**Both SQLSTATEs, not the obvious one.** What Postgres raised is
`unique_violation` (23505) on `pg_authid_rolname_index` — **not**
`duplicate_object` (42710). Catching only `duplicate_object` is the intuitive fix
and does not work; which one surfaces depends on where the loser lands, so both
are named.

**One block per role.** A `DO` block is a single statement, so an exception
anywhere in it rolls the whole block back. Three roles in one block meant a loser
on the first never created the other two — and the apply then granted against
roles that did not exist.

After the fix, **0 of 6 fail** and all three roles are present.

## Two tests, and why the second exists

**`schema-concurrency.db.test.ts`** races six applies across six **separate
databases** — the real shape, since concurrent runs each own a database and share
only the cluster-global roles. Racing six against *one* database instead collides
on `pg_type_typname_nsp_index` (every `CREATE TABLE` makes a row type), which is a
different race and not one `applySchema` promises to survive; its contract is "a
fresh database".

That test **skips** wherever the roles cannot be dropped — and they cannot be
while any database in the cluster holds a grant, which is most developer machines
after a single run. Its first version reported that as a **pass**. That is the
vacuous green this branch's sibling PRs keep catching, so it is a real
`ctx.skip()` with a stated reason now.

**So the durable guard is a shape assertion** in the integration tier, which
always runs: one `CREATE ROLE` per block, and both SQLSTATEs named. Verified red
against `main`'s schema —

```
AssertionError: a block creates 3 roles:
AssertionError: role block without an exception handler:
```

— and green against this one.

## Behavior

Full gate: 1528 unit, 582 integration, and **the whole db tier against a real
Postgres 17.7 with pgvector — 39 files, 294 passing**.

## Out of scope, deliberately

The **27 db suites that still use fixed database names**. The issue is explicit
that renaming alone does not fix concurrency, and this role race is the part that
failed *regardless* of naming — so it is the right first cut. Also untouched:
`migrate.db.test.ts`, whose stable per-admin-DSN name carries a recorded live
incident that should be read before anyone changes it. A reaper for leaked
per-run databases is the third half and is not here either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)