### PR TITLE
Merge the site manifest on migrate, and write the upgrade path down

### DIFF
--- a/.changeset/migrate-site-manifest.md
+++ b/.changeset/migrate-site-manifest.md
@@ -1,0 +1,19 @@
+---
+"@panaversity/ksor": patch
+---
+
+`ksor migrate --write-site` no longer deletes dependencies the adopter added to
+their site.
+
+Every file under `system/site` is offered as a whole-file replacement, which is
+right for the copied rule modules and wrong for `system/site/package.json` — a
+register ksor and the adopter both write in. Copying it whole removed anything
+they had added, inside the same hunk that carried a pin bump, so a project could
+stop building on the release meant to fix it. It is now merged per section: the
+entries ksor ships move to this release's versions, the adopter's own survive,
+and an entry ksor no longer ships is left alone rather than deleted (the tool
+cannot tell one it retired from one they added).
+
+Adds `docs/upgrading.md`, which ships in the tarball: the four-step path, the
+table of what migrate carries, the list of files it does not — so an adopter
+knows what to diff by hand — and the refusals to expect.

--- a/.changeset/next-16-3-3.md
+++ b/.changeset/next-16-3-3.md
@@ -14,9 +14,10 @@ semver-major and Fumadocs peers Next as a range (`16.x.x`), so nothing else
 moves with it. The committed pnpm lockfile is regenerated to match — the half
 that would otherwise break an adopter whose CI installs frozen.
 
-This fixes NEW scaffolds only. `ksor migrate` rewrites the root `package.json`'s
-scripts and no dependency pin, so a project scaffolded before this release stays
-on `16.2.9` until #177 gives it a way across.
+An existing project takes both across with
+`ksor migrate --write-site`, which offers every file of `system/site` this
+release emits — the pin and the config among them. It prints the diff and
+changes nothing without `--write`.
 
 The scaffold's `next.config.mjs` also sets `agentRules: false`. From Next 16.3,
 a `next dev` that detects a coding agent writes `AGENTS.md` and `CLAUDE.md` into

--- a/docs/status.md
+++ b/docs/status.md
@@ -106,8 +106,13 @@ takedown` may have appended to it — but a row nothing accounts for is
 APPENDED, including the one a repointed denial leaves behind, which is the
 state `ksor ingest` and `ksor serve` refuse as `ksor-takedown-unledgered` and
 name this command as the remedy for. Without `--write` it prints a
-unified diff and changes nothing. `--write-site` UPDATES the byte-copied rule
-modules where a `system/site` exists; it never creates one. It refuses by name (`ksor-migrate-underivable`) rather
+unified diff and changes nothing. `--write-site` UPDATES every file of
+`system/site` this release emits — the byte-copied rule modules, the site's
+`next.config.mjs`, and its `package.json`, which is the only path by which a
+dependency bump reaches a record already scaffolded. It never creates a site.
+That manifest is MERGED rather than reissued: the entries ksor ships move to
+this release's versions and anything the adopter added stays, because copying
+it whole deleted their own dependencies (walked live, 2026-08-30). It refuses by name (`ksor-migrate-underivable`) rather
 than author a title, a description, a `generated.at` or the actor behind a
 takedown — and rather than DERIVE either of the two values a re-run can no
 longer know: an audience, once the `audiences:` model it deleted is gone (it

--- a/packages/ksor/docs/index.md
+++ b/packages/ksor/docs/index.md
@@ -51,6 +51,11 @@ instead of their training memory. The corpus grows with each implemented verb.
     current. Serving does not publish, so a first deploy with no ingest serves
     an empty record; this is the page that explains why, where ingest belongs
     (never inside the container), and how the abstention gate gets turned on.
+  - **[upgrading.md](./upgrading.md)** — moving an existing record onto a newer
+    ksor. `ksor migrate` offers a diff and changes nothing without `--write`;
+    `--write-site` is the one flag to remember, because it is the only path by
+    which a dependency bump reaches a project already scaffolded. Includes the
+    list of files migrate does NOT carry, so you know what to diff by hand.
   - **[authorization.md](./authorization.md)** — putting the record behind an
     authorization server, with worked recipes for two of them, executed rather
     than written. `ksor serve` refuses to boot unauthenticated on a public bind,

--- a/packages/ksor/docs/upgrading.md
+++ b/packages/ksor/docs/upgrading.md
@@ -1,0 +1,106 @@
+---
+title: Upgrading a record to a newer ksor
+status: draft
+---
+
+# Upgrading a record to a newer ksor
+
+Your repository is yours. `ksor init` copied files into it and stopped owning
+them the moment it did (decision 4), so upgrading is never something a release
+does to you — it is `ksor migrate` **offering** a diff you read and apply.
+
+Nothing here changes a byte until you pass `--write`.
+
+## The four steps
+
+```sh
+# 1. take the new tool
+pnpm add -w @panaversity/ksor@latest       # npm i / bun add — whichever scaffolded this
+
+# 2. read what it would change
+pnpm exec ksor migrate --instance instance.md --write-site
+
+# 3. apply it
+pnpm exec ksor migrate --instance instance.md --write-site --write --actor human:<your-id>
+
+# 4. rebuild, and check
+pnpm build && pnpm check
+```
+
+`--actor` is required for step 3 whenever the migration touches governance, and
+the tool will not guess one: a ledger entry that names a person who was never
+there is worse than no entry (decision 21). Use the identifier your
+`.ksor/governance.yaml` already knows you by.
+
+Run step 2 on a clean working tree. The diff is the review, and it is much
+easier to read when nothing else is uncommitted.
+
+## What `migrate` carries
+
+|                                                 |                                                                                             |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `instance.md`                                   | the format bump and the keys that moved                                                     |
+| `knowledge/**`                                  | frontmatter into the current profile — statuses, audiences, the trust block, instants       |
+| `.ksor/takedowns.yaml`, `.ksor/governance.yaml` | the ledger and the policy, including denials that lived only in a database                  |
+| `.gitignore`                                    | the entries a new release needs negated                                                     |
+| `.agents/` and `.claude/` format-checker        | the emitted checker, so your own `pnpm check` and your CI agree with the tool               |
+| root `package.json` **scripts**                 | scripts a release broke — a removed flag, a step that now needs `ksor build` in front of it |
+| `system/site/**`                                | **only with `--write-site`** — every file of the site this release emits                    |
+
+`--write-site` is the one to remember, because it is the only path by which a
+security bump reaches an existing project: the site's `package.json` is where
+`next`, `react` and the Fumadocs pins live, and nothing else updates them.
+
+It is an **update, never a creation**. A record with no `system/site` of its own
+is not given one.
+
+### The site manifest is merged, not replaced
+
+Every other file under `system/site` is reissued whole. `system/site/package.json`
+is not, because it is a register with two authors: ksor owns the entries it
+ships, you own everything else. So a dependency or script you added survives the
+upgrade, and the pins ksor ships move to the new versions. An entry ksor no
+longer ships is left alone rather than deleted — the tool cannot tell one it
+retired from one you added.
+
+## What `migrate` does not carry
+
+These are yours, and no release touches them. Diff them against a fresh
+`ksor init` in a scratch directory when a release note says they changed:
+
+- `Dockerfile` and `.dockerignore`
+- `vercel.json` (or whatever your host reads)
+- `.github/workflows/validate.yml`
+- `.env.example`
+- `README.md`, `AGENTS.md`, `CLAUDE.md` at the repository root
+- `pnpm-workspace.yaml` / `.npmrc` and any lockfile
+
+```sh
+npx @panaversity/ksor@latest init /tmp/fresh
+diff -ru /tmp/fresh/vercel.json ./vercel.json
+```
+
+## What refuses, and why that is the point
+
+`migrate` stops rather than inventing. `ksor-migrate-underivable` names the one
+thing it cannot know — a title, a description, a `generated.at`, or the actor
+behind a takedown it found in a database — and tells you the flag or the edit
+that supplies it. Two you will meet often:
+
+- **A record that declares `database:`** refuses until `KSOR_DB_URL` is
+  exported, because denials living only in that database would be republished by
+  a migration that never read them. Export it, or remove `database:` if the
+  record no longer has one.
+- **`approved` documents become `draft`** unless `--approve-by <actor>` says who
+  approves them in the same act. Approval is a human act and a migration is not
+  a human.
+
+## After it applies
+
+`pnpm build` regenerates every index and rewrites `build.lock.json`; `pnpm check`
+runs the record checker that shipped with the new tool. If you serve the record,
+`ksor schema --apply` and then a full `pnpm refresh` publish a generation the new
+door can read — and a calibrated `vector_floor` measured under an older serving
+predicate must be re-measured with `ksor calibrate`, because a floor measured
+against a different predicate is a declared-but-uncalibrated floor and the door
+will refuse every search until it is replaced.

--- a/packages/ksor/src/migrate.integration.test.ts
+++ b/packages/ksor/src/migrate.integration.test.ts
@@ -1050,6 +1050,63 @@ describe("ksor migrate --write-site", () => {
     expect(version).not.toContain("KSOR-STAMP-VERSION");
   });
 
+  /**
+   * The site's package.json is a register with TWO authors, so it is merged
+   * rather than reissued.
+   *
+   * Byte-copying it deleted whatever the adopter had added — walked live on a
+   * scaffold carrying one extra dependency, which the upgrade removed inside
+   * the same hunk that carried a security pin, so the site stopped building on
+   * the release meant to fix it. The diff shows the removal, but a line an
+   * adopter has to spot inside a whole-site diff is not a line they chose.
+   */
+  it("merges the site manifest: ksor's pins win, the adopter's own entries stay", () => {
+    const template = JSON.parse(
+      readFileSync(
+        path.join(repoRoot, "packages/ksor/templates/scaffold/system/site/package.json"),
+        "utf8",
+      ),
+    ) as { dependencies: Record<string, string>; scripts: Record<string, string> };
+
+    const root = repo([
+      ["instance.md", "---\nformat: 1\nname: acme\n---\n\n# Acme\n\nOne sentence of scope.\n"],
+      ["knowledge/a.md", "---\ntitle: A\ndescription: A doc.\nstatus: draft\n---\n\nBody.\n"],
+      [
+        "system/site/package.json",
+        `${JSON.stringify(
+          {
+            name: "site",
+            private: true,
+            type: "module",
+            scripts: { build: "next build", dev: "next dev", "check:css": "stylelint ." },
+            dependencies: { next: "16.0.0", "date-fns": "4.1.0" },
+          },
+          null,
+          2,
+        )}\n`,
+      ],
+    ]);
+
+    const r = run(root, "migrate", "--write", "--actor", ACTOR, "--write-site");
+    expect(r.status, r.stderr).toBe(0);
+    const after = JSON.parse(read(root, "system/site/package.json")) as {
+      dependencies: Record<string, string>;
+      scripts: Record<string, string>;
+    };
+
+    expect(after.dependencies["next"], "ksor owns the pin it ships").toBe(
+      template.dependencies["next"],
+    );
+    expect(after.dependencies["date-fns"], "the adopter's own dependency survives").toBe("4.1.0");
+    expect(after.dependencies["fumadocs-core"], "a pin they were missing is added").toBe(
+      template.dependencies["fumadocs-core"],
+    );
+    expect(after.scripts["build"], "ksor owns the build script it ships").toBe(
+      template.scripts["build"],
+    );
+    expect(after.scripts["check:css"], "the adopter's own script survives").toBe("stylelint .");
+  });
+
   // An update, never a creation: a record with no site of its own does not
   // want one conjured into it by a migration.
   it("offers nothing to a record that has no site", () => {

--- a/packages/ksor/src/migrate/index.ts
+++ b/packages/ksor/src/migrate/index.ts
@@ -995,7 +995,7 @@ function siteChanges(root: string, templatesDir: string, stamps: Stamps): FileCh
         continue;
       }
       if (!SITE_TEXT_EXTENSIONS.has(path.extname(entry.name))) continue;
-      const after = applyProse(
+      const rendered = applyProse(
         readFileSync(abs, "utf8")
           .replaceAll("KSOR-STAMP-NAME", stamps.name)
           .replaceAll("KSOR-STAMP-VERSION", stamps.version),
@@ -1003,11 +1003,89 @@ function siteChanges(root: string, templatesDir: string, stamps: Stamps): FileCh
       );
       const target = path.join(root, child);
       const before = existsSync(target) ? readFileSync(target, "utf8") : null;
+      // The site's MANIFEST is merged, never replaced. Every other file here is
+      // ours to reissue whole; this one is a register the adopter also writes
+      // in, and byte-copying it deleted whatever they had added — walked live
+      // on a scaffold carrying one extra dependency, which the upgrade removed
+      // in the same hunk that carried a security pin, so the site stopped
+      // building on the release that was meant to fix it. Shown as a diff and
+      // gated on --write either way; a removal an adopter has to spot inside a
+      // whole-site diff is not the same as one they chose.
+      const after =
+        child === "system/site/package.json" && before !== null
+          ? mergeSiteManifest(before, rendered)
+          : rendered;
       if (before !== after) out.push({ path: child, before, after });
     }
   };
   walk(from, "system/site");
   return out;
+}
+
+/**
+ * The site manifest, merged: what ksor pins wins, what the adopter added stays.
+ *
+ * Applied per SECTION rather than per file. `dependencies`, `devDependencies`
+ * and `scripts` are registers with two authors — ksor owns the entries it ships
+ * (they are what the emitted site is built and tested against, and a security
+ * bump reaches an existing project through exactly this path), and the adopter
+ * owns everything else in them. A key ksor no longer ships is left alone rather
+ * than deleted: this cannot tell one it retired from one the adopter added.
+ *
+ * Unparseable on either side falls back to the template, which is the same
+ * whole-file offer every other site file gets — a diff, gated on `--write`.
+ */
+function mergeSiteManifest(before: string, template: string): string {
+  const parse = (text: string): Record<string, unknown> | null => {
+    try {
+      const value: unknown = JSON.parse(text);
+      return typeof value === "object" && value !== null && !Array.isArray(value)
+        ? (value as Record<string, unknown>)
+        : null;
+    } catch {
+      return null;
+    }
+  };
+  const mine = parse(before);
+  const theirs = parse(template);
+  if (mine === null || theirs === null) return template;
+
+  const section = (key: string): Record<string, unknown> | undefined => {
+    const a = mine[key];
+    const b = theirs[key];
+    const table = (v: unknown): Record<string, unknown> | null =>
+      typeof v === "object" && v !== null && !Array.isArray(v)
+        ? (v as Record<string, unknown>)
+        : null;
+    const ours = table(b);
+    const adopters = table(a);
+    if (ours === null) return adopters ?? undefined;
+    if (adopters === null) return ours;
+    // Adopter's ORDER first, so the diff shows the versions that moved rather
+    // than reordering every line around them.
+    const merged: Record<string, unknown> = {};
+    for (const [name, version] of Object.entries(adopters)) {
+      merged[name] = name in ours ? ours[name] : version;
+    }
+    for (const [name, version] of Object.entries(ours)) {
+      if (!(name in merged)) merged[name] = version;
+    }
+    return merged;
+  };
+
+  const MERGED = ["dependencies", "devDependencies", "scripts"] as const;
+  const out: Record<string, unknown> = { ...mine, ...theirs };
+  for (const key of MERGED) {
+    const value = section(key);
+    if (value === undefined) delete out[key];
+    else out[key] = value;
+  }
+  // The adopter's own formatting, for the reason the root manifest gives: a
+  // re-indented file arrives as an unreviewable whole-file hunk and their next
+  // formatter run reverts it.
+  const eol = before.includes("\r\n") ? "\r\n" : "\n";
+  const rendered = JSON.stringify(out, null, indentOf(before)).replaceAll("\n", eol);
+  return `${rendered}${/\r?\n$/.test(before) ? eol : ""}`;
 }
 
 interface Stamps {


### PR DESCRIPTION
Items 2 and 3 of #177, plus a correction to something I asserted in #215.

## The correction, first

I wrote — here, in #215's body, and twice on #207 — that `ksor migrate` "rewrites the root `package.json`'s scripts and no dependency pin". **That is wrong.** `siteChanges` walks the whole template `system/site` including `.json`, so `--write-site` has always offered the site's manifest and with it every pin.

Walked rather than re-read: a scaffold pinned to `next@16.2.9` was offered `16.3.3` by the current build. The `.changeset` for #215 is corrected in this PR — it had not been released yet, so the false sentence never reached a changelog.

## The defect that walk found

The offer is a **whole-file replacement**, so the same hunk that carried the pin deleted a dependency the adopter had added:

```diff
     "yaml": "2.9.0",
-    "zod": "4.4.3",
-    "date-fns": "4.1.0"
+    "zod": "4.4.3"
```

A project could stop building on the release meant to fix it. Whole-file is right for the byte-copied rule modules and wrong for a manifest — it is a register with two authors, and the ROOT manifest is already merged structurally for exactly this reason (`manifestChange`: "the manifest is the one file where a half-applied edit would still parse and then lie").

`system/site/package.json` is now merged per section — `dependencies`, `devDependencies`, `scripts`:

- entries ksor ships move to this release's versions;
- the adopter's own survive;
- an entry ksor **no longer** ships is left alone rather than deleted, because the tool cannot tell one it retired from one they added;
- adopter order is preserved, so the diff shows the versions that moved instead of reordering every line around them, and their indentation and line endings are read off their own bytes.

Proved by mutation: pointing the merge at a path that never matches restores byte-copying and the new test fails on `date-fns` — `expected undefined to be '4.1.0'`.

## The document

`packages/ksor/docs/upgrading.md` — in the tarball, where the agent that operates the record reads it. It carries the four-step path, a table of what migrate carries, the list of files it does **not** carry so an adopter knows what to diff by hand, and the refusals to expect (`database:` without `KSOR_DB_URL`; `approved` becoming `draft` without `--approve-by`).

Executed end to end against a real scaffold before it was written:

| step | result |
|---|---|
| `migrate --write-site` (diff) | 2 files offered |
| `migrate --write-site --write --actor` | applied |
| manifest after | `next 16.3.3`, `date-fns 4.1.0` still there, `agentRules: false` carried |
| `pnpm install && pnpm build` | 52.7s, 22 static pages, `llms.txt` 5 entries |
| `pnpm check` | ok |

`docs/status.md` is corrected in the same commit: it said `--write-site` updates "the byte-copied rule modules", which understated it.

## Not in this PR

**Item 1 of #177 — recording the decision 28 reversal.** Its condition is *"the day a record we do not operate is built by a published release"*, and the decision is explicit that this is an event to be observed, not forecast: *"an adopter might" is not an adopter*. I have no observation either way, and recording a reversal is an owner act. Flagging it rather than deciding it.

Local: unit 1547 · integration 61 files / 607 passed · migrate suite 75 passed · guard, corpus, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)