### PR TITLE
Name every db-tier scratch database per run, and reap what an interrupt leaks

### DIFF
--- a/.changeset/db-scratch-names.md
+++ b/.changeset/db-scratch-names.md
@@ -1,0 +1,14 @@
+---
+"@panaversity/ksor": patch
+---
+
+Test infrastructure only — nothing an adopter installs behaves differently.
+
+Every database-tier suite now bootstraps its scratch database under a name
+unique to the run (`ksor_<slug>_<base36 ms>_<6 hex>`) instead of a fixed one.
+Fixed names meant two runs against one Postgres — a second `pnpm test:db`, a CI
+matrix job, an agent running the tier alongside a person — dropped each other's
+database `WITH (FORCE)` mid-test, which surfaced as a missing table or a short
+row count and read as flakiness. A new reaper (`scripts/db-reaper.ts`, the
+tier's globalSetup) drops what an interrupted run leaks, and guard rule 12 keeps
+the naming from drifting back.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1585,7 +1585,11 @@ assertion.
   because of what it touches, never because of what it costs.
 - `*.db.test.ts` — real Postgres, gated on `KSOR_DB_URL` (`pnpm test:db`; CI
   provides the service). The kernel's guarantees are SQL, so the tier that runs
-  them against a real database is where they are actually held.
+  them against a real database is where they are actually held. A suite here
+  owns its own scratch DATABASE, named uniquely per run and stamped with the
+  instant it was made (guard rule 12) — a fixed name let two runs on one
+  cluster drop each other's database mid-test, and the stamp is what lets the
+  tier's reaper tell a leak from a live run's database (issue #166).
 
 The tiers are a contract, not a preference: a file that reads the filesystem
 belongs in the second one however small it is. Seven did not, and drifted there

--- a/packages/content-gateway/src/auth-adversarial.db.test.ts
+++ b/packages/content-gateway/src/auth-adversarial.db.test.ts
@@ -23,6 +23,7 @@
  * in `aud`, one accepted and one refused.
  */
 
+import { randomBytes } from "node:crypto";
 import { spawn, type ChildProcess } from "node:child_process";
 import { createServer, type Server } from "node:http";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
@@ -40,7 +41,7 @@ const adminDsn = process.env["KSOR_DB_URL"] ?? "";
 const CLI = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "dist", "cli.mjs");
 /** The write verbs live on the ksor binary; CLI above is the gateway's serve entry. */
 const KSOR_CLI = path.resolve(CLI, "..", "..", "..", "ksor", "dist", "cli.mjs");
-const DB = "ksor_auth_adversarial";
+const DB = `ksor_auth_adversarial_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
 const TENANT = "auth-corp";
 
 interface TestAs {
@@ -153,7 +154,6 @@ describe.runIf(adminDsn !== "")("the bearer door, adversarially (db)", () => {
 
   beforeAll(async () => {
     admin = new pg.Pool({ connectionString: adminDsn });
-    await admin.query(`DROP DATABASE IF EXISTS ${DB} WITH (FORCE)`).catch(() => undefined);
     await admin.query(`CREATE DATABASE ${DB}`);
     const url = new URL(adminDsn);
     url.pathname = `/${DB}`;

--- a/packages/content-gateway/src/content-gateway.db.test.ts
+++ b/packages/content-gateway/src/content-gateway.db.test.ts
@@ -103,7 +103,7 @@ describe.runIf(adminDsn !== "")("gateway acceptance (HTTP, real MCP client)", ()
   }
 
   beforeAll(async () => {
-    dbName = `ksor_g_${randomBytes(4).toString("hex")}`;
+    dbName = `ksor_g_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
     admin = new pg.Pool({ connectionString: adminDsn, max: 1 });
     await admin.query(`CREATE DATABASE ${dbName}`);
     const url = new URL(adminDsn);

--- a/packages/content-gateway/src/governance-surface.db.test.ts
+++ b/packages/content-gateway/src/governance-surface.db.test.ts
@@ -143,7 +143,7 @@ describe.runIf(adminDsn !== "")("the governance surface of `search` (db)", () =>
   ): Promise<string[]> => ((await searchAs(ctx, args)).hits ?? []).map((h) => h.slug).sort();
 
   beforeAll(async () => {
-    dbName = `ksor_trust_${randomBytes(4).toString("hex")}`;
+    dbName = `ksor_trust_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
     admin = new pg.Pool({ connectionString: adminDsn, max: 1 });
     await admin.query(`CREATE DATABASE ${dbName}`);
     const url = new URL(adminDsn);

--- a/packages/content-gateway/src/read-frontmatter.db.test.ts
+++ b/packages/content-gateway/src/read-frontmatter.db.test.ts
@@ -89,7 +89,7 @@ describe.runIf(adminDsn !== "")("`read` returns the frontmatter intact (db)", ()
     });
 
   beforeAll(async () => {
-    dbName = `ksor_fm_${randomBytes(4).toString("hex")}`;
+    dbName = `ksor_fm_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
     admin = new pg.Pool({ connectionString: adminDsn, max: 1 });
     await admin.query(`CREATE DATABASE ${dbName}`);
     const url = new URL(adminDsn);

--- a/packages/content-gateway/src/refusal-governance.db.test.ts
+++ b/packages/content-gateway/src/refusal-governance.db.test.ts
@@ -17,6 +17,7 @@
  * not of one a test built.
  */
 
+import { randomBytes } from "node:crypto";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import {
@@ -32,7 +33,7 @@ import type pg from "pg";
 import { refusalBody } from "./refusal-body.js";
 
 const adminDsn = process.env["KSOR_DB_URL"] ?? "";
-const DB = "ksor_refusal_governance_test";
+const DB = `ksor_refusal_governance_test_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
 const TENANT = "refusal-corp";
 
 /** Shaped like real withdrawals, because the point is that these never leave. */
@@ -72,7 +73,6 @@ describe.runIf(adminDsn !== "")("a governance refusal names no withdrawn documen
   beforeAll(async () => {
     const { Pool } = (await import("pg")).default;
     admin = new Pool({ connectionString: adminDsn });
-    await admin.query(`DROP DATABASE IF EXISTS ${DB} WITH (FORCE)`).catch(() => undefined);
     await admin.query(`CREATE DATABASE ${DB}`);
     const url = new URL(adminDsn);
     url.pathname = `/${DB}`;

--- a/packages/content-gateway/src/snapshot-viewer.db.test.ts
+++ b/packages/content-gateway/src/snapshot-viewer.db.test.ts
@@ -126,7 +126,7 @@ describe.runIf(adminDsn !== "")("a snapshot token is bound to its viewer (db)", 
   let internalPort: number;
 
   beforeAll(async () => {
-    dbName = `ksor_viewer_${randomBytes(4).toString("hex")}`;
+    dbName = `ksor_viewer_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
     admin = new pg.Pool({ connectionString: adminDsn, max: 1 });
     await admin.query(`CREATE DATABASE ${dbName}`);
     const url = new URL(adminDsn);

--- a/packages/content/src/calibrate/run.db.test.ts
+++ b/packages/content/src/calibrate/run.db.test.ts
@@ -14,6 +14,7 @@
  * one (found live 2026-08-21).
  */
 
+import { randomBytes } from "node:crypto";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -31,7 +32,7 @@ import type { ContentInstance } from "../instance.js";
 import type pg from "pg";
 
 const adminDsn = process.env["KSOR_DB_URL"] ?? "";
-const DB = "ksor_calibrate_run";
+const DB = `ksor_calibrate_run_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
 const TENANT = "calib-corp";
 
 const DOC = (title: string, order: number): string =>
@@ -57,7 +58,6 @@ describe.runIf(adminDsn !== "")("runCalibration against a real store (db)", () =
   beforeAll(async () => {
     const { Pool } = (await import("pg")).default;
     admin = new Pool({ connectionString: adminDsn });
-    await admin.query(`DROP DATABASE IF EXISTS ${DB} WITH (FORCE)`).catch(() => undefined);
     await admin.query(`CREATE DATABASE ${DB}`);
     const url = new URL(adminDsn);
     url.pathname = `/${DB}`;

--- a/packages/content/src/db-input.db.test.ts
+++ b/packages/content/src/db-input.db.test.ts
@@ -23,6 +23,7 @@
  * connection afterwards — neither of which a hand-built error can show.
  */
 
+import { randomBytes } from "node:crypto";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { ContentInputError, ContentStoreError, contentPool, runRead } from "./db.js";
@@ -31,7 +32,7 @@ import { WHOLE_RECORD_SCOPE } from "./lib/audience.js";
 import type pg from "pg";
 
 const adminDsn = process.env["KSOR_DB_URL"] ?? "";
-const DB = "ksor_input_error";
+const DB = `ksor_input_error_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
 const TENANT = "input-corp";
 const NUL = String.fromCharCode(0);
 
@@ -42,7 +43,6 @@ describe.runIf(adminDsn !== "")("a malformed argument is not an outage (db)", ()
   beforeAll(async () => {
     const { Pool } = (await import("pg")).default;
     admin = new Pool({ connectionString: adminDsn });
-    await admin.query(`DROP DATABASE IF EXISTS ${DB} WITH (FORCE)`).catch(() => undefined);
     await admin.query(`CREATE DATABASE ${DB}`);
     const url = new URL(adminDsn);
     url.pathname = `/${DB}`;

--- a/packages/content/src/evals/behavioural.db.test.ts
+++ b/packages/content/src/evals/behavioural.db.test.ts
@@ -25,6 +25,7 @@
  * already described correctly — round-9 review of PR 43.)
  */
 
+import { randomBytes } from "node:crypto";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { contentPool } from "../db.js";
@@ -51,7 +52,7 @@ const canMeasure = adminDsn !== "" && apiKey !== "";
 const PROVIDER = apiKey === "" ? "fake" : "gemini";
 const MODEL = apiKey === "" ? "fake-embed-001" : "gemini-embedding-001";
 
-const DB = "ksor_eval_behavioural";
+const DB = `ksor_eval_behavioural_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
 const TENANT = "example-corpus";
 const CORPUS = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -89,7 +90,6 @@ describe.runIf(canRun)("behavioural evals", () => {
   beforeAll(async () => {
     const { Pool } = (await import("pg")).default;
     admin = new Pool({ connectionString: adminDsn });
-    await admin.query(`DROP DATABASE IF EXISTS ${DB} WITH (FORCE)`).catch(() => undefined);
     await admin.query(`CREATE DATABASE ${DB}`);
     const url = new URL(adminDsn);
     url.pathname = `/${DB}`;

--- a/packages/content/src/evals/retrieval-measure.db.test.ts
+++ b/packages/content/src/evals/retrieval-measure.db.test.ts
@@ -22,6 +22,7 @@
  *     would rank a classifier that admits everything as the winner
  */
 
+import { randomBytes } from "node:crypto";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -48,7 +49,7 @@ const adminDsn = process.env["KSOR_DB_URL"] ?? "";
 const apiKey = process.env["GEMINI_API_KEY"] ?? "";
 /** A real embedding space, or the measurement measures nothing. */
 const canMeasure = adminDsn !== "" && apiKey !== "";
-const DB = "ksor_retrieval_measure";
+const DB = `ksor_retrieval_measure_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
 const TENANT = "handbook-eval";
 const KS = [1, 3, 5] as const;
 
@@ -75,7 +76,6 @@ describe.runIf(canMeasure)("what a handbook-shaped record can be asked (db, live
   beforeAll(async () => {
     const { Pool } = (await import("pg")).default;
     admin = new Pool({ connectionString: adminDsn });
-    await admin.query(`DROP DATABASE IF EXISTS ${DB} WITH (FORCE)`).catch(() => undefined);
     await admin.query(`CREATE DATABASE ${DB}`);
     const url = new URL(adminDsn);
     url.pathname = `/${DB}`;

--- a/packages/content/src/governance-chain.db.test.ts
+++ b/packages/content/src/governance-chain.db.test.ts
@@ -26,6 +26,7 @@
  * re-run against it and both are caught.
  */
 
+import { randomBytes } from "node:crypto";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -54,7 +55,7 @@ import type { ServiceContext } from "./service.js";
 import type pg from "pg";
 
 const adminDsn = process.env["KSOR_DB_URL"] ?? "";
-const DB = "ksor_governance_chain";
+const DB = `ksor_governance_chain_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
 const TENANT = "chain-corp";
 
 /** One shared, unmistakable word, so a leak is visible in any surface's output. */
@@ -182,7 +183,6 @@ describe.runIf(adminDsn !== "")("the governance chain, markdown to answer (db)",
   beforeAll(async () => {
     const { Pool } = (await import("pg")).default;
     admin = new Pool({ connectionString: adminDsn });
-    await admin.query(`DROP DATABASE IF EXISTS ${DB} WITH (FORCE)`).catch(() => undefined);
     await admin.query(`CREATE DATABASE ${DB}`);
     const url = new URL(adminDsn);
     url.pathname = `/${DB}`;
@@ -420,7 +420,7 @@ describe.runIf(adminDsn === "")("the governance chain (db) — gated", () => {
  * withdrawal is not a withdrawal.
  */
 describe.runIf(adminDsn !== "")("a pin does not outlive a restriction (db)", () => {
-  const DB2 = "ksor_pin_governance";
+  const DB2 = `ksor_pin_governance_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
   const T = "pincorp";
   let pool2: pg.Pool;
   let admin2: pg.Pool;
@@ -478,7 +478,6 @@ describe.runIf(adminDsn !== "")("a pin does not outlive a restriction (db)", () 
   beforeAll(async () => {
     const { Pool } = (await import("pg")).default;
     admin2 = new Pool({ connectionString: adminDsn });
-    await admin2.query(`DROP DATABASE IF EXISTS ${DB2} WITH (FORCE)`).catch(() => undefined);
     await admin2.query(`CREATE DATABASE ${DB2}`);
     const url = new URL(adminDsn);
     url.pathname = `/${DB2}`;

--- a/packages/content/src/governance-gate.db.test.ts
+++ b/packages/content/src/governance-gate.db.test.ts
@@ -9,6 +9,7 @@
  * entry never merged is reported.
  */
 
+import { randomBytes } from "node:crypto";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -25,7 +26,7 @@ import { applySchema } from "./schema.js";
 import type pg from "pg";
 
 const adminDsn = process.env["KSOR_DB_URL"] ?? "";
-const DB = "ksor_governance_gate";
+const DB = `ksor_governance_gate_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
 const TENANT = "gate-corp";
 
 describe.runIf(adminDsn !== "")("the governance boot gate (db)", () => {
@@ -84,7 +85,6 @@ describe.runIf(adminDsn !== "")("the governance boot gate (db)", () => {
   beforeAll(async () => {
     const { Pool } = (await import("pg")).default;
     admin = new Pool({ connectionString: adminDsn });
-    await admin.query(`DROP DATABASE IF EXISTS ${DB} WITH (FORCE)`).catch(() => undefined);
     await admin.query(`CREATE DATABASE ${DB}`);
     const url = new URL(adminDsn);
     url.pathname = `/${DB}`;
@@ -211,7 +211,7 @@ describe.runIf(adminDsn === "")("the governance boot gate (db) — gated", () =>
 describe.runIf(adminDsn !== "")("a takedown that no longer resolves (db)", () => {
   let pool: pg.Pool;
   let admin: pg.Pool;
-  const DB2 = "ksor_gate_takedown";
+  const DB2 = `ksor_gate_takedown_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
   const T = "gatetd";
   const instance = instanceOf(T, T);
 
@@ -239,7 +239,6 @@ describe.runIf(adminDsn !== "")("a takedown that no longer resolves (db)", () =>
   beforeAll(async () => {
     const { Pool } = (await import("pg")).default;
     admin = new Pool({ connectionString: adminDsn });
-    await admin.query(`DROP DATABASE IF EXISTS ${DB2} WITH (FORCE)`).catch(() => undefined);
     await admin.query(`CREATE DATABASE ${DB2}`);
     const url = new URL(adminDsn);
     url.pathname = `/${DB2}`;
@@ -321,7 +320,7 @@ describe.runIf(adminDsn !== "")("a takedown that no longer resolves (db)", () =>
  * them: every piece was locally correct and `expected` simply never crossed.
  */
 describe.runIf(adminDsn !== "")("a denial whose document was deliberately deleted (db)", () => {
-  const DB3 = "ksor_gate_removed";
+  const DB3 = `ksor_gate_removed_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
   const T3 = "removed-corp";
   const instance = instanceOf(T3, T3);
   let pool: pg.Pool;
@@ -372,7 +371,6 @@ describe.runIf(adminDsn !== "")("a denial whose document was deliberately delete
   beforeAll(async () => {
     const { Pool } = (await import("pg")).default;
     admin = new Pool({ connectionString: adminDsn });
-    await admin.query(`DROP DATABASE IF EXISTS ${DB3} WITH (FORCE)`).catch(() => undefined);
     await admin.query(`CREATE DATABASE ${DB3}`);
     const url = new URL(adminDsn);
     url.pathname = `/${DB3}`;

--- a/packages/content/src/grant.db.test.ts
+++ b/packages/content/src/grant.db.test.ts
@@ -39,7 +39,7 @@ describe.runIf(adminDsn !== "")("ksor grant — acceptance", () => {
   let dbName: string;
 
   beforeAll(async () => {
-    dbName = `ksor_grant_${randomBytes(4).toString("hex")}`;
+    dbName = `ksor_grant_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
     admin = new pg.Pool({ connectionString: adminDsn, max: 1 });
     await admin.query(`CREATE DATABASE ${dbName}`);
     const url = new URL(adminDsn);

--- a/packages/content/src/ingest/departed-authority.db.test.ts
+++ b/packages/content/src/ingest/departed-authority.db.test.ts
@@ -21,6 +21,7 @@
  * and covered it while ingest was broken.
  */
 
+import { randomBytes } from "node:crypto";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -43,7 +44,7 @@ import {
 import type { ContentInstance } from "../instance.js";
 
 const adminDsn = process.env["KSOR_DB_URL"] ?? "";
-const DB = "ksor_departed_authority";
+const DB = `ksor_departed_authority_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
 const DIM = 8;
 const TENANT = "handbook";
 const DEPARTED = "human:alice";
@@ -88,7 +89,6 @@ describe.runIf(adminDsn !== "")("a departed takedown authority (db)", () => {
 
   beforeAll(async () => {
     admin = new pg.Pool({ connectionString: adminDsn });
-    await admin.query(`DROP DATABASE IF EXISTS ${DB} WITH (FORCE)`).catch(() => undefined);
     await admin.query(`CREATE DATABASE ${DB}`);
     const dsn = new URL(adminDsn);
     dsn.pathname = `/${DB}`;

--- a/packages/content/src/ingest/flip-guard.db.test.ts
+++ b/packages/content/src/ingest/flip-guard.db.test.ts
@@ -14,6 +14,7 @@
  * same path the adopter does.
  */
 
+import { randomBytes } from "node:crypto";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -28,7 +29,7 @@ import { profileDoc, writeRecord } from "./fixtures/record-fixture.js";
 import type pg from "pg";
 
 const adminDsn = process.env["KSOR_DB_URL"] ?? "";
-const DB = "ksor_flip_guard";
+const DB = `ksor_flip_guard_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
 
 let work = "";
 let dsn = "";
@@ -76,7 +77,6 @@ describe.runIf(adminDsn !== "")("ksor ingest --flip refuses what serving would (
   beforeAll(async () => {
     const { Pool } = (await import("pg")).default;
     admin = new Pool({ connectionString: adminDsn });
-    await admin.query(`DROP DATABASE IF EXISTS ${DB} WITH (FORCE)`).catch(() => undefined);
     await admin.query(`CREATE DATABASE ${DB}`);
     const url = new URL(adminDsn);
     url.pathname = `/${DB}`;

--- a/packages/content/src/ingest/governance-generation.db.test.ts
+++ b/packages/content/src/ingest/governance-generation.db.test.ts
@@ -19,6 +19,7 @@
  * other two were broken (review 2026-08-25, finding 32).
  */
 
+import { randomBytes } from "node:crypto";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -40,7 +41,7 @@ import {
 import type { ContentInstance } from "../instance.js";
 
 const adminDsn = process.env["KSOR_DB_URL"] ?? "";
-const DB = "ksor_governance_generation";
+const DB = `ksor_governance_generation_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
 const DIM = 8;
 const TENANT = "gov-gen";
 /** The same commit throughout: a new commit earns a generation on its own, which would mask everything. */
@@ -94,7 +95,6 @@ describe.runIf(adminDsn !== "")("governance alone earns a generation (db)", () =
 
   beforeAll(async () => {
     admin = new pg.Pool({ connectionString: adminDsn });
-    await admin.query(`DROP DATABASE IF EXISTS ${DB} WITH (FORCE)`).catch(() => undefined);
     await admin.query(`CREATE DATABASE ${DB}`);
     const dsn = new URL(adminDsn);
     dsn.pathname = `/${DB}`;

--- a/packages/content/src/ingest/ingest.db.test.ts
+++ b/packages/content/src/ingest/ingest.db.test.ts
@@ -117,7 +117,7 @@ describe.runIf(adminDsn !== "")("ingest pipeline db acceptance", () => {
   let totalChunks = 0;
 
   beforeAll(async () => {
-    dbName = `ksor_ing_${randomBytes(4).toString("hex")}`;
+    dbName = `ksor_ing_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
     admin = new pg.Pool({ connectionString: adminDsn, max: 1 });
     await admin.query(`CREATE DATABASE ${dbName}`);
     const url = new URL(adminDsn);
@@ -211,7 +211,7 @@ describe.runIf(adminDsn !== "")("ingest pipeline db acceptance", () => {
     // Drop a database, apply the schema, then remove node_centroids.embedding
     // — the half-applied shape. The guard must NAME the missing table so the
     // ingest CLI refuses BEFORE embedding the whole corpus (double spend).
-    const halfName = `ksor_half_${randomBytes(4).toString("hex")}`;
+    const halfName = `ksor_half_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
     await admin.query(`CREATE DATABASE ${halfName}`);
     const halfUrl = new URL(adminDsn);
     halfUrl.pathname = `/${halfName}`;
@@ -615,7 +615,7 @@ describe.runIf(adminDsn === "")("ingest pipeline db acceptance (gated)", () => {
  * is expressed by order rather than by exclusion.
  */
 describe.runIf(adminDsn !== "")("carry-forward across an interrupted run (db)", () => {
-  const DB2 = `ksor_carry_${randomBytes(4).toString("hex")}`;
+  const DB2 = `ksor_carry_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
   const T2 = "carry";
   const C2 = "carry-rulebook";
   const fake2 = buildShippedProvider("fake", { apiKey: null, dim: DIM });

--- a/packages/content/src/ingest/unledgered.db.test.ts
+++ b/packages/content/src/ingest/unledgered.db.test.ts
@@ -22,6 +22,7 @@
  * than no refusal.
  */
 
+import { randomBytes } from "node:crypto";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -42,7 +43,7 @@ import {
 import type { ContentInstance } from "../instance.js";
 
 const adminDsn = process.env["KSOR_DB_URL"] ?? "";
-const DB = "ksor_unledgered";
+const DB = `ksor_unledgered_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
 const DIM = 8;
 const TENANT = "handbook";
 const DENIED = "knowledge/notes/withdrawn";
@@ -83,7 +84,6 @@ describe.runIf(adminDsn !== "")("an unledgered denial stops ingest where it happ
 
   beforeAll(async () => {
     admin = new pg.Pool({ connectionString: adminDsn });
-    await admin.query(`DROP DATABASE IF EXISTS ${DB} WITH (FORCE)`).catch(() => undefined);
     await admin.query(`CREATE DATABASE ${DB}`);
     const dsn = new URL(adminDsn);
     dsn.pathname = `/${DB}`;

--- a/packages/content/src/ingest/unsearchable.db.test.ts
+++ b/packages/content/src/ingest/unsearchable.db.test.ts
@@ -16,6 +16,7 @@
  * findable by name.
  */
 
+import { randomBytes } from "node:crypto";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -31,7 +32,7 @@ import { instanceOf, profileDoc, writeRecord } from "./fixtures/record-fixture.j
 import type pg from "pg";
 
 const adminDsn = process.env["KSOR_DB_URL"] ?? "";
-const DB = "ksor_unsearchable";
+const DB = `ksor_unsearchable_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
 
 /**
  * Navigation: a page of links, which no search should ever return. Every link
@@ -85,7 +86,6 @@ describe.runIf(adminDsn !== "")("ingest reports what search cannot reach (db)", 
   beforeAll(async () => {
     const { Pool } = (await import("pg")).default;
     admin = new Pool({ connectionString: adminDsn });
-    await admin.query(`DROP DATABASE IF EXISTS ${DB} WITH (FORCE)`).catch(() => undefined);
     await admin.query(`CREATE DATABASE ${DB}`);
     const url = new URL(adminDsn);
     url.pathname = `/${DB}`;

--- a/packages/content/src/kernel.db.test.ts
+++ b/packages/content/src/kernel.db.test.ts
@@ -60,7 +60,7 @@ describe.runIf(adminDsn !== "")("kernel db acceptance", () => {
   let dbName: string;
 
   beforeAll(async () => {
-    dbName = `ksor_t_${randomBytes(4).toString("hex")}`;
+    dbName = `ksor_t_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
     admin = new pg.Pool({ connectionString: adminDsn, max: 1 });
     await admin.query(`CREATE DATABASE ${dbName}`);
     const url = new URL(adminDsn);
@@ -597,7 +597,7 @@ describe.runIf(adminDsn !== "")("kernel db acceptance", () => {
     // A reachable database with no schema at all (schema_meta absent → 42P01)
     // must REFUSE, not fall through to the caller's "unreachable" warning and
     // then error per-request (review 2026-08-19).
-    const emptyName = `ksor_empty_${randomBytes(4).toString("hex")}`;
+    const emptyName = `ksor_empty_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
     await admin.query(`CREATE DATABASE ${emptyName}`);
     const emptyUrl = new URL(adminDsn);
     emptyUrl.pathname = `/${emptyName}`;

--- a/packages/content/src/lib/admit.db.test.ts
+++ b/packages/content/src/lib/admit.db.test.ts
@@ -13,6 +13,7 @@
  * floor, would still have carried their audience lists.
  */
 
+import { randomBytes } from "node:crypto";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { scopedTxn } from "@panaversity/ksor-postgres";
@@ -24,7 +25,7 @@ import { trustGucs } from "./trust.js";
 import type pg from "pg";
 
 const adminDsn = process.env["KSOR_DB_URL"] ?? "";
-const DB = "ksor_admit_seam";
+const DB = `ksor_admit_seam_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
 const TENANT = "t-admit";
 const DAY = 86_400_000;
 
@@ -138,7 +139,6 @@ describe.runIf(adminDsn !== "")("the admission seam (db)", () => {
   beforeAll(async () => {
     const { Pool } = (await import("pg")).default;
     admin = new Pool({ connectionString: adminDsn });
-    await admin.query(`DROP DATABASE IF EXISTS ${DB} WITH (FORCE)`).catch(() => undefined);
     await admin.query(`CREATE DATABASE ${DB}`);
     const url = new URL(adminDsn);
     url.pathname = `/${DB}`;

--- a/packages/content/src/lib/audience-conformance.db.test.ts
+++ b/packages/content/src/lib/audience-conformance.db.test.ts
@@ -19,6 +19,7 @@
  * one hand-written INSERT away from being served.
  */
 
+import { randomBytes } from "node:crypto";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { scopedTxn } from "@panaversity/ksor-postgres";
@@ -31,7 +32,7 @@ import { REFUSAL_SLUGS } from "../record/refusal.js";
 import type pg from "pg";
 
 const adminDsn = process.env["KSOR_DB_URL"] ?? "";
-const DB = "ksor_audience_conformance";
+const DB = `ksor_audience_conformance_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
 const TENANT = "t-audience";
 
 describe.runIf(adminDsn !== "")("the audience decision table, in SQL (db)", () => {
@@ -41,7 +42,6 @@ describe.runIf(adminDsn !== "")("the audience decision table, in SQL (db)", () =
   beforeAll(async () => {
     const { Pool } = (await import("pg")).default;
     admin = new Pool({ connectionString: adminDsn });
-    await admin.query(`DROP DATABASE IF EXISTS ${DB} WITH (FORCE)`).catch(() => undefined);
     await admin.query(`CREATE DATABASE ${DB}`);
     const url = new URL(adminDsn);
     url.pathname = `/${DB}`;

--- a/packages/content/src/lib/audience.db.test.ts
+++ b/packages/content/src/lib/audience.db.test.ts
@@ -9,6 +9,7 @@
  * predicate, and that a viewer holding a list sees exactly the overlap.
  */
 
+import { randomBytes } from "node:crypto";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { contentPool, runRead } from "../db.js";
@@ -19,7 +20,7 @@ import { keywordSearch } from "./search.js";
 import type pg from "pg";
 
 const adminDsn = process.env["KSOR_DB_URL"] ?? "";
-const DB = "ksor_audience_test";
+const DB = `ksor_audience_test_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
 const TENANT = "audience-corp";
 
 /** A viewer is a LIST; the ranked model's tiers become the lists a viewer of that tier holds. */
@@ -42,7 +43,6 @@ describe.runIf(adminDsn !== "")("audience filtering (db)", () => {
   beforeAll(async () => {
     const { Pool } = (await import("pg")).default;
     admin = new Pool({ connectionString: adminDsn });
-    await admin.query(`DROP DATABASE IF EXISTS ${DB} WITH (FORCE)`).catch(() => undefined);
     await admin.query(`CREATE DATABASE ${DB}`);
     const url = new URL(adminDsn);
     url.pathname = `/${DB}`;

--- a/packages/content/src/lib/lifecycle-conformance.db.test.ts
+++ b/packages/content/src/lib/lifecycle-conformance.db.test.ts
@@ -12,6 +12,7 @@
  * uses the default; the build passes its `as_of`.
  */
 
+import { randomBytes } from "node:crypto";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { contentPool } from "../db.js";
@@ -20,7 +21,7 @@ import { lifecycleAdmits } from "./lifecycle.js";
 import type pg from "pg";
 
 const adminDsn = process.env["KSOR_DB_URL"] ?? "";
-const DB = "ksor_lifecycle_conformance";
+const DB = `ksor_lifecycle_conformance_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
 
 describe.runIf(adminDsn !== "")("the lifecycle decision table, in SQL (db)", () => {
   let pool: pg.Pool;
@@ -29,7 +30,6 @@ describe.runIf(adminDsn !== "")("the lifecycle decision table, in SQL (db)", () 
   beforeAll(async () => {
     const { Pool } = (await import("pg")).default;
     admin = new Pool({ connectionString: adminDsn });
-    await admin.query(`DROP DATABASE IF EXISTS ${DB} WITH (FORCE)`).catch(() => undefined);
     await admin.query(`CREATE DATABASE ${DB}`);
     const url = new URL(adminDsn);
     url.pathname = `/${DB}`;

--- a/packages/content/src/lib/read.db.test.ts
+++ b/packages/content/src/lib/read.db.test.ts
@@ -57,7 +57,7 @@ describe.runIf(adminDsn !== "")("read db acceptance", () => {
   let dbName: string;
 
   beforeAll(async () => {
-    dbName = `ksor_t_${randomBytes(4).toString("hex")}`;
+    dbName = `ksor_t_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
     admin = new pg.Pool({ connectionString: adminDsn, max: 1 });
     await admin.query(`CREATE DATABASE ${dbName}`);
     const url = new URL(adminDsn);

--- a/packages/content/src/lib/takedown-sweep.db.test.ts
+++ b/packages/content/src/lib/takedown-sweep.db.test.ts
@@ -73,7 +73,7 @@ describe.runIf(adminDsn !== "")("a withdrawn document leaks through no request s
   let queryVector: string;
 
   beforeAll(async () => {
-    dbName = `ksor_sweep_${randomBytes(4).toString("hex")}`;
+    dbName = `ksor_sweep_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
     admin = new pg.Pool({ connectionString: adminDsn, max: 1 });
     await admin.query(`CREATE DATABASE ${dbName}`);
     const url = new URL(adminDsn);

--- a/packages/content/src/lib/takedown.db.test.ts
+++ b/packages/content/src/lib/takedown.db.test.ts
@@ -67,7 +67,7 @@ describe.runIf(adminDsn !== "")("scoped takedown (db)", () => {
   let dbName: string;
 
   beforeAll(async () => {
-    dbName = `ksor_td_${randomBytes(4).toString("hex")}`;
+    dbName = `ksor_td_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
     admin = new pg.Pool({ connectionString: adminDsn, max: 1 });
     await admin.query(`CREATE DATABASE ${dbName}`);
     const url = new URL(adminDsn);

--- a/packages/content/src/lib/text-search-config.db.test.ts
+++ b/packages/content/src/lib/text-search-config.db.test.ts
@@ -17,6 +17,7 @@
  * the new one. That is a boot refusal, asserted here too.
  */
 
+import { randomBytes } from "node:crypto";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { contentPool } from "../db.js";
@@ -24,15 +25,14 @@ import { applySchema, storedTextSearchConfig } from "../schema.js";
 import type pg from "pg";
 
 const adminDsn = process.env["KSOR_DB_URL"] ?? "";
-const EN = "ksor_ts_english";
-const ES = "ksor_ts_spanish";
+const EN = `ksor_ts_english_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
+const ES = `ksor_ts_spanish_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
 
 describe.runIf(adminDsn !== "")("the record's text-search configuration (db)", () => {
   let admin: pg.Pool;
   const pools: pg.Pool[] = [];
 
   const provision = async (db: string, config: string): Promise<pg.Pool> => {
-    await admin.query(`DROP DATABASE IF EXISTS ${db} WITH (FORCE)`).catch(() => undefined);
     await admin.query(`CREATE DATABASE ${db}`);
     const url = new URL(adminDsn);
     url.pathname = `/${db}`;

--- a/packages/content/src/lib/vector-plan.db.test.ts
+++ b/packages/content/src/lib/vector-plan.db.test.ts
@@ -67,6 +67,7 @@
  * file is what proved they had not.
  */
 
+import { randomBytes } from "node:crypto";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { contentPool, runRead } from "../db.js";
@@ -76,7 +77,7 @@ import { WHOLE_RECORD_SCOPE } from "./audience.js";
 import type pg from "pg";
 
 const adminDsn = process.env["KSOR_DB_URL"] ?? "";
-const DB = "ksor_vector_plan";
+const DB = `ksor_vector_plan_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
 const TENANT = "planned";
 /** Enough rows that a sequential scan is genuinely the wrong answer. */
 const ROWS = 20_000;
@@ -88,7 +89,6 @@ describe.runIf(adminDsn !== "")("the serving query opens the vector index (db)",
   beforeAll(async () => {
     const { Pool } = (await import("pg")).default;
     admin = new Pool({ connectionString: adminDsn });
-    await admin.query(`DROP DATABASE IF EXISTS ${DB} WITH (FORCE)`).catch(() => undefined);
     await admin.query(`CREATE DATABASE ${DB}`);
     const url = new URL(adminDsn);
     url.pathname = `/${DB}`;

--- a/packages/content/src/migrate.db.test.ts
+++ b/packages/content/src/migrate.db.test.ts
@@ -9,6 +9,7 @@
  * could not be rebuilt survive.
  */
 
+import { randomBytes } from "node:crypto";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { readFileSync, readdirSync } from "node:fs";
@@ -29,7 +30,7 @@ import type { ContentInstance } from "./instance.js";
 import type pg from "pg";
 
 const adminDsn = process.env["KSOR_DB_URL"] ?? "";
-const DB = "ksor_migrate_test";
+const DB = `ksor_migrate_test_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
 const TENANT = "migrate-corp";
 
 /** What 2.2 added and 2.5 still carries (2.5 drops `visibility` for `audience`). */
@@ -68,7 +69,6 @@ describe.runIf(adminDsn !== "")("forward migration (db)", () => {
   beforeAll(async () => {
     const { Pool } = (await import("pg")).default;
     admin = new Pool({ connectionString: adminDsn });
-    await admin.query(`DROP DATABASE IF EXISTS ${DB} WITH (FORCE)`).catch(() => undefined);
     await admin.query(`CREATE DATABASE ${DB}`);
     const dsn = new URL(adminDsn);
     dsn.pathname = `/${DB}`;

--- a/packages/content/src/schema-concurrency.db.test.ts
+++ b/packages/content/src/schema-concurrency.db.test.ts
@@ -28,11 +28,14 @@ const adminDsn = process.env["KSOR_DB_URL"] ?? "";
 
 /**
  * Scratch databases for this suite: named so a leaked one is obviously ours,
- * and UNIQUE per run. Fixed names would have made this suite the thing it is
- * testing for — two concurrent `pnpm test:db` runs force-dropping each other's
- * databases mid-apply, which is issue #166's own symptom.
+ * UNIQUE per run, and stamped with the instant they were made. Fixed names
+ * would have made this suite the thing it is testing for — two concurrent
+ * `pnpm test:db` runs force-dropping each other's databases mid-apply, which is
+ * issue #166's own symptom. The stamp is what lets `scripts/db-reaper.mjs` drop
+ * these if the run is interrupted before the `finally` below.
  */
-const SCRATCH_PREFIX = `ksor_role_race_${randomBytes(4).toString("hex")}_`;
+const scratchName = (n: number): string =>
+  `ksor_role_race_${n}_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
 
 /** The admin DSN with its database swapped — `pg` has no API for this. */
 function dsnFor(dsn: string, database: string): string {
@@ -85,9 +88,8 @@ describe.runIf(adminDsn !== "")("applying the schema concurrently (db)", () => {
     // then on `pg_type_typname_nsp_index`, since every CREATE TABLE makes a row
     // type. Those are different races and not ones `applySchema` promises to
     // survive: its contract is "a fresh database".
-    const names = Array.from({ length: 6 }, (_unused, i) => `${SCRATCH_PREFIX}${i}`);
+    const names = Array.from({ length: 6 }, (_unused, i) => scratchName(i));
     for (const name of names) {
-      await admin.query(`DROP DATABASE IF EXISTS ${name} WITH (FORCE)`);
       await admin.query(`CREATE DATABASE ${name}`);
     }
     const pools = names.map(

--- a/packages/content/src/schema-concurrency.db.test.ts
+++ b/packages/content/src/schema-concurrency.db.test.ts
@@ -31,7 +31,7 @@ const adminDsn = process.env["KSOR_DB_URL"] ?? "";
  * UNIQUE per run, and stamped with the instant they were made. Fixed names
  * would have made this suite the thing it is testing for — two concurrent
  * `pnpm test:db` runs force-dropping each other's databases mid-apply, which is
- * issue #166's own symptom. The stamp is what lets `scripts/db-reaper.mjs` drop
+ * issue #166's own symptom. The stamp is what lets `scripts/db-reaper.ts` drop
  * these if the run is interrupted before the `finally` below.
  */
 const scratchName = (n: number): string =>

--- a/packages/content/src/schema-parity.db.test.ts
+++ b/packages/content/src/schema-parity.db.test.ts
@@ -27,6 +27,7 @@
  *                      by nothing.
  */
 
+import { randomBytes } from "node:crypto";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { runMigrations } from "./migrate.js";
@@ -34,8 +35,8 @@ import { applySchema, schemaVersion } from "./schema.js";
 import type pg from "pg";
 
 const adminDsn = process.env["KSOR_DB_URL"] ?? "";
-const FRESH_DB = "ksor_parity_fresh";
-const MIGRATED_DB = "ksor_parity_migrated";
+const FRESH_DB = `ksor_parity_fresh_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
+const MIGRATED_DB = `ksor_parity_migrated_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
 
 /** What 2.2 added to `content_nodes` and 2.5 still carries. */
 const V22_NODE_COLUMNS = ["corpus_id", "doc_status", "owner", "provenance", "superseded_by"];
@@ -104,7 +105,6 @@ describe.runIf(adminDsn !== "")(
 
     const create = async (db: string): Promise<pg.Pool> => {
       const { Pool } = (await import("pg")).default;
-      await admin.query(`DROP DATABASE IF EXISTS ${db} WITH (FORCE)`).catch(() => undefined);
       await admin.query(`CREATE DATABASE ${db}`);
       const pool = new Pool({ connectionString: dsnFor(db) });
       await applySchema(pool, 1536);

--- a/packages/content/src/takedown-ops.db.test.ts
+++ b/packages/content/src/takedown-ops.db.test.ts
@@ -9,6 +9,7 @@
  * ONE RECORD, not merely to the tenant.
  */
 
+import { randomBytes } from "node:crypto";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { contentPool, runIngest } from "./db.js";
@@ -22,7 +23,7 @@ import type { ContentInstance } from "./instance.js";
 import type pg from "pg";
 
 const adminDsn = process.env["KSOR_DB_URL"] ?? "";
-const DB = "ksor_takedown_ops_test";
+const DB = `ksor_takedown_ops_test_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
 const TENANT = "takedown-corp";
 
 const instance: ContentInstance = instanceOf(TENANT, TENANT);
@@ -58,7 +59,6 @@ describe.runIf(adminDsn !== "")("takedown read plane (db)", () => {
   beforeAll(async () => {
     const { Pool } = (await import("pg")).default;
     admin = new Pool({ connectionString: adminDsn });
-    await admin.query(`DROP DATABASE IF EXISTS ${DB} WITH (FORCE)`).catch(() => undefined);
     await admin.query(`CREATE DATABASE ${DB}`);
     const url = new URL(adminDsn);
     url.pathname = `/${DB}`;

--- a/packages/content/src/takedown-verb.db.test.ts
+++ b/packages/content/src/takedown-verb.db.test.ts
@@ -10,6 +10,7 @@
  * where they disagree is the one decision 19 exists to prevent.
  */
 
+import { randomBytes } from "node:crypto";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -26,7 +27,7 @@ import { applySchema } from "./schema.js";
 import type pg from "pg";
 
 const adminDsn = process.env["KSOR_DB_URL"] ?? "";
-const DB = "ksor_takedown_verb";
+const DB = `ksor_takedown_verb_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
 const TENANT = "takedown-corp";
 const DSN_ENV = "KSOR_TAKEDOWN_TEST_DSN";
 const ACTOR = "human:ciso";
@@ -100,7 +101,6 @@ describe.runIf(adminDsn !== "")("ksor takedown (db)", () => {
   beforeAll(async () => {
     const { Pool } = (await import("pg")).default;
     admin = new Pool({ connectionString: adminDsn });
-    await admin.query(`DROP DATABASE IF EXISTS ${DB} WITH (FORCE)`).catch(() => undefined);
     await admin.query(`CREATE DATABASE ${DB}`);
     const url = new URL(adminDsn);
     url.pathname = `/${DB}`;

--- a/packages/ksor/src/migrate.db.test.ts
+++ b/packages/ksor/src/migrate.db.test.ts
@@ -10,6 +10,7 @@
  * before a single query ran, with a refusal that blamed the database and told
  * the operator to run the command that had just refused.
  */
+import { randomBytes } from "node:crypto";
 import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -31,14 +32,17 @@ import { runMigrate } from "./migrate/index.js";
 
 const adminDsn = process.env["KSOR_DB_URL"] ?? "";
 /**
- * Suffixed with the ADMIN database's own name, so two checkouts of this
- * repository pointed at one cluster do not share a scratch database. A fixed
- * name is not merely untidy here: this suite drops its database `WITH (FORCE)`
- * between runs, which terminates the other checkout's connections mid-INSERT
- * with `terminating connection due to administrator command` — observed live
- * on a shared cluster.
+ * Unique per RUN, not merely per checkout. The incident this name was first
+ * written for is real and worth keeping: this suite used to drop its database
+ * `WITH (FORCE)` before creating it, which terminated another checkout's
+ * connections mid-INSERT with `terminating connection due to administrator
+ * command` — observed live on a shared cluster. Deriving the name from the
+ * admin database narrowed that to one checkout per cluster; the run stamp
+ * closes it, because two runs from the SAME checkout collided just as hard
+ * (issue #166). The pre-emptive drop is gone with it: a name nothing has ever
+ * used cannot have a leftover to clear.
  */
-const DB = `ksor_migrate_denials_${(adminDsn === "" ? "x" : new URL(adminDsn).pathname.slice(1)).replace(/[^a-z0-9_]/gi, "_")}`;
+const DB = `ksor_migrate_denials_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
 const TENANT = "acme";
 const DSN_ENV = "KSOR_MIGRATE_TEST_DSN";
 const ACTOR = "human:mjs";
@@ -96,7 +100,6 @@ describe.runIf(adminDsn !== "")("ksor migrate reads a declared database (db)", (
   beforeAll(async () => {
     const { Pool } = (await import("pg")).default;
     admin = new Pool({ connectionString: adminDsn });
-    await admin.query(`DROP DATABASE IF EXISTS ${DB} WITH (FORCE)`).catch(() => undefined);
     await admin.query(`CREATE DATABASE ${DB}`);
     const url = new URL(adminDsn);
     url.pathname = `/${DB}`;
@@ -197,7 +200,7 @@ describe.runIf(adminDsn !== "")("ksor migrate reads a declared database (db)", (
  * 2026-08-26).
  */
 describe.runIf(adminDsn !== "")("ksor migrate accounts for every denylist row (db)", () => {
-  const DB2 = `${DB}_repoint`;
+  const DB2 = `ksor_migrate_repoint_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
   const DSN_ENV2 = "KSOR_MIGRATE_REPOINT_DSN";
   const DENIER = "human:ciso";
   const DENIED_AT = "2026-07-01T09:00:00Z";
@@ -267,7 +270,6 @@ describe.runIf(adminDsn !== "")("ksor migrate accounts for every denylist row (d
   beforeAll(async () => {
     const { Pool } = (await import("pg")).default;
     admin2 = new Pool({ connectionString: adminDsn });
-    await admin2.query(`DROP DATABASE IF EXISTS ${DB2} WITH (FORCE)`).catch(() => undefined);
     await admin2.query(`CREATE DATABASE ${DB2}`);
     const url = new URL(adminDsn);
     url.pathname = `/${DB2}`;

--- a/packages/postgres/src/checkout-error.db.test.ts
+++ b/packages/postgres/src/checkout-error.db.test.ts
@@ -20,13 +20,14 @@
  * assertion is the run itself.
  */
 
+import { randomBytes } from "node:crypto";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 
 import { createPool, scopedTxn } from "./db.js";
 import type pg from "pg";
 
 const adminDsn = process.env["KSOR_DB_URL"] ?? "";
-const DB = "ksor_checkout_error_test";
+const DB = `ksor_checkout_error_test_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
 
 describe.runIf(adminDsn !== "")("a checked-out client losing its socket (db)", () => {
   let pool: pg.Pool;
@@ -40,7 +41,6 @@ describe.runIf(adminDsn !== "")("a checked-out client losing its socket (db)", (
   beforeAll(async () => {
     const { Pool } = (await import("pg")).default;
     admin = new Pool({ connectionString: adminDsn });
-    await admin.query(`DROP DATABASE IF EXISTS ${DB} WITH (FORCE)`).catch(() => undefined);
     await admin.query(`CREATE DATABASE ${DB}`);
     const url = new URL(adminDsn);
     url.pathname = `/${DB}`;

--- a/packages/postgres/src/connect-per-request.db.test.ts
+++ b/packages/postgres/src/connect-per-request.db.test.ts
@@ -12,13 +12,14 @@
  * what it says, and the cost difference is measured rather than assumed.
  */
 
+import { randomBytes } from "node:crypto";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 
 import { createPool, withGuardedClient } from "./db.js";
 import type pg from "pg";
 
 const adminDsn = process.env["KSOR_DB_URL"] ?? "";
-const DB = "ksor_per_request_test";
+const DB = `ksor_per_request_test_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
 
 describe.runIf(adminDsn !== "")("connect-per-request (db)", () => {
   let admin: pg.Pool;
@@ -33,7 +34,6 @@ describe.runIf(adminDsn !== "")("connect-per-request (db)", () => {
   beforeAll(async () => {
     const { Pool } = (await import("pg")).default;
     admin = new Pool({ connectionString: adminDsn });
-    await admin.query(`DROP DATABASE IF EXISTS ${DB} WITH (FORCE)`).catch(() => undefined);
     await admin.query(`CREATE DATABASE ${DB}`);
     const url = new URL(adminDsn);
     url.pathname = `/${DB}`;

--- a/packages/postgres/src/idle.db.test.ts
+++ b/packages/postgres/src/idle.db.test.ts
@@ -12,13 +12,14 @@
  * actually opens what it says.
  */
 
+import { randomBytes } from "node:crypto";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 import { createPool, prewarmPool } from "./db.js";
 import type pg from "pg";
 
 const adminDsn = process.env["KSOR_DB_URL"] ?? "";
-const DB = "ksor_idle_test";
+const DB = `ksor_idle_test_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
 
 describe.runIf(adminDsn !== "")("idle connection policy (db)", () => {
   let admin: pg.Pool;
@@ -71,7 +72,6 @@ describe.runIf(adminDsn !== "")("idle connection policy (db)", () => {
   beforeAll(async () => {
     const { Pool } = (await import("pg")).default;
     admin = new Pool({ connectionString: adminDsn });
-    await admin.query(`DROP DATABASE IF EXISTS ${DB} WITH (FORCE)`).catch(() => undefined);
     await admin.query(`CREATE DATABASE ${DB}`);
     const url = new URL(adminDsn);
     url.pathname = `/${DB}`;

--- a/packages/postgres/src/saturation.db.test.ts
+++ b/packages/postgres/src/saturation.db.test.ts
@@ -16,13 +16,14 @@
  * review of #43).
  */
 
+import { randomBytes } from "node:crypto";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { connectedCount, createPool, ConnectTimeoutError, PoolTimeoutError } from "./db.js";
 import type pg from "pg";
 
 const adminDsn = process.env["KSOR_DB_URL"] ?? "";
-const DB = "ksor_saturation_test";
+const DB = `ksor_saturation_test_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
 
 /**
  * TEST-NET-1 (RFC 5737), reserved for documentation and not routable: packets
@@ -43,7 +44,6 @@ describe.runIf(adminDsn !== "")("connect timeout: saturation vs cold start (db)"
   beforeAll(async () => {
     const { Pool } = (await import("pg")).default;
     admin = new Pool({ connectionString: adminDsn });
-    await admin.query(`DROP DATABASE IF EXISTS ${DB} WITH (FORCE)`).catch(() => undefined);
     await admin.query(`CREATE DATABASE ${DB}`);
     const url = new URL(adminDsn);
     url.pathname = `/${DB}`;

--- a/scripts/db-reaper.db.test.ts
+++ b/scripts/db-reaper.db.test.ts
@@ -1,0 +1,86 @@
+/**
+ * The reaper against a real cluster: it drops the leak and nothing else.
+ *
+ * `db-scratch.test.ts` covers which NAMES are reapable. This covers the part
+ * that can only be wrong against Postgres — that the sweep drops exactly the
+ * candidates, that an open connection saves a database even when its name and
+ * age qualify, and that a name from before this grammar is left alone.
+ *
+ * Names here are assembled from their fields rather than written as
+ * `ksor_…` literals, because the fixtures are deliberately shapes a suite is
+ * forbidden to use (guard rule 12): one too old, one not ours at all.
+ */
+
+import { randomBytes } from "node:crypto";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import pg from "pg";
+
+import { REAP_AFTER_MS } from "./lib/db-scratch.mjs";
+import { setup as reap } from "./db-reaper.mjs";
+
+const adminDsn = process.env["KSOR_DB_URL"] ?? "";
+
+/** A scratch name stamped `agoMs` in the past — the field order, built by hand. */
+const named = (slug: string, agoMs: number): string =>
+  ["ksor", slug, (Date.now() - agoMs).toString(36), randomBytes(3).toString("hex")].join("_");
+
+const HOUR = 60 * 60 * 1000;
+
+describe.runIf(adminDsn !== "")("the scratch-database reaper (db)", () => {
+  let admin: pg.Pool;
+  /** Held open for the whole suite, so `busy` never has zero backends. */
+  let occupant: pg.Client;
+
+  const leak = named("reapleak", REAP_AFTER_MS + HOUR);
+  const young = named("reapyoung", 0);
+  const busy = named("reapbusy", REAP_AFTER_MS + HOUR);
+  // No stamp to date it by: the shape a developer cluster still carries from
+  // before this grammar. The reaper must not guess.
+  const foreign = ["ksor", "reapforeign", "prod"].join("_");
+  const all = [leak, young, busy, foreign];
+
+  const exists = async (name: string): Promise<boolean> => {
+    const { rows } = await admin.query("SELECT 1 FROM pg_database WHERE datname = $1", [name]);
+    return rows.length === 1;
+  };
+
+  beforeAll(async () => {
+    admin = new pg.Pool({ connectionString: adminDsn, max: 1 });
+    for (const name of all) await admin.query(`CREATE DATABASE ${name}`);
+    const url = new URL(adminDsn);
+    url.pathname = `/${busy}`;
+    occupant = new pg.Client({ connectionString: url.toString() });
+    await occupant.connect();
+    await occupant.query("SELECT 1");
+  }, 120_000);
+
+  afterAll(async () => {
+    await occupant?.end().catch(() => undefined);
+    for (const name of all) {
+      await admin?.query(`DROP DATABASE IF EXISTS ${name} WITH (FORCE)`).catch(() => undefined);
+    }
+    await admin?.end().catch(() => undefined);
+  });
+
+  it("drops the leak, and spares the young, the busy and the unrecognised", async () => {
+    await reap();
+
+    // Reported together rather than one assertion each, so a failure prints the
+    // whole picture instead of the first thing that went wrong.
+    const after = Object.fromEntries(
+      await Promise.all(all.map(async (name) => [name, await exists(name)] as const)),
+    );
+    expect(after, "only the aged, idle, well-named database may be dropped").toEqual({
+      [leak]: false,
+      [young]: true,
+      [busy]: true,
+      [foreign]: true,
+    });
+  }, 120_000);
+
+  it("is safe to run twice — a swept cluster is a no-op", async () => {
+    await expect(reap()).resolves.toBeUndefined();
+    expect(await exists(young), "a second sweep must not age the survivors in").toBe(true);
+  }, 120_000);
+});

--- a/scripts/db-reaper.db.test.ts
+++ b/scripts/db-reaper.db.test.ts
@@ -14,10 +14,9 @@
 import { randomBytes } from "node:crypto";
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import pg from "pg";
 
-import { REAP_AFTER_MS } from "./lib/db-scratch.mjs";
-import { setup as reap } from "./db-reaper.mjs";
+import { REAP_AFTER_MS } from "./lib/db-scratch.js";
+import { type Connectable, type Queryable, pg, setup as reap } from "./db-reaper.js";
 
 const adminDsn = process.env["KSOR_DB_URL"] ?? "";
 
@@ -28,9 +27,9 @@ const named = (slug: string, agoMs: number): string =>
 const HOUR = 60 * 60 * 1000;
 
 describe.runIf(adminDsn !== "")("the scratch-database reaper (db)", () => {
-  let admin: pg.Pool;
+  let admin: Queryable;
   /** Held open for the whole suite, so `busy` never has zero backends. */
-  let occupant: pg.Client;
+  let occupant: Connectable;
 
   const leak = named("reapleak", REAP_AFTER_MS + HOUR);
   const young = named("reapyoung", 0);
@@ -63,6 +62,10 @@ describe.runIf(adminDsn !== "")("the scratch-database reaper (db)", () => {
     await admin?.end().catch(() => undefined);
   });
 
+  // What saves `busy` is that the reaper drops WITHOUT (FORCE), not the backend
+  // count it also reads: deleting that count keeps this test green, because the
+  // drop still fails on a connected database. Recorded so nobody deletes the
+  // wrong one of the two.
   it("drops the leak, and spares the young, the busy and the unrecognised", async () => {
     await reap();
 

--- a/scripts/db-reaper.mjs
+++ b/scripts/db-reaper.mjs
@@ -1,0 +1,95 @@
+/**
+ * Drop the scratch databases an INTERRUPTED db-tier run left behind.
+ *
+ * Vitest `globalSetup` for `vitest.db.config.ts`, so it runs once before the
+ * tier and never during it.
+ *
+ * Why this exists at all: every `.db.test.ts` now bootstraps a database under a
+ * name unique to its run (guard rule 12), which is what stops two runs against
+ * one cluster from dropping each other's database `WITH (FORCE)` mid-INSERT —
+ * the failure issue #166 opens with, and the one the fixed names caused. But
+ * unique names alone would trade a visible failure for an invisible one: a run
+ * killed with Ctrl-C never reaches its `afterAll`, and the database it made
+ * stays on the cluster forever under a name nothing will ever reuse. So the
+ * rename and the reaper land together; either half on its own is worse than
+ * neither.
+ *
+ * Three conditions before anything is dropped, because a drop is not
+ * recoverable:
+ *
+ *   1. the name parses as the scratch grammar, timestamp and all
+ *      (`parseScratchName` — `ksor_` on its own is NOT evidence);
+ *   2. that timestamp is at least REAP_AFTER_MS old, so a database a
+ *      concurrent run created seconds ago and has not connected to yet is
+ *      never a candidate;
+ *   3. Postgres reports no backends on it — checked, and then relied on by
+ *      dropping WITHOUT (FORCE), so a connection that arrives in between makes
+ *      the drop fail rather than making it kill somebody's work.
+ *
+ * Failures here are reported and swallowed. The reaper is housekeeping: a
+ * cluster that will not let us tidy up is not a reason to refuse to run the
+ * tests, and the tests themselves say plainly enough when the database is
+ * unusable.
+ */
+
+import { createRequire } from "node:module";
+
+import { REAP_AFTER_MS, parseScratchName } from "./lib/db-scratch.mjs";
+
+// `pg` is a dependency of ksor-postgres, not of the root workspace, and pnpm's
+// strict layout means the root cannot resolve it. Anchoring `require` at that
+// package's manifest borrows its resolution without adding a root devDependency
+// for a housekeeping script.
+const require = createRequire(new URL("../packages/postgres/package.json", import.meta.url));
+
+export async function setup() {
+  const adminDsn = process.env["KSOR_DB_URL"] ?? "";
+  if (adminDsn === "") return;
+
+  /** @type {import("pg")} */
+  const pg = require("pg");
+  const admin = new pg.Pool({ connectionString: adminDsn, max: 1 });
+  try {
+    const { rows } = await admin.query(
+      `SELECT d.datname AS name,
+              (SELECT count(*)::int FROM pg_stat_activity a WHERE a.datname = d.datname) AS backends
+         FROM pg_database d
+        WHERE d.datname LIKE 'ksor\\_%' AND NOT d.datistemplate`,
+    );
+    const now = Date.now();
+    const dropped = [];
+    const skipped = [];
+    for (const row of rows) {
+      const parsed = parseScratchName(row.name, now);
+      if (parsed === null) continue;
+      const ageMs = now - parsed.createdAtMs;
+      if (ageMs < REAP_AFTER_MS) continue;
+      if (row.backends > 0) {
+        skipped.push(`${row.name} (${row.backends} connection(s))`);
+        continue;
+      }
+      try {
+        // No (FORCE): if something connected between the count above and here,
+        // this must fail rather than terminate it.
+        await admin.query(`DROP DATABASE ${row.name}`);
+        dropped.push(row.name);
+      } catch (error) {
+        skipped.push(`${row.name} (${error instanceof Error ? error.message : String(error)})`);
+      }
+    }
+    if (dropped.length > 0) {
+      console.log(
+        `db-reaper: dropped ${dropped.length} scratch database(s) left by an interrupted run: ${dropped.join(", ")}`,
+      );
+    }
+    if (skipped.length > 0) {
+      console.log(`db-reaper: left in place: ${skipped.join(", ")}`);
+    }
+  } catch (error) {
+    console.warn(
+      `db-reaper: could not sweep stale scratch databases — ${error instanceof Error ? error.message : String(error)}`,
+    );
+  } finally {
+    await admin.end().catch(() => undefined);
+  }
+}

--- a/scripts/db-reaper.ts
+++ b/scripts/db-reaper.ts
@@ -22,9 +22,14 @@
  *   2. that timestamp is at least REAP_AFTER_MS old, so a database a
  *      concurrent run created seconds ago and has not connected to yet is
  *      never a candidate;
- *   3. Postgres reports no backends on it — checked, and then relied on by
- *      dropping WITHOUT (FORCE), so a connection that arrives in between makes
- *      the drop fail rather than making it kill somebody's work.
+ *   3. the drop is issued WITHOUT (FORCE), so a connected database refuses to
+ *      be dropped instead of having its connections terminated.
+ *
+ * The backend count is read too, but it is a COURTESY and not the guarantee:
+ * deleting that check leaves the reaper correct, because the drop still fails
+ * on a busy database — proved by mutation, which is why it is written down
+ * here. What the count buys is a legible log line ("2 connections") instead of
+ * a Postgres error. The absence of FORCE is the thing that must never go.
  *
  * Failures here are reported and swallowed. The reaper is housekeeping: a
  * cluster that will not let us tidy up is not a reason to refuse to run the
@@ -34,31 +39,51 @@
 
 import { createRequire } from "node:module";
 
-import { REAP_AFTER_MS, parseScratchName } from "./lib/db-scratch.mjs";
+import { REAP_AFTER_MS, parseScratchName } from "./lib/db-scratch.js";
 
-// `pg` is a dependency of ksor-postgres, not of the root workspace, and pnpm's
-// strict layout means the root cannot resolve it. Anchoring `require` at that
-// package's manifest borrows its resolution without adding a root devDependency
-// for a housekeeping script.
-const require = createRequire(new URL("../packages/postgres/package.json", import.meta.url));
+/** Exactly the slice of `pg` this file and its test use. */
+export interface Queryable {
+  query(text: string, values?: readonly unknown[]): Promise<{ rows: readonly unknown[] }>;
+  end(): Promise<void>;
+}
+export interface Connectable extends Queryable {
+  connect(): Promise<void>;
+}
+export interface PgSlice {
+  Pool: new (config: { connectionString: string; max?: number }) => Queryable;
+  Client: new (config: { connectionString: string }) => Connectable;
+}
 
-export async function setup() {
+/**
+ * `pg` is a dependency of ksor-postgres, not of the root workspace, and pnpm's
+ * strict layout means `scripts/` cannot resolve it. Anchoring `require` at that
+ * package's manifest borrows its resolution without adding a root
+ * devDependency for a housekeeping script.
+ */
+export const pg: PgSlice = createRequire(
+  new URL("../packages/postgres/package.json", import.meta.url),
+)("pg") as PgSlice;
+
+interface DatabaseRow {
+  readonly name: string;
+  readonly backends: number;
+}
+
+export async function setup(): Promise<void> {
   const adminDsn = process.env["KSOR_DB_URL"] ?? "";
   if (adminDsn === "") return;
 
-  /** @type {import("pg")} */
-  const pg = require("pg");
   const admin = new pg.Pool({ connectionString: adminDsn, max: 1 });
   try {
-    const { rows } = await admin.query(
+    const { rows } = (await admin.query(
       `SELECT d.datname AS name,
               (SELECT count(*)::int FROM pg_stat_activity a WHERE a.datname = d.datname) AS backends
          FROM pg_database d
         WHERE d.datname LIKE 'ksor\\_%' AND NOT d.datistemplate`,
-    );
+    )) as { rows: readonly DatabaseRow[] };
     const now = Date.now();
-    const dropped = [];
-    const skipped = [];
+    const dropped: string[] = [];
+    const skipped: string[] = [];
     for (const row of rows) {
       const parsed = parseScratchName(row.name, now);
       if (parsed === null) continue;

--- a/scripts/db-scratch.test.ts
+++ b/scripts/db-scratch.test.ts
@@ -10,7 +10,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { REAP_AFTER_MS, SCRATCH_LITERAL, parseScratchName } from "./lib/db-scratch.mjs";
+import { REAP_AFTER_MS, parseScratchName } from "./lib/db-scratch.js";
 
 const NOW = Date.UTC(2026, 7, 30, 12, 0, 0);
 const stamp = (at: number): string => at.toString(36);
@@ -56,20 +56,14 @@ describe("parseScratchName refuses anything it cannot prove is ours", () => {
   });
 });
 
-describe("the literal guard rule 12 requires", () => {
-  it("matches the canonical form", () => {
-    expect(
-      SCRATCH_LITERAL.test(
-        '`ksor_idle_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`',
-      ),
-    ).toBe(true);
-  });
-
-  it("produces a name the reaper can then parse", () => {
-    // The two halves of the contract meeting: the shape the tests must write,
-    // evaluated, is a shape the reaper recognises. Guard rule 12 asserts this
-    // too, so a change to either side fails twice rather than silently leaking.
-    const built = `ksor_idle_${Date.now().toString(36)}_3f2c8e`;
+describe("the shape guard rule 12 requires", () => {
+  it("evaluates to a name the reaper can parse", () => {
+    // The two halves of the contract meeting. Rule 12 makes every suite write
+    // a name carrying `Date.now().toString(36)` and a `randomBytes` suffix;
+    // this is that name, evaluated, being one the reaper recognises. The guard
+    // asserts the same round trip itself, so a change to either side fails
+    // twice rather than silently leaking every scratch database forever.
+    const built = `ksor_idle_${Date.now().toString(36)}_${"3f2c8e"}`;
     expect(parseScratchName(built)).not.toBeNull();
   });
 });

--- a/scripts/db-scratch.test.ts
+++ b/scripts/db-scratch.test.ts
@@ -1,0 +1,84 @@
+/**
+ * What the reaper is allowed to drop.
+ *
+ * `parseScratchName` is the only thing standing between "tidy up after an
+ * interrupted run" and "drop somebody's database", so it is tested in the
+ * refusing direction first: a name it refuses is left alone forever, a name it
+ * accepts may be DROPPED. `ksor_` on its own is not evidence — an adopter's own
+ * database on a shared cluster may well start that way.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { REAP_AFTER_MS, SCRATCH_LITERAL, parseScratchName } from "./lib/db-scratch.mjs";
+
+const NOW = Date.UTC(2026, 7, 30, 12, 0, 0);
+const stamp = (at: number): string => at.toString(36);
+
+describe("parseScratchName accepts a scratch name", () => {
+  it("reads the instant back out of the name", () => {
+    const made = NOW - 5 * 60_000;
+    const parsed = parseScratchName(`ksor_idle_${stamp(made)}_3f2c8e`, NOW);
+    expect(parsed?.createdAtMs, "the stamp is the creation instant").toBe(made);
+  });
+
+  it("tolerates a multi-part slug", () => {
+    // `ksor_governance_generation_…` — the slug is everything between the
+    // prefix and the last two fields, so parsing has to come from the RIGHT.
+    const parsed = parseScratchName(`ksor_governance_generation_${stamp(NOW)}_a1b2c3`, NOW);
+    expect(parsed?.createdAtMs).toBe(NOW);
+  });
+
+  it("tolerates a digit in the slug, which the concurrency suite uses", () => {
+    expect(parseScratchName(`ksor_role_race_4_${stamp(NOW)}_a1b2c3`, NOW)).not.toBeNull();
+  });
+});
+
+describe("parseScratchName refuses anything it cannot prove is ours", () => {
+  const refused: readonly (readonly [string, string])[] = [
+    ["ksor_production", "a plausible adopter database — no stamp, no random suffix"],
+    ["knowledge_base", "not even the prefix"],
+    [`ksor_${stamp(NOW)}_a1b2c3`, "no slug at all, so a bare two-field name cannot qualify"],
+    [`ksor_idle_${stamp(NOW)}_A1B2C3`, "uppercase — the suffix is lowercase hex or nothing"],
+    [`ksor_idle_${stamp(NOW)}_a1b2c`, "five hex characters, not six"],
+    [`ksor_idle_${stamp(NOW)}_a1b2c3d`, "seven hex characters, not six"],
+    ["ksor_idle_notbase36!_a1b2c3", "a stamp that is not base36"],
+    [`ksor_idle_${stamp(Date.UTC(2019, 0, 1))}_a1b2c3`, "an instant before this project existed"],
+    [`ksor_idle_${stamp(NOW + 2 * 86_400_000)}_a1b2c3`, "two days in the future"],
+    // A leaked database from BEFORE this grammar shipped. It is left alone on
+    // purpose: the reaper cannot date it, and guessing is how it would drop
+    // something that matters. Sweeping those is a one-off by hand.
+    ["ksor_r19_1787829592", "the pre-#166 shape, found live on a developer cluster"],
+  ];
+
+  it.each(refused)("%s — %s", (name) => {
+    expect(parseScratchName(name, NOW), `${name} must not be reapable`).toBeNull();
+  });
+});
+
+describe("the literal guard rule 12 requires", () => {
+  it("matches the canonical form", () => {
+    expect(
+      SCRATCH_LITERAL.test(
+        '`ksor_idle_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`',
+      ),
+    ).toBe(true);
+  });
+
+  it("produces a name the reaper can then parse", () => {
+    // The two halves of the contract meeting: the shape the tests must write,
+    // evaluated, is a shape the reaper recognises. Guard rule 12 asserts this
+    // too, so a change to either side fails twice rather than silently leaking.
+    const built = `ksor_idle_${Date.now().toString(36)}_3f2c8e`;
+    expect(parseScratchName(built)).not.toBeNull();
+  });
+});
+
+describe("the reaping window", () => {
+  it("is long enough that a running suite is never a candidate", () => {
+    // The db tier's own hook timeout is 180s and a full serial run is minutes,
+    // so the window has to exceed a whole run by a wide margin — a database
+    // dropped out from under a live suite is exactly the #166 failure, moved.
+    expect(REAP_AFTER_MS).toBeGreaterThan(60 * 60 * 1000);
+  });
+});

--- a/scripts/guard-invariants.integration.test.ts
+++ b/scripts/guard-invariants.integration.test.ts
@@ -39,10 +39,11 @@ function harness(): string {
 
   mkdirSync(path.join(root, "scripts", "lib"), { recursive: true });
   copyFileSync(script, path.join(root, "scripts", "guard-invariants.mjs"));
-  copyFileSync(
-    path.join(scriptsDir, "lib", "frontmatter.mjs"),
-    path.join(root, "scripts", "lib", "frontmatter.mjs"),
-  );
+  // Every module the guard imports, or it dies on resolution before a single
+  // rule runs — which is how this harness noticed rule 12's new import.
+  for (const lib of ["frontmatter.mjs", "db-scratch.ts"]) {
+    copyFileSync(path.join(scriptsDir, "lib", lib), path.join(root, "scripts", "lib", lib));
+  }
 
   writeFileSync(path.join(root, "AGENTS.md"), "# Agents\n");
   symlinkSync("AGENTS.md", path.join(root, "CLAUDE.md"));

--- a/scripts/guard-invariants.mjs
+++ b/scripts/guard-invariants.mjs
@@ -10,6 +10,7 @@ import { existsSync, lstatSync, readFileSync, readdirSync, readlinkSync } from "
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { parseScratchName } from "./lib/db-scratch.mjs";
 import { parseFrontmatter } from "./lib/frontmatter.mjs";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -451,9 +452,90 @@ if (!isSymlinkTo(path.join(repoRoot, "CLAUDE.md"), "AGENTS.md")) {
   }
 }
 
+// Rule 12 — every scratch database a `.db.test.ts` creates is named uniquely
+// per RUN, and stamped with the instant it was made.
+//
+// Fixed names are what issue #166 opens with: a suite that bootstraps
+// `ksor_idle_test` and drops it `WITH (FORCE)` terminates the connections of
+// any OTHER run using that name — a second `pnpm test:db` on the same cluster,
+// a CI matrix job, an agent running the tier while a person does. It surfaces
+// as a missing table or a row count short, which reads as flakiness, and the
+// natural response to flakiness is to re-run and stop believing the tier.
+//
+// The stamp is not decoration. Postgres records no creation time for a
+// database, so without one in the name `scripts/db-reaper.mjs` cannot tell a
+// database an interrupted run leaked from one a CONCURRENT run made seconds
+// ago — and unique names with no reaper only trade a visible failure for an
+// invisible one.
+//
+// Checked as TEXT rather than by tracing a declaration, and deliberately: the
+// alternative was a shared `scratchDb()` helper, which the next suite can
+// simply not call, with nothing going red. This fails on the file that wrote
+// the name.
+{
+  const dbTests = [];
+  const walkTests = (dir) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name === "node_modules" || entry.name === "dist") continue;
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walkTests(full);
+      else if (entry.name.endsWith(".db.test.ts")) dbTests.push(full);
+    }
+  };
+  // Both roots the db tier collects from (vitest.db.config.ts).
+  for (const root of ["packages", "scripts"]) {
+    const dir = path.join(repoRoot, root);
+    if (existsSync(dir)) walkTests(dir);
+  }
+
+  const WHY =
+    "a fixed or unstamped scratch name lets two runs on one cluster drop each other's database mid-test (#166), and leaves the reaper unable to tell a leak from a live run's database";
+  const FIX =
+    'name it `ksor_<slug>_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}` — see any .db.test.ts';
+
+  for (const file of dbTests) {
+    const rel = path.relative(repoRoot, file);
+    // Comments are stripped first: a doc comment that QUOTES the shape it is
+    // warning about is not a violation, and failing on prose would teach
+    // authors to stop writing the prose.
+    const text = readFileSync(file, "utf8")
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/^[ \t]*\/\/.*$/gm, "");
+
+    // A plain string is never a legitimate scratch name any more. Role names in
+    // this tier are `sor_`-prefixed, so `ksor_` in quotes is always this defect.
+    for (const match of text.matchAll(/"(ksor_[a-z0-9_]*)"/g)) {
+      violate(12, `${rel} names a scratch database with the fixed string "${match[1]}"`, WHY, FIX);
+    }
+
+    // …and a template literal starting `ksor_` must carry both halves.
+    for (const match of text.matchAll(/`ksor_[^`]*`/g)) {
+      const literal = match[0];
+      const missing = [];
+      if (!literal.includes("Date.now().toString(36)")) missing.push("the run stamp");
+      if (!literal.includes("randomBytes(")) missing.push("the random suffix");
+      if (missing.length > 0) {
+        violate(12, `${rel} builds ${literal} without ${missing.join(" or ")}`, WHY, FIX);
+      }
+    }
+  }
+
+  // The reaper reads names the guard admits, so a change to either that stops
+  // them agreeing is caught here rather than by a database nobody drops.
+  const sample = `ksor_idle_${Date.now().toString(36)}_3f2c8e`;
+  if (parseScratchName(sample) === null) {
+    violate(
+      12,
+      `scripts/db-reaper.mjs would not recognise ${sample} as a scratch database`,
+      "the reaper only drops names it can parse, so a grammar it disagrees with means every scratch database leaks forever",
+      "reconcile parseScratchName in scripts/lib/db-scratch.mjs with the literal this rule requires",
+    );
+  }
+}
+
 if (violations.length > 0) {
   console.error(`guard: ${violations.length} invariant violation(s):\n`);
   for (const v of violations) console.error(`  ${v}\n`);
   process.exit(1);
 }
-console.log("guard: ok (11 rules)");
+console.log("guard: ok (12 rules)");

--- a/scripts/guard-invariants.mjs
+++ b/scripts/guard-invariants.mjs
@@ -10,7 +10,11 @@ import { existsSync, lstatSync, readFileSync, readdirSync, readlinkSync } from "
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { parseScratchName } from "./lib/db-scratch.mjs";
+// A `.ts` module imported from plain node: Node >= 24 (the engines floor)
+// strips types natively, so the grammar can be shared with the TypeScript
+// tests without a build step and without a second copy. This is Node, not
+// the TypeScript compiler API — coding principle 2 is untouched.
+import { parseScratchName } from "./lib/db-scratch.ts";
 import { parseFrontmatter } from "./lib/frontmatter.mjs";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -463,7 +467,7 @@ if (!isSymlinkTo(path.join(repoRoot, "CLAUDE.md"), "AGENTS.md")) {
 // natural response to flakiness is to re-run and stop believing the tier.
 //
 // The stamp is not decoration. Postgres records no creation time for a
-// database, so without one in the name `scripts/db-reaper.mjs` cannot tell a
+// database, so without one in the name `scripts/db-reaper.ts` cannot tell a
 // database an interrupted run leaked from one a CONCURRENT run made seconds
 // ago — and unique names with no reaper only trade a visible failure for an
 // invisible one.
@@ -526,9 +530,9 @@ if (!isSymlinkTo(path.join(repoRoot, "CLAUDE.md"), "AGENTS.md")) {
   if (parseScratchName(sample) === null) {
     violate(
       12,
-      `scripts/db-reaper.mjs would not recognise ${sample} as a scratch database`,
+      `scripts/db-reaper.ts would not recognise ${sample} as a scratch database`,
       "the reaper only drops names it can parse, so a grammar it disagrees with means every scratch database leaks forever",
-      "reconcile parseScratchName in scripts/lib/db-scratch.mjs with the literal this rule requires",
+      "reconcile parseScratchName in scripts/lib/db-scratch.ts with the literal this rule requires",
     );
   }
 }

--- a/scripts/lib/db-scratch.mjs
+++ b/scripts/lib/db-scratch.mjs
@@ -1,0 +1,67 @@
+/**
+ * The grammar of a db-tier scratch database name, in ONE place.
+ *
+ * Two programs read it — guard rule 12, which requires every `.db.test.ts` to
+ * name its scratch database this way, and `scripts/db-reaper.mjs`, which drops
+ * the ones an interrupted run left behind. A reaper that parses a shape the
+ * guard does not enforce would either miss leaks or, far worse, drop a database
+ * it cannot prove is ours.
+ *
+ *     ksor_<slug>_<created-at, base36 ms>_<6 random hex>
+ *     ksor_idle_mfr3k9a1_3f2c8e
+ *
+ * The timestamp is IN THE NAME on purpose. Postgres records no creation time
+ * for a database — `pg_database` has no such column, and reading it off the
+ * data directory needs `pg_read_server_files`, which a managed Postgres does
+ * not grant. Without an age the reaper cannot tell a leak from a database a
+ * CONCURRENT run created seconds ago and has not connected to yet, and dropping
+ * that is the failure the reaper exists to prevent.
+ */
+
+/** Nothing before this could be one of ours; guards against matching an adopter's own name. */
+const EPOCH_FLOOR = Date.UTC(2020, 0, 1);
+
+/**
+ * Parse a scratch name, or answer `null` for anything that is not certainly one.
+ *
+ * Deliberately strict in the one direction that matters: a name this refuses is
+ * left alone forever, and a name it accepts may be DROPPED. `ksor_` alone is not
+ * evidence — an adopter's own database on a shared cluster may well start that
+ * way — so acceptance needs the whole shape AND a timestamp that is a plausible
+ * instant rather than merely base36.
+ *
+ * @param {string} name
+ * @param {number} [now]
+ * @returns {{ createdAtMs: number } | null}
+ */
+export function parseScratchName(name, now = Date.now()) {
+  if (!name.startsWith("ksor_")) return null;
+  const parts = name.split("_");
+  // ksor + at least one slug part + stamp + random
+  if (parts.length < 4) return null;
+  const random = parts.at(-1);
+  const stamp = parts.at(-2);
+  if (random === undefined || stamp === undefined) return null;
+  if (!/^[0-9a-f]{6}$/.test(random)) return null;
+  if (!/^[0-9a-z]{6,10}$/.test(stamp)) return null;
+  const createdAtMs = Number.parseInt(stamp, 36);
+  if (!Number.isFinite(createdAtMs)) return null;
+  // A clock ahead of ours by a little is ordinary on a shared cluster; a day is
+  // not, and a name minted before this project existed is somebody else's.
+  if (createdAtMs < EPOCH_FLOOR || createdAtMs > now + 86_400_000) return null;
+  return { createdAtMs };
+}
+
+/**
+ * The literal a `.db.test.ts` must use, as a regular expression.
+ *
+ * The tests build the name INLINE rather than calling a helper, and guard rule
+ * 12 checks the literal. That is the stronger of the two: a helper can be
+ * bypassed by the next suite that writes its own string and nothing goes red,
+ * whereas the guard fails on exactly that file.
+ */
+export const SCRATCH_LITERAL =
+  /^`ksor_[a-z0-9]+(?:_[a-z0-9]+)*_\$\{Date\.now\(\)\.toString\(36\)\}_\$\{randomBytes\(3\)\.toString\("hex"\)\}`$/;
+
+/** How long a scratch database must have existed before the reaper will drop it. */
+export const REAP_AFTER_MS = 3 * 60 * 60 * 1000;

--- a/scripts/lib/db-scratch.ts
+++ b/scripts/lib/db-scratch.ts
@@ -2,7 +2,7 @@
  * The grammar of a db-tier scratch database name, in ONE place.
  *
  * Two programs read it — guard rule 12, which requires every `.db.test.ts` to
- * name its scratch database this way, and `scripts/db-reaper.mjs`, which drops
+ * name its scratch database this way, and `scripts/db-reaper.ts`, which drops
  * the ones an interrupted run left behind. A reaper that parses a shape the
  * guard does not enforce would either miss leaks or, far worse, drop a database
  * it cannot prove is ours.
@@ -19,7 +19,12 @@
  */
 
 /** Nothing before this could be one of ours; guards against matching an adopter's own name. */
-const EPOCH_FLOOR = Date.UTC(2020, 0, 1);
+const EPOCH_FLOOR: number = Date.UTC(2020, 0, 1);
+
+export interface ScratchName {
+  /** The instant encoded in the name, which is the only age the reaper has. */
+  readonly createdAtMs: number;
+}
 
 /**
  * Parse a scratch name, or answer `null` for anything that is not certainly one.
@@ -29,12 +34,8 @@ const EPOCH_FLOOR = Date.UTC(2020, 0, 1);
  * evidence — an adopter's own database on a shared cluster may well start that
  * way — so acceptance needs the whole shape AND a timestamp that is a plausible
  * instant rather than merely base36.
- *
- * @param {string} name
- * @param {number} [now]
- * @returns {{ createdAtMs: number } | null}
  */
-export function parseScratchName(name, now = Date.now()) {
+export function parseScratchName(name: string, now: number = Date.now()): ScratchName | null {
   if (!name.startsWith("ksor_")) return null;
   const parts = name.split("_");
   // ksor + at least one slug part + stamp + random
@@ -52,16 +53,5 @@ export function parseScratchName(name, now = Date.now()) {
   return { createdAtMs };
 }
 
-/**
- * The literal a `.db.test.ts` must use, as a regular expression.
- *
- * The tests build the name INLINE rather than calling a helper, and guard rule
- * 12 checks the literal. That is the stronger of the two: a helper can be
- * bypassed by the next suite that writes its own string and nothing goes red,
- * whereas the guard fails on exactly that file.
- */
-export const SCRATCH_LITERAL =
-  /^`ksor_[a-z0-9]+(?:_[a-z0-9]+)*_\$\{Date\.now\(\)\.toString\(36\)\}_\$\{randomBytes\(3\)\.toString\("hex"\)\}`$/;
-
 /** How long a scratch database must have existed before the reaper will drop it. */
-export const REAP_AFTER_MS = 3 * 60 * 60 * 1000;
+export const REAP_AFTER_MS: number = 3 * 60 * 60 * 1000;

--- a/vitest.db.config.ts
+++ b/vitest.db.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     // rule 12), which is what stops two runs dropping each other's — but a run
     // killed with Ctrl-C never reaches its `afterAll`, and a unique name is one
     // nothing will ever reuse. The rename and the reaper are one change.
-    globalSetup: ["scripts/db-reaper.mjs"],
+    globalSetup: ["scripts/db-reaper.ts"],
     // Suites get their own DATABASE, but Postgres ROLES are cluster-global:
     // two suites applying schema.sql concurrently raced its check-then-act
     // CREATE ROLE into a pg_authid duplicate-key error (found live in CI,

--- a/vitest.db.config.ts
+++ b/vitest.db.config.ts
@@ -8,18 +8,28 @@ import { defineConfig } from "vitest/config";
 // container; dev uses local Postgres or a throwaway Neon.
 export default defineConfig({
   test: {
-    include: ["packages/*/src/**/*.db.test.ts"],
+    include: ["packages/*/src/**/*.db.test.ts", "scripts/**/*.db.test.ts"],
     testTimeout: 60_000,
     hookTimeout: 180_000,
+    // Drop the scratch databases an INTERRUPTED run left behind, before this
+    // one starts. Every suite now names its database uniquely per run (guard
+    // rule 12), which is what stops two runs dropping each other's — but a run
+    // killed with Ctrl-C never reaches its `afterAll`, and a unique name is one
+    // nothing will ever reuse. The rename and the reaper are one change.
+    globalSetup: ["scripts/db-reaper.mjs"],
     // Suites get their own DATABASE, but Postgres ROLES are cluster-global:
     // two suites applying schema.sql concurrently raced its check-then-act
     // CREATE ROLE into a pg_authid duplicate-key error (found live in CI,
     // 2026-08-19). That cause is GONE — the DDL tolerates the race now, on
-    // both paths that create a role (issue #166) — and the setting stays,
-    // because it was never the only reason: 27 of these suites still bootstrap
-    // a scratch database under a FIXED name and drop it `WITH (FORCE)`, so two
-    // files running at once still terminate each other's connections. Removing
-    // this is that half of #166, not this one.
+    // both paths that create a role (issue #166) — and so is the second one,
+    // the fixed scratch names that let two files force-drop each other's
+    // database mid-test.
+    //
+    // What keeps it false is now a BUDGET, not a bug: these suites hold pools,
+    // and running 40 files at once against one Postgres asks for more backends
+    // than a default `max_connections` of 100 will give. Raising this is a
+    // measurement (how many workers a 100-connection cluster survives), not a
+    // one-line flip.
     fileParallelism: false,
   },
 });


### PR DESCRIPTION
## Problem

Twenty-eight `.db.test.ts` suites bootstrapped a scratch database under a **fixed** name (`ksor_idle_test`, `ksor_audience_test`, …) and dropped it `WITH (FORCE)` before creating it. Two runs against one cluster therefore terminated each other's connections mid-test — a second `pnpm test:db`, a CI matrix job, an agent running the tier while a person does.

It surfaces as a missing table or a row count short, so it reads as flakiness, and the response to flakiness is to re-run and stop believing the tier. That matters more here than in most repos: the db tier is where this project's SQL governance guarantees are actually held.

Reproduced on the tip of `main`, four simultaneous runs of one suite:

```
run1..run4:  Test Files  1 failed (1)
error: database "ksor_audience_test" does not exist
```

## Solution

**One name per run, stamped.** Every scratch database is now
`ksor_<slug>_<base36 ms>_<6 hex>`. The pre-emptive `DROP … WITH (FORCE)` before each `CREATE` is gone with the fixed names — a name nothing has ever used cannot have a leftover to clear, and that drop was the dangerous verb. Teardown keeps its FORCE, where it can only ever reach the suite's own database.

**The stamp is load-bearing, not decoration.** Postgres records no creation time for a database (`pg_database` has no such column; reading it off the data directory needs `pg_read_server_files`, which managed Postgres does not grant). Without an age, a sweep cannot tell a leak from a database a *concurrent* run made seconds ago.

**The reaper lands in the same change.** Unique names on their own would trade a visible failure for an invisible one: a run killed with Ctrl-C never reaches its `afterAll`, and the database it made sits there forever under a name nothing will reuse. `scripts/db-reaper.ts` is the tier's `globalSetup` and drops only what parses as ours, is ≥3h old, and has no backends — issued **without** `(FORCE)`, so a connection arriving in between fails the drop rather than killing work.

**Guard rule 12** requires the shape, checked as text. The alternative was a shared `scratchDb()` helper, which the next suite can simply not call with nothing going red; the guard fails on the file that wrote the name.

## Behaviour

Same four simultaneous runs, on this branch:

```
run1..run4:  Test Files  1 passed (1)   Tests  9 passed | 1 skipped (10)
```

Full tiers, local Postgres 17.7 + pgvector 0.8.2:

| tier | before | after |
|---|---|---|
| db | 39 passed, 1 skipped · 297 tests | **40 passed, 1 skipped · 299 tests** |
| unit | 1548 | 1547 (+15 new, −16 removed with `SCRATCH_LITERAL`) |
| integration | — | 61 files · 605 passed, 31 skipped |

Both new suites were mutation-checked rather than merely watched pass: dropping the epoch sanity check, parsing from the left, and ignoring the reaper's age window each turn a test red. Removing the reaper's backend count does **not** — that is recorded in both files, because the no-`FORCE` drop is the guarantee and the count is only a legible log line.

## Scope

`fileParallelism` stays `false`. Its comment claimed the fixed names were a reason; they are gone, and what keeps it false now is a connection budget rather than a bug, so the comment says that instead. Flipping it is a measurement (how many workers a 100-connection cluster survives), not a one-line change.

Closes the naming and reaper halves of #166. The role race was #206.

🤖 Generated with [Claude Code](https://claude.com/claude-code)