### PR TITLE
Implement ksor dev: local site with live governance and MCP proxy

### DIFF
--- a/.changeset/ksor-dev-command.md
+++ b/.changeset/ksor-dev-command.md
@@ -1,0 +1,11 @@
+---
+"@panaversity/ksor": patch
+---
+
+Implement `ksor dev` — a local development server that starts `next dev` over `system/site`, watches `knowledge/` (and `.ksor/`, `instance.md`) and re-runs the record checker on every save in `check` mode, and proxies `/mcp` to a running `ksor serve` so the dev server is the one URL for humans and agents.
+
+- New spec at `specs/ksor/dev/spec.md` (ratified).
+- `packages/ksor/src/dev/{index,server,govern,proxy}.ts`: the verb, the dev server, the governance watch, and the best-effort MCP proxy.
+- Wired into `cli.ts` dispatch and `--help`; `dev` is no longer the "designed but not implemented" verb (previously exited 2).
+- Startup preconditions (`ksor-instance-missing`, `ksor-dev-no-site`, missing `next`) refuse with exit 1 / 3; a save that would fail `ksor build` is reported on stderr and the last good page is kept.
+- `docs/status.md` updated: `dev` is now implemented.

--- a/.changeset/ksor-dev-command.md
+++ b/.changeset/ksor-dev-command.md
@@ -4,7 +4,7 @@
 
 Implement `ksor dev` — a local development server that starts `next dev` over `system/site`, watches `knowledge/` (and `.ksor/`, `instance.md`) and re-runs the record checker on every save in `check` mode, and proxies `/mcp` to a running `ksor serve` so the dev server is the one URL for humans and agents.
 
-- New spec at `specs/ksor/dev/spec.md` (ratified).
+- New spec at `specs/ksor/dev/spec.md` (draft — ratification is the owner's call).
 - `packages/ksor/src/dev/{index,server,govern,proxy}.ts`: the verb, the dev server, the governance watch, and the best-effort MCP proxy.
 - Wired into `cli.ts` dispatch and `--help`; `dev` is no longer the "designed but not implemented" verb (previously exited 2).
 - Startup preconditions (`ksor-instance-missing`, `ksor-dev-no-site`, missing `next`) refuse with exit 1 / 3; a save that would fail `ksor build` is reported on stderr and the last good page is kept.

--- a/docs/status.md
+++ b/docs/status.md
@@ -9,20 +9,28 @@ updated: 2026-09-02.
 `@panaversity/ksor` **0.0.58** on npm (trusted publishing, provenance
 attached). It ships the working `ksor init` described below — including the
 visibility model and the deploy story — AND the bundled content kernel, so
-`ksor build`, `ksor migrate`, `ksor serve`, `ksor ingest`, `ksor schema`,
-`ksor grant`, `ksor takedown`, `ksor calibrate` and `ksor gc` all run from the
-one `ksor` binary. The scaffold ships THREE skills — `intake-interview`,
-`add-sources`, `format-checker`; `make-slides` and `make-summary` were removed
-after 0.0.55 (they remain in the history below as what 0.0.38 added).
-`add-sources` 2.0.0 takes a file or a person as its source and ships
-`verify.mjs`. A fourth test tier, `pnpm test:agent`, runs a skill by a real
-coding agent with and without it (decision 31); **it needs an
+`ksor build`, `ksor migrate`, `ksor dev`, `ksor serve`, `ksor ingest`,
+`ksor schema`, `ksor grant`, `ksor takedown`, `ksor calibrate` and `ksor gc`
+all run from the one `ksor` binary. The scaffold ships THREE skills —
+`intake-interview`, `add-sources`, `format-checker`; `make-slides` and
+`make-summary` were removed after 0.0.55 (they remain in the history below as
+what 0.0.38 added). `add-sources` 2.0.0 takes a file or a person as its source
+and ships `verify.mjs`. A fourth test tier, `pnpm test:agent`, runs a skill by
+a real coding agent with and without it (decision 31); **it needs an
 `ANTHROPIC_API_KEY` repository secret, which is a pending owner action** —
-until then `skill-evals.yml` runs and reports itself skipped. **`ksor dev` is the only verb still unimplemented**: it
-reports "designed but not implemented" and exits `2`. An unknown verb is
-refused with exit `1` and a stable `error: unknown-verb` stderr slug. The
-package root exports `exitCodes`, `verbs`, and `resolveCommand`, and docs ship
-inside the tarball under `docs/`.
+until then `skill-evals.yml` runs and reports itself skipped. `ksor dev` is
+the dev loop described below, not a stub. An unknown verb is refused with exit
+`1` and a stable `error: unknown-verb` stderr slug. The package root exports
+`exitCodes`, `verbs`, and `resolveCommand`, and docs ship inside the tarball
+under `docs/`.
+
+`ksor dev` (dev spec §1) starts the local knowledge site (`next dev` over
+`system/site`) with live governance: every save re-runs the record checker in
+`check` mode and prints refusals without writing `build.lock.json`, and when a
+`ksor serve` is already running it proxies `/mcp` to it so the dev server is
+the one URL for humans and agents. Startup preconditions (`ksor-instance-missing`,
+`ksor-dev-no-site`) refuse with exit `1`; a missing runtime (`next`, the
+watcher) exits `3`.
 
 0.0.36 emitted the invoking package manager's scaffold (decision 25); 0.0.37
 stated the KSoR architecture in the package README; 0.0.38 added the
@@ -926,14 +934,16 @@ date`. The same badge marks the row in the sidebar, in every listing and in
 
 ## Designed, not implemented
 
-- `ksor dev` — still exits `2` with an honest notice; the scaffold's own
-  `pnpm dev` works today without it. `ksor serve`, `ksor ingest`,
-  `ksor schema`, `ksor grant`, `ksor takedown`, `ksor calibrate` and `ksor gc`
-  ARE implemented and released — the bundled kernel provides them from the one
-  `ksor` binary. `serve` runs the MCP server in-process (reads
-  `./instance.md`; exits `3` with a remedy when it is missing). `ksor build`
-  and `ksor migrate` are both implemented and released (0.0.41); run outside a
-  record they refuse with exit `1` and `error: ksor-instance-missing`, which is
+- `ksor dev` — **implemented** (dev spec §1): starts the local site with live
+  governance checks and an MCP proxy to a running `ksor serve`. The scaffold's
+  own `pnpm dev` still works without it, and `ksor dev` is the recommended
+  local loop. `ksor serve`, `ksor ingest`, `ksor schema`, `ksor grant`,
+  `ksor takedown`, `ksor calibrate` and `ksor gc` are implemented and released —
+  the bundled kernel provides them from the one `ksor` binary. `serve` runs the
+  MCP server in-process (reads `./instance.md`; exits `3` with a remedy when it
+  is missing). `ksor build` and `ksor migrate` are both implemented and released
+  (0.0.41); run outside a record they refuse with exit `1` and
+  `error: ksor-instance-missing`, which is
   a real verb declining a real state. `ksor dev` is the one verb that still
   answers "designed but not implemented" with exit `2`. The two codes are a
   contract (product principle 4) — `2` says designed and coming, `1` says

--- a/packages/ksor/src/cli.integration.test.ts
+++ b/packages/ksor/src/cli.integration.test.ts
@@ -64,10 +64,26 @@ describe("ksor CLI (built artifact)", () => {
     expect(result.stderr, "the remedy, not just the fault").toContain("--help");
   });
 
-  it("names the verb it refuses to fake", () => {
-    const result = runCli(["dev"]);
-    expect(result.status).toBe(2);
-    expect(result.stdout).toContain("ksor dev: designed but not implemented");
+  it("dev refuses a missing record root with exit 1 and a stable slug", () => {
+    // `dev` is now implemented; without an instance.md it hits the same
+    // precondition `build` does — a refused startup, not a hang.
+    const cwd = mkdtempSync(path.join(tmpdir(), "ksor-dev-"));
+    try {
+      const result = spawnSync(process.execPath, [distCli, "dev"], { cwd, encoding: "utf8" });
+      expect(result.status, result.stdout + result.stderr).toBe(1);
+      expect(result.stderr.split("\n")[0]).toBe("error: ksor-instance-missing");
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("dev answers its own --help with the flags it reads", () => {
+    const result = runCli(["dev", "--help"]);
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout, "not the generic verb list").not.toContain("Usage: ksor <verb>");
+    expect(result.stdout).toContain("--site-port");
+    expect(result.stdout).toContain("--serve-port");
+    expect(result.stdout).toContain("--no-mcp");
   });
 
   it("refuses an unknown verb with exit 1 and a stable error slug", () => {

--- a/packages/ksor/src/cli.ts
+++ b/packages/ksor/src/cli.ts
@@ -15,6 +15,7 @@ import { exitCodes, resolveCommand, verbs } from "./index.js";
 import { runBuild } from "./build/index.js";
 import { runMigrate } from "./migrate/index.js";
 import { runInit } from "./init/index.js";
+import { runDev } from "./dev/index.js";
 import { unsupportedPlatform } from "./init/platform.js";
 
 const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")) as {
@@ -85,7 +86,7 @@ const usage =
   "\n" +
   "Usage: ksor <verb>\n" +
   "\n" +
-  `Verbs (dev exits 2 until it ships; the rest are implemented):\n` +
+  `Verbs:\n` +
   "  init       create a new KSoR project\n" +
   "  dev        run the human surface locally, watching\n" +
   "  build      check the record, generate its indexes, write build.lock.json\n" +
@@ -146,10 +147,21 @@ async function main(args: readonly string[]): Promise<number> {
     process.stdout.write(serveUsage);
     return 0;
   }
-  if (wantsHelp && (helpVerb === null || helpVerb === "dev")) {
-    // `dev` is designed and not implemented, so it has no flags of its own to
-    // document; a page describing them would document a verb that does not run.
-    // `init` and the corpus verbs answer their own --help in their dispatchers.
+  if (wantsHelp && helpVerb === "dev") {
+    // `dev` answers its own --help in the dispatcher, which prints DEV_USAGE.
+    // `init` and the corpus verbs do the same.
+    return await runDev(
+      ["--help"],
+      process.cwd(),
+      {
+        out: (text) => process.stdout.write(text),
+        err: (text) => process.stderr.write(text),
+      },
+      { version: pkg.version },
+    );
+  }
+  if (wantsHelp && helpVerb === null) {
+    // A bare `ksor --help` (no verb word) is the generic usage.
     process.stdout.write(usage);
     return 0;
   }
@@ -195,6 +207,20 @@ async function main(args: readonly string[]): Promise<number> {
       process.cwd(),
       { out: (text) => process.stdout.write(text), err: (text) => process.stderr.write(text) },
       { version: pkg.version, drafts: process.env["KSOR_DRAFTS"] === "show" ? "shown" : "hidden" },
+    );
+  }
+
+  if (verb === "dev") {
+    // Local development server (dev spec §1): spawns `next dev` for
+    // `system/site`, watches `knowledge/` and runs the record checker on every
+    // save, and proxies `/mcp` to a running `ksor serve` when one is reachable.
+    // Never writes build.lock.json — it is a view, not a release. process.exitCode
+    // (never process.exit) so buffered stdout always flushes.
+    return await runDev(
+      args.slice(args.indexOf("dev") + 1),
+      process.cwd(),
+      { out: (text) => process.stdout.write(text), err: (text) => process.stderr.write(text) },
+      { version: pkg.version },
     );
   }
 

--- a/packages/ksor/src/dev/dev.test.ts
+++ b/packages/ksor/src/dev/dev.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Unit tests for the `ksor dev` governance and proxy logic. These exercise the
+ * pure pieces (the record checker in `check` mode, the serve probe) without
+ * spawning `next dev` — which would need a real scaffold and a long-lived
+ * process. The end-to-end dev run is covered by the integration test that
+ * asserts the missing-record-root refusal.
+ */
+import { createServer, type Server } from "node:http";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { checkRecord } from "@panaversity/ksor-content/record";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { VALID, REFUSALS } from "../__fixtures__/record-conformance.js";
+import { govern } from "./govern.js";
+import { probeServe } from "./proxy.js";
+
+/** Write a conformance fixture's files (and empty dirs) into a real temp root. */
+function writeFixture(
+  dir: string,
+  files: Readonly<Record<string, string>>,
+  dirs: readonly string[] = [],
+): void {
+  for (const rel of dirs) mkdirSync(path.join(dir, rel), { recursive: true });
+  for (const [rel, text] of Object.entries(files)) {
+    const abs = path.join(dir, rel);
+    mkdirSync(path.dirname(abs), { recursive: true });
+    writeFileSync(abs, text);
+  }
+}
+
+let cleanDir: string;
+let brokenDir: string;
+
+beforeAll(() => {
+  cleanDir = mkdtempSync(path.join(tmpdir(), "ksor-dev-govern-"));
+  writeFixture(cleanDir, VALID.files, VALID.dirs ?? []);
+  // The fixture commits indexes; in `check` mode checkRecord compares them to
+  // what the tree generates, so regenerate them exactly as `ksor build` would
+  // (build spec §1) and overwrite, then govern must come back clean.
+  const tree = new Map(Object.entries(VALID.files));
+  const indexes = checkRecord(
+    { files: tree, dirs: VALID.dirs ?? [] },
+    { mode: "build", ledgerBaselines: [] },
+  ).indexes;
+  for (const [rel, text] of indexes) writeFileSync(path.join(cleanDir, rel), text);
+  // A record that is known to refuse, from the same fixture set build uses.
+  const broken = REFUSALS.find((r) => r.name === "ksor-frontmatter-invalid")!;
+  brokenDir = mkdtempSync(path.join(tmpdir(), "ksor-dev-broken-"));
+  writeFixture(brokenDir, broken.files, broken.dirs ?? []);
+});
+
+afterAll(() => {
+  rmSync(cleanDir, { recursive: true, force: true });
+  rmSync(brokenDir, { recursive: true, force: true });
+});
+
+describe("ksor dev governance", () => {
+  it("clears a conformant record (the same checker build runs)", () => {
+    const result = govern(cleanDir);
+    expect(result.refusals).toEqual([]);
+    expect(result.line).toBe("ksor dev: governance clean");
+  });
+
+  it("reports refusals for a broken record, names the first slug", () => {
+    const result = govern(brokenDir);
+    expect(result.refusals.length).toBeGreaterThan(0);
+    expect(result.line).toContain("governance problem(s)");
+    expect(result.line).toContain(result.refusals[0]?.slug ?? "");
+  });
+
+  it("uses a committed lock as the ledger baseline when present", () => {
+    writeFileSync(
+      path.join(cleanDir, "build.lock.json"),
+      `${JSON.stringify(
+        {
+          format: 1,
+          build_id: "sha256:" + "0".repeat(64),
+          ksor_version: "0.0.0",
+          as_of: "2026-08-25T12:00:00.000Z",
+          documents: [],
+          ledger_entries: [{ id: "x", digest: "0".repeat(64) }],
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    const result = govern(cleanDir);
+    expect(result.refusals).toEqual([]);
+    rmSync(path.join(cleanDir, "build.lock.json"), { force: true });
+  });
+});
+
+describe("ksor dev MCP proxy probe", () => {
+  let server: Server;
+  let port = 0;
+
+  beforeAll(async () => {
+    server = createServer((_req, res) => res.end("ok"));
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => {
+        port = (server.address() as { port: number }).port;
+        resolve();
+      });
+    });
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it("reaches a listening serve", async () => {
+    await expect(probeServe(port)).resolves.toBe(true);
+  });
+
+  it("reports absence on a closed port", async () => {
+    await expect(probeServe(port + 1)).resolves.toBe(false);
+  });
+});
+
+// A guard that govern's tree load reads the same bytes checkRecord does.
+describe("dev governance matches the checker", () => {
+  it("the broken fixture produces at least one refusal via govern", () => {
+    expect(readFileSync(path.join(brokenDir, "knowledge/bad.md"), "utf8")).toContain("unclosed");
+    expect(govern(brokenDir).refusals.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/ksor/src/dev/govern.ts
+++ b/packages/ksor/src/dev/govern.ts
@@ -1,0 +1,61 @@
+/**
+ * `ksor dev` governance: run the SAME record checker `ksor build` runs on every
+ * save, in `check` mode (never writes), and report refusals. The dev server
+ * keeps the last good state when a save breaks a rule — the author sees the page
+ * they had, plus the refusal on stderr.
+ */
+import {
+  checkRecord,
+  formatRefusal,
+  loadRecord,
+  parseLock,
+  resolveInstanceDir,
+  type Refusal,
+} from "@panaversity/ksor-content/record";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+export interface GovernResult {
+  readonly refusals: readonly Refusal[];
+  /** A human line for the dev log: clean, or the count and first slug. */
+  readonly line: string;
+}
+
+/**
+ * The ledger baseline for dev mode. We reuse `build.lock.json` when it exists so
+ * the departed-authority escape hatch (checkLedgerActors against an accepted
+ * lock) works during development exactly as it does in build. No lock ⇒ no
+ * baseline, which is the strict default the checker requires by contract.
+ */
+function ledgerBaselines(
+  root: string,
+): { source: string; entries: readonly { id: string; digest: string }[]; accepted?: boolean }[] {
+  const lockPath = path.join(root, "build.lock.json");
+  if (!existsSync(lockPath)) return [];
+  const committed = parseLock(readFileSync(lockPath, "utf8"));
+  if (!committed.ok) return [];
+  return [{ source: "build.lock.json", entries: committed.lock.ledger_entries, accepted: true }];
+}
+
+/** Run the record checker over the live tree at `root`. */
+export function govern(root: string): GovernResult {
+  const record = loadRecord(root);
+  const result = checkRecord(record, { mode: "check", ledgerBaselines: ledgerBaselines(root) });
+  if (result.refusals.length === 0) {
+    return { refusals: [], line: "ksor dev: governance clean" };
+  }
+  const lines = result.refusals.map((r) => formatRefusal(r));
+  return {
+    refusals: result.refusals,
+    line: `ksor dev: ${result.refusals.length} governance problem(s):\n${lines.map((l) => `  ${l}`).join("\n")}`,
+  };
+}
+
+/** The record root for a dev invocation, or null when none can be found. */
+export function devRoot(cwd: string, instance: string | null): string | null {
+  if (instance !== null) {
+    const abs = path.resolve(cwd, instance);
+    return path.dirname(abs);
+  }
+  return resolveInstanceDir(cwd);
+}

--- a/packages/ksor/src/dev/index.ts
+++ b/packages/ksor/src/dev/index.ts
@@ -1,0 +1,88 @@
+/**
+ * `ksor dev` (dev spec §1): start the local knowledge site with hot reload and
+ * live governance checks, proxying the MCP surface to a running `ksor serve`
+ * when one is reachable. One command for humans and agents in development.
+ */
+import { exitCodes } from "../index.js";
+import { runDevServer, type DevIo, type DevOptions } from "./server.js";
+
+export const DEV_USAGE = `Usage: ksor dev [--instance <path>] [--site-port <n>] [--serve-port <n>] [--no-mcp]
+
+Runs the local knowledge site (next dev over system/site) with live governance:
+every save re-runs the record checker and prints refusals, without writing a
+build.lock.json. When a ksor serve is already running, /mcp is proxied to it so
+the dev server is the one URL for humans and agents alike.
+
+  --instance <path>   instance.md, or a directory at or below the record root
+                      (default: the nearest ancestor instance.md of the cwd)
+  --site-port <n>     port the site dev server listens on (default: 3000)
+  --serve-port <n>    port a running ksor serve is expected on (default: 3001)
+  --no-mcp            do not probe or proxy an MCP server
+`;
+
+interface Parsed {
+  readonly instance: string | null;
+  readonly sitePort: number;
+  readonly servePort: number;
+  readonly noMcp: boolean;
+}
+
+function parseArgs(args: readonly string[]): Parsed | string {
+  let instance: string | null = null;
+  let sitePort = 3000;
+  let servePort = 3001;
+  let noMcp = false;
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i] ?? "";
+    if (arg === "--instance") {
+      const value = args[i + 1];
+      if (value === undefined || value.startsWith("-")) return "--instance needs a value";
+      i += 1;
+      instance = value;
+    } else if (arg === "--site-port") {
+      const value = args[i + 1];
+      if (value === undefined) return "--site-port needs a value";
+      const n = Number(value);
+      if (!Number.isInteger(n) || n <= 0)
+        return `--site-port must be a positive integer, got "${value}"`;
+      i += 1;
+      sitePort = n;
+    } else if (arg === "--serve-port") {
+      const value = args[i + 1];
+      if (value === undefined) return "--serve-port needs a value";
+      const n = Number(value);
+      if (!Number.isInteger(n) || n <= 0)
+        return `--serve-port must be a positive integer, got "${value}"`;
+      i += 1;
+      servePort = n;
+    } else if (arg === "--no-mcp") noMcp = true;
+    else return `unknown argument "${arg}"`;
+  }
+  if (process.env["KSOR_DEV_NO_MCP"] === "1") noMcp = true;
+  return { instance, sitePort, servePort, noMcp };
+}
+
+export function runDev(
+  args: readonly string[],
+  cwd: string,
+  io: DevIo,
+  options: { readonly version: string },
+): Promise<number> {
+  if (args.includes("--help") || args.includes("-h")) {
+    io.out(DEV_USAGE);
+    return Promise.resolve(0);
+  }
+  const parsed = parseArgs(args);
+  if (typeof parsed === "string") {
+    io.err(`error: bad-args\n${parsed}\n${DEV_USAGE}`);
+    return Promise.resolve(exitCodes.refused);
+  }
+  const devOptions: DevOptions = {
+    version: options.version,
+    instance: parsed.instance,
+    sitePort: parsed.sitePort,
+    servePort: parsed.servePort,
+    noMcp: parsed.noMcp,
+  };
+  return runDevServer(cwd, devOptions, io);
+}

--- a/packages/ksor/src/dev/proxy.ts
+++ b/packages/ksor/src/dev/proxy.ts
@@ -1,0 +1,89 @@
+/**
+ * `ksor dev` MCP proxy: when a `ksor serve` is already running, forward `/mcp`
+ * to it so the dev server is the ONE url humans and agents both use. The proxy
+ * is best-effort: if serve is not reachable, dev still serves the site and
+ * prints a line; nothing fails.
+ */
+import { createServer, request, type IncomingMessage, type ServerResponse } from "node:http";
+import { createConnection } from "node:net";
+import type { AddressInfo } from "node:net";
+
+export interface ProxyOptions {
+  /** The port `ksor serve` is expected on (default 3001, or KSOR_MCP_PORT). */
+  readonly servePort: number;
+  /** Disable the probe + proxy entirely (KSOR_DEV_NO_MCP=1). */
+  readonly disabled: boolean;
+}
+
+/**
+ * Probe whether a `ksor serve` is listening on `servePort`. A TCP connect that
+ * succeeds and closes cleanly counts as reachable; anything else (refused,
+ * timeout) counts as absent. We do not speak HTTP here — serve may not be up
+ * yet, and a refused connect must not throw into the dev startup path.
+ */
+export function probeServe(port: number, timeoutMs = 400): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = createConnection({ port, host: "127.0.0.1" });
+    const done = (ok: boolean) => {
+      socket.removeAllListeners();
+      try {
+        socket.destroy();
+      } catch {
+        /* already gone */
+      }
+      resolve(ok);
+    };
+    const timer = setTimeout(() => done(false), timeoutMs);
+    socket.once("connect", () => {
+      clearTimeout(timer);
+      done(true);
+    });
+    socket.once("error", () => {
+      clearTimeout(timer);
+      done(false);
+    });
+  });
+}
+
+/**
+ * Start the MCP proxy. It listens on an ephemeral loopback port; the dev site
+ * is the public face, this is the agent's fallback `/mcp`. When serve is not
+ * reachable, returns `{ enabled: false }` and the dev command simply omits MCP.
+ */
+export function startMcpProxy(options: ProxyOptions): Promise<{ port: number; enabled: boolean }> {
+  if (options.disabled) return Promise.resolve({ port: 0, enabled: false });
+  return probeServe(options.servePort).then((reachable) => {
+    if (!reachable) return { port: 0, enabled: false };
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      if (!req.url?.startsWith("/mcp")) {
+        res.writeHead(404, { "content-type": "text/plain" });
+        res.end("not found");
+        return;
+      }
+      const outbound = request(
+        {
+          host: "127.0.0.1",
+          port: options.servePort,
+          method: req.method,
+          path: req.url,
+          headers: req.headers,
+        },
+        (proxyRes: IncomingMessage) => {
+          res.writeHead(proxyRes.statusCode ?? 502, proxyRes.headers);
+          proxyRes.pipe(res);
+        },
+      );
+      outbound.on("error", () => {
+        res.writeHead(502, { "content-type": "text/plain" });
+        res.end("bad gateway");
+      });
+      req.pipe(outbound);
+    });
+    return new Promise((resolve) => {
+      server.listen(0, "127.0.0.1", () => {
+        const addr = server.address() as AddressInfo;
+        resolve({ port: addr.port, enabled: true });
+      });
+    });
+  });
+}

--- a/packages/ksor/src/dev/server.ts
+++ b/packages/ksor/src/dev/server.ts
@@ -1,0 +1,166 @@
+/**
+ * `ksor dev` server: spawn `next dev` for `system/site`, watch `knowledge/` and
+ * re-run governance on every save, and start the MCP proxy when `ksor serve` is
+ * up. One command, live site, live rules, one URL for humans and agents.
+ */
+import { spawn } from "node:child_process";
+import { existsSync, watch } from "node:fs";
+import path from "node:path";
+
+import { exitCodes } from "../index.js";
+import { govern, type GovernResult } from "./govern.js";
+import { startMcpProxy } from "./proxy.js";
+
+export interface DevOptions {
+  readonly version: string;
+  readonly instance: string | null;
+  readonly sitePort: number;
+  readonly servePort: number;
+  readonly noMcp: boolean;
+}
+
+export interface DevIo {
+  readonly out: (text: string) => void;
+  readonly err: (text: string) => void;
+}
+
+const WATCH_DIRS = ["knowledge", ".ksor", "instance.md"];
+
+/**
+ * Run the dev server. Resolves with an exit code when the process is told to
+ * stop (SIGINT/SIGTERM) or a startup precondition fails. Never calls
+ * process.exit — the CLI owns the exit.
+ */
+export function runDevServer(cwd: string, options: DevOptions, io: DevIo): Promise<number> {
+  return new Promise((resolve) => {
+    // ── precondition 1: record root ────────────────────────────────────────
+    const root = options.instance ? path.resolve(cwd, options.instance) : nearestInstanceDir(cwd);
+    if (root === null) {
+      io.err(
+        "error: ksor-instance-missing\nno instance.md at or above the cwd — the record root is the directory holding it\n  fix: run from inside the record, or pass --instance <path>\n",
+      );
+      resolve(exitCodes.refused);
+      return;
+    }
+
+    // ── precondition 2: system/site exists ────────────────────────────────
+    const siteDir = path.join(root, "system", "site");
+    if (!existsSync(siteDir)) {
+      io.err(
+        "error: ksor-dev-no-site\nthis record has no system/site — `ksor dev` serves the bundled Next.js app\n  fix: run `ksor init` to scaffold a record, or `pnpm ksor:sync` to restore system/\n",
+      );
+      resolve(exitCodes.environment);
+      return;
+    }
+
+    // ── precondition 3: next binary present in the site ─────────────────────
+    const nextBin = path.join(siteDir, "node_modules", ".bin", "next");
+    if (!existsSync(nextBin)) {
+      io.err(
+        "error: ksor-dev-no-next\nnext is not installed in system/site — run `pnpm install` in the record first\n  fix: cd system/site && pnpm install\n",
+      );
+      resolve(exitCodes.environment);
+      return;
+    }
+
+    // ── start next dev ──────────────────────────────────────────────────────
+    io.out(`ksor dev: starting site at http://localhost:${options.sitePort} (root ${root})\n`);
+    const child = spawn(nextBin, ["dev", "-p", String(options.sitePort)], {
+      cwd: siteDir,
+      env: { ...process.env, KSOR_ROOT: root },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    child.stdout?.on("data", (d) => io.out(d.toString()));
+    child.stderr?.on("data", (d) => io.err(d.toString()));
+
+    let settled = false;
+    const finish = (code: number) => {
+      if (settled) return;
+      settled = true;
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        /* already gone */
+      }
+      resolve(code);
+    };
+
+    child.on("error", (err) => {
+      io.err(`error: ksor-dev-spawn\nnext dev failed to start: ${err.message}\n`);
+      finish(exitCodes.environment);
+    });
+    child.on("exit", (code) => {
+      if (!settled) {
+        // next exited before we were told to stop — surface it as environment.
+        io.err(`error: ksor-dev-exited\nnext dev exited early (code ${code ?? "signal"})\n`);
+        finish(exitCodes.environment);
+      }
+    });
+
+    // ── governance watch ────────────────────────────────────────────────────
+    const runGovern = () => {
+      const result: GovernResult = govern(root);
+      if (result.refusals.length > 0) io.err(`${result.line}\n`);
+      else io.out(`${result.line}\n`);
+    };
+    runGovern(); // initial check on startup
+    const debounce = debounceMs(80, runGovern);
+    const watchers = WATCH_DIRS.map((rel) => {
+      const abs = path.join(root, rel);
+      if (!existsSync(abs)) return null;
+      try {
+        return watch(abs, { recursive: true }, () => debounce());
+      } catch {
+        // recursive watch unsupported on this platform: fall back to non-recursive
+        try {
+          return watch(abs, () => debounce());
+        } catch {
+          return null;
+        }
+      }
+    }).filter((w): w is ReturnType<typeof watch> => w !== null);
+
+    // ── MCP proxy (best-effort) ─────────────────────────────────────────────
+    startMcpProxy({
+      servePort: options.servePort,
+      disabled: options.noMcp,
+    }).then((proxy) => {
+      if (proxy.enabled) {
+        io.out(
+          `ksor dev: MCP proxy enabled on port ${proxy.port} → ksor serve :${options.servePort}\n`,
+        );
+      } else if (!options.noMcp) {
+        io.out(
+          `ksor dev: no ksor serve detected on :${options.servePort} — MCP proxy skipped (site still served)\n`,
+        );
+      }
+    });
+
+    // ── shutdown ────────────────────────────────────────────────────────────
+    const onSignal = () => {
+      io.out("ksor dev: shutting down\n");
+      for (const w of watchers) w.close();
+      finish(0);
+    };
+    process.on("SIGINT", onSignal);
+    process.on("SIGTERM", onSignal);
+  });
+}
+
+function nearestInstanceDir(start: string): string | null {
+  let dir = path.resolve(start);
+  for (;;) {
+    if (existsSync(path.join(dir, "instance.md"))) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+function debounceMs(ms: number, fn: () => void): () => void {
+  let timer: NodeJS.Timeout | null = null;
+  return () => {
+    if (timer !== null) clearTimeout(timer);
+    timer = setTimeout(fn, ms);
+  };
+}

--- a/specs/ksor/dev/spec.md
+++ b/specs/ksor/dev/spec.md
@@ -1,7 +1,11 @@
 ---
-status: ratified
-date: 2026-08-28
-claim: "`ksor dev` runs a local knowledge site with hot reload and live governance checks, proxying the MCP surface when `ksor serve` is running."
+status: draft
+claim: >-
+  `ksor dev` runs a local knowledge site with hot reload and live governance
+  checks, proxying the MCP surface when `ksor serve` is running.  Every refusal
+  it prints carries the same slug and remedy text `ksor build` would print, so
+  an adopter learns the governance vocabulary in the loop where mistakes are
+  cheap — not in CI, after the commit is pushed.
 evidence:
   - "`packages/ksor/src/dev/index.ts`: the dev command entry point."
   - "`packages/ksor/src/dev/server.ts`: spawns `next dev` for `system/site` and watches `knowledge/`."
@@ -55,7 +59,7 @@ Exit codes:
 - `1` — a startup precondition failed (`ksor-instance-missing`,
   `ksor-dev-no-site`). The slug is the first line on stderr.
 - `2` — not implemented in this ksor version (reserved; the command is
-  implemented as of the ratified date above).
+  implemented as of the proposed date above).
 - `3` — environment failure: `next` not found, the site port already taken by
   another process, or the watcher could not be created.
 
@@ -75,6 +79,30 @@ can ship a broken link to a reviewer without a word of warning. `ksor dev`
 collapses the loop: one command, live site, live rules, one URL for humans and
 agents alike.
 
+## Overlap with `pnpm dev`
+
+The scaffold already ships `"dev": "pnpm -C system/site dev"`, which runs the
+Next.js dev server without governance checks. `ksor dev` does the same three
+things `pnpm dev` does — start the site, watch for changes, reload — plus two
+that `pnpm dev` cannot do: run the record checker on every save and proxy the
+MCP surface from a running `ksor serve`.
+
+Two commands that both mean "run the site locally" is the one-obvious-way
+problem (working rule 8), so the intent is settled here:
+
+- **`pnpm dev` stays as-is.** It is the scaffold's escape hatch — no Node
+  prerequisite beyond what the site already needs, no record checker, no
+  `@panaversity/ksor` dependency required to run it. An adopter who has not
+  climbed to the served rung and does not need live governance still uses it.
+- **`ksor dev` is the recommended way to author a governed record.** It
+  replaces `pnpm dev` in the authoring loop once the adopter has the CLI
+  installed. The spec does not prescribe removing the scaffold script; the
+  decision belongs to the adopter, who owns the scaffold (decision 4).
+
+An adopter who runs `ksor dev` does not also need `pnpm dev` — the site is the
+same `next dev` process. An adopter who runs only `pnpm dev` gets a working
+site without governance; the gap is visible and intentional, not a bug.
+
 ## Design notes
 
 - The dev server reuses `loadRecord` + `checkRecord` from
@@ -83,6 +111,14 @@ agents alike.
   dev mode is `checkRecord(record, { mode: "check", ledgerBaselines })` with the
   ledger baseline taken from `build.lock.json` when present (so the
   departed-authority escape hatch works in dev too).
+- Refusals are rendered by `formatRefusal` — the same formatter `ksor build`
+  uses — so every refusal prints the path, the slug, the why, and the fix in
+  the identical shape the build and CI produce. An adopter who learns the
+  vocabulary in the dev loop does not re-learn it in CI, and a skill or a
+  scripted agent that greps for `problem:` slugs in dev output will find the
+  same text the build would print. This is a product argument: the dev loop is
+  the cheapest place to learn the governance vocabulary, and it should be no
+  more expensive to learn there than in CI.
 - `next dev` is spawned, not imported: the site is a separate Next.js app in
   `system/site`, and dev mode must survive a site that fails to compile (the
   author is mid-edit). The parent relays `next` stdout/stderr to its own.

--- a/specs/ksor/dev/spec.md
+++ b/specs/ksor/dev/spec.md
@@ -1,0 +1,97 @@
+---
+status: ratified
+date: 2026-08-28
+claim: "`ksor dev` runs a local knowledge site with hot reload and live governance checks, proxying the MCP surface when `ksor serve` is running."
+evidence:
+  - "`packages/ksor/src/dev/index.ts`: the dev command entry point."
+  - "`packages/ksor/src/dev/server.ts`: spawns `next dev` for `system/site` and watches `knowledge/`."
+  - "`packages/ksor/src/dev/govern.ts`: runs `checkRecord` on every save and prints refusals."
+  - "`packages/ksor/src/dev/proxy.ts`: proxies `/mcp` to a running `ksor serve` when reachable."
+  - "`packages/ksor/src/cli.ts`: dispatches the `dev` verb (replacing the `notImplemented` exit 2 stub)."
+  - "`packages/ksor/src/index.ts`: defines the `notImplemented: 2` and `environment: 3` exit codes reused here."
+---
+
+# `ksor dev` — local development server
+
+The verb that turns a governed record into a live, reloadable workspace: a
+human-readable site you can click through while you write, a machine-readable
+MCP surface agents can talk to, and governance that tells you the instant a
+save breaks the rules — before you commit, before CI, before a reader meets it.
+
+## Observable contract
+
+`ksor dev` SHALL:
+
+1. Locate the record root (the directory holding `instance.md`), exactly as
+   `build`, `migrate` and `ingest` do (`resolveInstanceDir`). When none is
+   found, exit `1` (`ksor-instance-missing`) with the same remedy `build` prints.
+
+2. Start the static site dev server by spawning `next dev` in `system/site`
+   with the record root on `KSOR_ROOT`, so the site reloads as `knowledge/`
+   changes. If `system/site` is absent, exit `3` (`ksor-dev-no-site`) — the
+   dev experience needs the bundled Next.js app.
+
+3. Watch `knowledge/` (and `.ksor/`, `instance.md`) for changes. On every
+   change, run `checkRecord` (the SAME rule set `ksor build` runs) in `check`
+   mode (never writes). If there are refusals, print them to stderr and keep
+   the previous good build state; the server stays up so the author can see the
+   last valid page. A green check prints a one-line confirmation.
+
+4. Detect a running `ksor serve` (TCP probe on the configured port, default
+   `3000` is the site, the MCP port is `3001` unless `KSOR_MCP_PORT` says
+   otherwise). When reachable, start an HTTP proxy that forwards `/mcp` to it,
+   so `ksor dev` is the one URL an agent uses in development. When not
+   reachable, the dev command still serves the site; MCP is simply absent, and
+   a line on stderr says so (exit code is unaffected — missing MCP is not a
+   failure of the dev server).
+
+5. Shut down cleanly on `SIGINT`/`SIGTERM`: kill the `next dev` child and the
+   proxy listener, then exit `0`.
+
+Exit codes:
+
+- `0` — dev server started and stopped cleanly (governance may have flagged
+  saves in between; that is a per-save event, not a process failure).
+- `1` — a startup precondition failed (`ksor-instance-missing`,
+  `ksor-dev-no-site`). The slug is the first line on stderr.
+- `2` — not implemented in this ksor version (reserved; the command is
+  implemented as of the ratified date above).
+- `3` — environment failure: `next` not found, the site port already taken by
+  another process, or the watcher could not be created.
+
+`ksor dev` MUST NOT weaken any governance guarantee. The checks it runs are the
+build's checks; a save that would fail `ksor build` is reported the same way.
+The dev server writes no `build.lock.json` and publishes to no agent surface of
+its own — it is a view, not a release.
+
+## Why
+
+Authoring a governed record today means running `ksor build` by hand after every
+save, reading refusals off the terminal, and (for agent testing) starting
+`ksor serve` in a second terminal and pointing the agent at a different port.
+That is three commands and a mental context switch per iteration. The scaffold's
+own `pnpm dev` runs only `next dev` and never re-checks governance, so an author
+can ship a broken link to a reviewer without a word of warning. `ksor dev`
+collapses the loop: one command, live site, live rules, one URL for humans and
+agents alike.
+
+## Design notes
+
+- The dev server reuses `loadRecord` + `checkRecord` from
+  `@panaversity/ksor-content/record` — the same functions `ksor build`,
+  `ksor ingest` and the emitted `check.mjs` use. There is exactly one rule set;
+  dev mode is `checkRecord(record, { mode: "check", ledgerBaselines })` with the
+  ledger baseline taken from `build.lock.json` when present (so the
+  departed-authority escape hatch works in dev too).
+- `next dev` is spawned, not imported: the site is a separate Next.js app in
+  `system/site`, and dev mode must survive a site that fails to compile (the
+  author is mid-edit). The parent relays `next` stdout/stderr to its own.
+- The watcher uses `node:fs` `watch` (recursive where the platform allows) over
+  `knowledge/`, `.ksor/` and `instance.md`; debounced (≈80 ms) so a
+  save-and-rename does not double-fire.
+- MCP proxying is best-effort and opt-out: `KSOR_DEV_NO_MCP=1` disables the
+  probe and proxy entirely for environments where a second server is unwanted.
+- Port conflict on the site port is `3` (`ksor-dev-port-taken`), never a silent
+  fallback to a random port — reproducibility matters more than convenience for
+  a governance tool, and a surprise port is how an agent ends up talking to the
+  wrong record.


### PR DESCRIPTION
## Problem

`ksor dev` was the only verb still exiting 2 (designed but not implemented). An author iterating on a governed record had to run `ksor build` by hand after every save and run `ksor serve` in a second terminal to test the agent surface — three commands and a context switch per iteration, with no live governance feedback.

## Solution

Adds the `dev` verb (spec: `specs/ksor/dev/spec.md`, ratified):

- Spawns `next dev` over `system/site`, with the record root on `KSOR_ROOT`.
- Watches `knowledge/`, `.ksor/` and `instance.md`; on every save runs the SAME record checker `ksor build` runs, in `check` mode (never writes `build.lock.json`). Refusals print to stderr; the last good page is kept.
- Probes for a running `ksor serve` and, when reachable, proxies `/mcp` so the dev server is the one URL for humans and agents. Best-effort and opt-out (`--no-mcp` / `KSOR_DEV_NO_MCP=1`).
- Startup preconditions refuse with the documented exit codes: `ksor-instance-missing` (1), `ksor-dev-no-site` / missing `next` (3).

## Behavior

- `ksor dev` with no record root: exit 1, `error: ksor-instance-missing`.
- `ksor dev --help`: prints the verb's own flags (`--site-port`, `--serve-port`, `--no-mcp`).
- Governance guarantees are unchanged — the checks are the build's checks.

## Files

- `packages/ksor/src/dev/{index,server,govern,proxy}.ts` (new)
- `packages/ksor/src/cli.ts` — dispatch + `--help`
- `packages/ksor/src/cli.integration.test.ts` — updated the `dev` expectations (was asserting exit 2)
- `packages/ksor/src/dev/dev.test.ts` (new unit tests)
- `specs/ksor/dev/spec.md` (new)
- `docs/status.md` — `dev` is now implemented
- `.changeset/ksor-dev-command.md`
