### PR TITLE
Format the tutorial, unblocking Release

### DIFF
--- a/docs/tutorials/01-introduction-to-ksor.md
+++ b/docs/tutorials/01-introduction-to-ksor.md
@@ -180,7 +180,7 @@ For example, it cannot automatically know:
 - your accounting department's capitalization policy,
 - or which version of a procedure is currently in force.
 
-Even if the model has seen *some version* of that information, it does not know whether that version is the one your organization currently recognizes as authoritative.
+Even if the model has seen _some version_ of that information, it does not know whether that version is the one your organization currently recognizes as authoritative.
 
 ---
 
@@ -264,10 +264,10 @@ AI agents are increasingly being asked to perform work that humans once performe
 
 Those agents need both **current state** and **operating knowledge**.
 
-| Type | What it holds | Main question |
-| --- | --- | --- |
-| Traditional System of Record | Current operational data | **What is true right now?** |
-| Knowledge System of Record | Rules, methods, policies, procedures | **How should we operate?** |
+| Type                         | What it holds                        | Main question               |
+| ---------------------------- | ------------------------------------ | --------------------------- |
+| Traditional System of Record | Current operational data             | **What is true right now?** |
+| Knowledge System of Record   | Rules, methods, policies, procedures | **How should we operate?**  |
 
 ![Every AI worker needs two Systems of Record: a KSoR for governed knowledge and a traditional SoR for current state](01-assets/two-systems-of-record.png)
 
@@ -494,14 +494,14 @@ If the answer is yes, it is probably a good candidate for the KSoR.
 
 If it is a rapidly changing operational fact, it probably belongs in a traditional System of Record.
 
-| Question | Where it belongs |
-| --- | --- |
-| What is our medication dosage policy? | KSoR |
-| How many beds are available right now? | Operational SoR |
-| What is our capitalization policy? | KSoR |
-| What is the current ledger balance? | Accounting SoR |
-| What is the grading policy for this course? | KSoR |
-| Which students are currently enrolled? | Student information system |
+| Question                                    | Where it belongs           |
+| ------------------------------------------- | -------------------------- |
+| What is our medication dosage policy?       | KSoR                       |
+| How many beds are available right now?      | Operational SoR            |
+| What is our capitalization policy?          | KSoR                       |
+| What is the current ledger balance?         | Accounting SoR             |
+| What is the grading policy for this course? | KSoR                       |
+| Which students are currently enrolled?      | Student information system |
 
 The important distinction is not:
 
@@ -1718,7 +1718,7 @@ After the hospital establishes its governed knowledge, the nurse asks the same q
 
 Now all three helpers can point to the same authoritative rule:
 
-> *Medicine Rules, page 7, version 4.*
+> _Medicine Rules, page 7, version 4._
 
 ![The same question, asked again — same cited answer from all three helpers](01-assets/same-question-again.png)
 


### PR DESCRIPTION
## Problem

**Release has failed on `main` four times in a row since 2026-08-27**, and no
release has been publishable for three days.

The failing step is the Release workflow's own gate:

```
pnpm lint:ci && pnpm fmt:ci && pnpm typecheck && pnpm guard && pnpm check:corpus
```

`pnpm fmt:ci` reports:

```
docs/tutorials/01-introduction-to-ksor.md (402ms)
Format issues found in above 1 files. Run without `--check` to fix.
```

Reproduced locally on current `main`.

## Solution

`pnpm fmt`. The diff is exactly what the formatter does and nothing else —
`*emphasis*` → `_emphasis_` and table cells padded to column width. 14 lines
changed, no prose touched.

After it, every command in that gate passes: `lint:ci`, `fmt:ci`, `typecheck`,
`guard`, `check:corpus`.

## Worth recording, because the mechanism will repeat

The file arrived through commits pushed **directly to `main`** (`dd1c01c`,
`7f3ad74`). `Lint, format, guards, corpus` is a required check on every pull
request and would have caught this before it landed — a direct push is the only
route into `main` that skips it. That is what critical rule 2 exists for, and
this is the first time it has cost anything visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)