### PR TITLE
Add /review — the record-level half of "preview and review"

### DIFF
--- a/.changeset/review-surface.md
+++ b/.changeset/review-surface.md
@@ -1,0 +1,24 @@
+---
+"@panaversity/ksor": patch
+---
+
+The scaffold gains `/review` — one page listing everything in the record that
+still wants a human's eyes.
+
+Decision 7 calls the site "preview and review, not an editor". The per-page half
+shipped long ago: a badged page says what state it is in. The record-level half
+did not, so a reviewer asking "what needs me?" had to walk the sidebar document
+by document — free on the five-document starter, and the difference between
+review happening and review being skipped on a record of any size.
+
+`/review` groups every badged document by the state the lifecycle rule already
+computed — drafts, past their review date, not yet effective, deprecated — with
+each one's owner and the instant that explains it. It offers no approve control
+and never will: approving is `status: stable` with an actor, in a pull request.
+On a built site it cannot list drafts, because a build excludes them from every
+surface, and the page says exactly that rather than showing an empty list.
+
+It enumerates the same staged, audience-filtered set the sidebar reads, so it
+cannot list a document the rest of the site hides — asserted in both directions
+by the visibility canary, which now carries a badged restricted document that
+must never appear and a badged public one that must.

--- a/packages/ksor/src/review.test.ts
+++ b/packages/ksor/src/review.test.ts
@@ -1,0 +1,103 @@
+/**
+ * The review surface's grouping, which is the whole of `/review` that can be
+ * wrong without a browser.
+ *
+ * Two things are asserted harder than the rest. The ORDER is a claim about
+ * what a reviewer should do first, so it is pinned rather than left to however
+ * the badge enum happens to be declared. And the DRAFT sentence exists because
+ * a published build excludes every draft from every surface — so a page that
+ * showed an empty draft list and said nothing would be telling a reviewer
+ * "there are none" when the truth is "this build cannot see them", on a page
+ * whose only job is saying what needs looking at.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  draftVisibility,
+  reviewSections,
+  type ReviewItem,
+} from "../templates/scaffold/system/site/lib/review.js";
+import type { LifecycleBadge } from "../templates/scaffold/system/site/lib/lifecycle-rule.js";
+
+const item = (title: string, badge: LifecycleBadge, at: string | null = null): ReviewItem => ({
+  url: `/docs/${title.toLowerCase().replaceAll(" ", "-")}`,
+  title,
+  description: null,
+  badge,
+  owner: null,
+  at,
+});
+
+describe("reviewSections", () => {
+  it("orders the states by what costs most to ignore", () => {
+    const sections = reviewSections([
+      item("D", "deprecated"),
+      item("E", "effective-from"),
+      item("S", "stale"),
+      item("R", "draft"),
+    ]);
+    expect(sections.map((s) => s.badge)).toEqual([
+      "draft",
+      "stale",
+      "effective-from",
+      "deprecated",
+    ]);
+  });
+
+  it("drops a state with nothing in it rather than printing an empty heading", () => {
+    const sections = reviewSections([item("Only", "stale")]);
+    expect(sections.map((s) => s.badge)).toEqual(["stale"]);
+  });
+
+  it("is empty for a record where nothing is badged", () => {
+    expect(reviewSections([])).toEqual([]);
+  });
+
+  it("sorts within a state by title, so two reviewers see one list", () => {
+    const sections = reviewSections([
+      item("Zebra", "stale"),
+      item("apple", "stale"),
+      item("Mango", "stale"),
+    ]);
+    expect(sections[0]?.items.map((i) => i.title)).toEqual(["apple", "Mango", "Zebra"]);
+  });
+
+  it("keeps every item — the page groups the record, it never filters it", () => {
+    const items = [
+      item("A", "draft"),
+      item("B", "draft"),
+      item("C", "deprecated"),
+      item("D", "effective-from"),
+    ];
+    const total = reviewSections(items).reduce((n, s) => n + s.items.length, 0);
+    expect(total).toBe(items.length);
+  });
+
+  it("carries the instant that explains the badge through untouched", () => {
+    // As the record wrote it. Reformatting a date here would be the site
+    // making a claim about a timezone the record did not make.
+    const sections = reviewSections([item("Policy", "stale", "2026-01-01T00:00:00Z")]);
+    expect(sections[0]?.items[0]?.at).toBe("2026-01-01T00:00:00Z");
+  });
+
+  it("gives every state a heading and a reason", () => {
+    const all: LifecycleBadge[] = ["draft", "stale", "effective-from", "deprecated"];
+    for (const section of reviewSections(all.map((badge) => item(badge, badge)))) {
+      expect(section.heading.length, section.badge).toBeGreaterThan(0);
+      expect(section.note.length, section.badge).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("draftVisibility", () => {
+  it("says a hidden-drafts build cannot see them, rather than implying none exist", () => {
+    const note = draftVisibility("hidden");
+    expect(note).not.toBeNull();
+    expect(note).toContain("KSOR_DRAFTS=show");
+  });
+
+  it("says nothing when the build is showing drafts, because the list is then complete", () => {
+    expect(draftVisibility("shown")).toBeNull();
+  });
+});

--- a/packages/ksor/src/visibility-conformance.integration.test.ts
+++ b/packages/ksor/src/visibility-conformance.integration.test.ts
@@ -34,6 +34,13 @@ const RESTRICTED_TITLE = "Zebra Bands CANARYTITLE9F3A";
 const RESTRICTED_DESC = "CANARYDESC4A8C restricted only";
 const RESTRICTED_BODY = "CANARYBODY7B2E1";
 const INTERNAL_BODY = "INTERNALCANARY7A1D";
+// The review surface (`/review`) enumerates every BADGED document, so it is a
+// listing — the shape research/visibility.md §4-§5 says leaks. These two make
+// the sweep exercise it rather than pass over an empty page: one restricted
+// document that must never be listed, and one public document that must be, so
+// "filtered" can never be mistaken for "the page rendered nothing".
+const REVIEW_RESTRICTED_TITLE = "Retired Bands CANARYREVIEW5C2B";
+const REVIEW_PUBLIC_TITLE = "Retired Welcome REVIEWCONTROL8D4E";
 // A concept declaring TWO audiences: visible to a viewer holding either, and
 // to neither's public build. Before the overlap rule a document carried one
 // ordered tier and this shape could not be written at all.
@@ -233,6 +240,23 @@ takedown_authorities:
         }),
       );
       writeFileSync(path.join(knowledge, "comp-chart.png"), ASSET_PNG);
+      // Badged by a `stale_after` in the past: human-visible, machine-excluded
+      // (record spec §2.5), which is exactly what `/review` lists.
+      for (const [file, title, audience] of [
+        ["retired-comp.md", REVIEW_RESTRICTED_TITLE, "restricted"],
+        ["retired-welcome.md", REVIEW_PUBLIC_TITLE, "public"],
+      ] as const) {
+        writeFileSync(
+          path.join(knowledge, file),
+          concept({
+            title,
+            description: `${title} description.`,
+            audience: [audience],
+            body: `Body of ${title}.`,
+            order: 9,
+          }).replace("status: stable\n", "status: stable\nstale_after: 2020-01-01T00:00:00Z\n"),
+        );
+      }
       writeFileSync(
         path.join(knowledge, "compensation.summary.md"),
         `---\ntype: Summary\n---\n\nBands run to 240000 ${SUMMARY_BODY}.\n`,
@@ -291,6 +315,7 @@ takedown_authorities:
         RESTRICTED_TITLE,
         RESTRICTED_DESC,
         RESTRICTED_BODY,
+        REVIEW_RESTRICTED_TITLE,
         INTERNAL_BODY,
         BOTH_BODY,
         SUMMARY_BODY,
@@ -313,6 +338,19 @@ takedown_authorities:
       expect(llms).not.toContain("board-minutes");
       // No audience label on the public build.
       expect(filesContaining(outDir, "not for publication")).toEqual([]);
+
+      // The REVIEW surface: it renders (control), and it lists only what this
+      // viewer may see. A listing that walked its own tree instead of the
+      // staged one is exactly how the leak recurred four times.
+      const review = path.join(outDir, "review", "index.html");
+      expect(existsSync(review), "the review surface must be built").toBe(true);
+      const reviewHtml = readFileSync(review, "utf8");
+      expect(reviewHtml, "control: the public badged document is listed").toContain(
+        REVIEW_PUBLIC_TITLE,
+      );
+      expect(reviewHtml, "a restricted document was listed on the review surface").not.toContain(
+        REVIEW_RESTRICTED_TITLE,
+      );
     }, 300_000);
 
     it("public,internal: the internal concepts appear, the restricted one does not, label present", () => {
@@ -337,6 +375,13 @@ takedown_authorities:
 
     it("public,restricted (the control): every restricted canary present — and INTERNAL still absent", () => {
       mustPass(build("public,restricted"), "restricted build");
+      // The other half of the review canary: a viewer who HOLDS the audience
+      // sees it there, so the public build's absence is filtering rather than
+      // a page that lists nothing.
+      expect(
+        readFileSync(path.join(outDir, "review", "index.html"), "utf8"),
+        "a restricted viewer's review surface must list their badged document",
+      ).toContain(REVIEW_RESTRICTED_TITLE);
       for (const canary of [RESTRICTED_TITLE, RESTRICTED_BODY, BOTH_BODY]) {
         expect(
           filesContaining(outDir, canary).length,

--- a/packages/ksor/templates/scaffold/AGENTS.md
+++ b/packages/ksor/templates/scaffold/AGENTS.md
@@ -595,6 +595,16 @@ CI — and a first deploy without it serves an empty record. Full walkthrough:
   reviewed since its `stale_after` — a reader handed one of those with no word
   of it has been misled, and the sidebar, the listings and the search results
   say it whatever this key is set to.
+- **`/review` lists everything that wants a human's eyes**, in one page:
+  drafts, documents past their `stale_after`, documents not yet effective, and
+  deprecated ones — each with its owner and the date that explains it. It is
+  the record-level half of "preview and review"; the per-page half is the
+  chip below. It is not linked from the navbar (it is a maintainer's page, and
+  `noindex`), so go to `/review` directly. It offers no approve button and
+  never will: approving is `status: stable` with an actor, in a pull request.
+  On a BUILT site it cannot list drafts, because a build excludes them from
+  every surface — the page says so rather than showing an empty list; run
+  `pnpm dev` to review those.
 - **`status` is shown only when it is a caveat.** `deprecated` appears as a
   small label; `stable` shows nothing, because a reader already assumes a
   document in the record is current — so the label stays rare enough to be

--- a/packages/ksor/templates/scaffold/README.md
+++ b/packages/ksor/templates/scaffold/README.md
@@ -349,6 +349,18 @@ A new document is `status: draft`, and `pnpm build` admits a draft to no surface
 at all: no page, no sidebar row, no `/llms.txt` entry, nothing for an agent to
 read. `pnpm dev` shows it, marked — the preview is where drafts live.
 
+### `/review` — what still wants your eyes
+
+One page lists everything the record is not simply publishing: drafts, documents
+past their `stale_after`, documents not yet effective, and deprecated ones, each
+with its owner and the date that explains it. It is not linked from the navbar —
+it is a maintainer's page and it is `noindex` — so open `/review` directly.
+
+It offers no approve button, and never will: approving is `status: stable` with
+an actor, in a pull request. And on a BUILT site it cannot list drafts, because
+a build excludes them from every surface; the page says so instead of showing an
+empty list. `pnpm dev` is where you review those.
+
 ### Publishing adds two keys
 
 Beside `status: stable`, name what produced the text and who approved it. Both,

--- a/packages/ksor/templates/scaffold/system/site/app/review/page.tsx
+++ b/packages/ksor/templates/scaffold/system/site/app/review/page.tsx
@@ -1,0 +1,87 @@
+import Link from "next/link";
+import type { ReactElement } from "react";
+
+import { draftVisibility, reviewSections } from "@/lib/review";
+import { reviewItems } from "@/lib/source";
+import { readStageManifest } from "@/lib/stage-manifest";
+
+export const metadata = {
+  title: "Review",
+  description: "What in this record still wants a human's eyes.",
+  // Never an entry point for a reader or a crawler: this is a working page for
+  // whoever maintains the record, and it lists documents the machine surfaces
+  // have deliberately declined.
+  robots: { index: false, follow: false },
+};
+
+/**
+ * The review surface — the record-level half of "preview and review"
+ * (decision 7, whose 2026-08-25 revision made that clause load-bearing rather
+ * than descriptive).
+ *
+ * It offers no APPROVE control and never will. Approval is `status: stable`
+ * with an actor, in a pull request; a button here would be the site performing
+ * a governance act on somebody's behalf, which is decision 21's rule applied
+ * to the site. This page's whole job is to say what to go and look at.
+ *
+ * Server-rendered, no client JS, no dependency: it is a list.
+ *
+ * Deliberately NOT in the navbar. It is a working page for whoever maintains
+ * the record, it is `noindex`, and on a published build it is usually empty
+ * because drafts are excluded — so a permanent link would advertise an internal
+ * surface to every reader of a public record to no purpose. `/review` is named
+ * in AGENTS.md and the README instead. Add the link if your record's reviewers
+ * outnumber its readers; the file is yours.
+ */
+export default function ReviewPage(): ReactElement {
+  const manifest = readStageManifest();
+  const sections = reviewSections(reviewItems());
+  const draftNote = draftVisibility(manifest.drafts);
+
+  return (
+    <main className="mx-auto w-full max-w-3xl flex-1 px-6 py-16">
+      <h1 className="font-display text-2xl font-semibold tracking-[-0.01em]">Review</h1>
+      <p className="mt-2 text-fd-muted-foreground">
+        What in this record still wants a human&rsquo;s eyes, as of{" "}
+        <time dateTime={manifest.asOf}>{manifest.asOf}</time>.
+      </p>
+
+      {sections.length === 0 ? (
+        // Honest, in words. A blank page reads the same whether nothing needs
+        // review or the list failed to build.
+        <p className="mt-10 rounded-lg border border-fd-border bg-fd-card p-4">
+          Nothing in this build is awaiting review — every document it can see is stable, effective
+          and current.
+        </p>
+      ) : (
+        sections.map((section) => (
+          <section key={section.badge} className="mt-10">
+            <h2 className="font-display text-lg font-semibold">
+              {section.heading}{" "}
+              <span className="text-fd-muted-foreground font-normal">({section.items.length})</span>
+            </h2>
+            <p className="mt-1 text-sm text-fd-muted-foreground">{section.note}</p>
+            <ul className="mt-4 divide-y divide-fd-border border-y border-fd-border">
+              {section.items.map((item) => (
+                <li key={item.url} className="py-3">
+                  <Link href={item.url} className="font-medium hover:underline">
+                    {item.title}
+                  </Link>
+                  {item.description !== null && (
+                    <p className="mt-0.5 text-sm text-fd-muted-foreground">{item.description}</p>
+                  )}
+                  <p className="mt-1 font-mono text-xs text-fd-muted-foreground">
+                    {item.owner ?? "no owner declared"}
+                    {item.at !== null && <> · {item.at}</>}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ))
+      )}
+
+      {draftNote !== null && <p className="mt-10 text-sm text-fd-muted-foreground">{draftNote}</p>}
+    </main>
+  );
+}

--- a/packages/ksor/templates/scaffold/system/site/lib/review.ts
+++ b/packages/ksor/templates/scaffold/system/site/lib/review.ts
@@ -1,0 +1,107 @@
+/**
+ * What in this record still wants a human's eyes, as one list.
+ *
+ * The per-page half of "preview and review" (decision 7) already ships: a
+ * badged page says what state it is in, and the search dialog carries the same
+ * word. The record-level half is this — a reviewer asking "what needs me?"
+ * otherwise walks the sidebar page by page, which is free on the five-document
+ * starter and is the difference between review happening and review being
+ * skipped on a record of any size.
+ *
+ * Grouped by the badge the lifecycle rule already computes, so there is no
+ * second opinion about a document's state anywhere on the site: the group a
+ * document appears in here is the same `LifecycleBadge` its own page shows
+ * (record spec §2.5, `lib/lifecycle-rule.ts`).
+ *
+ * Pure — the page hands it entries and gets sections back — so the ordering
+ * and the empty cases are testable without a site install.
+ */
+
+import type { LifecycleBadge } from "./lifecycle-rule.js";
+
+export interface ReviewItem {
+  readonly url: string;
+  readonly title: string;
+  readonly description: string | null;
+  readonly badge: LifecycleBadge;
+  /** Who stands behind it; null when the record declares no owner (or governance is off). */
+  readonly owner: string | null;
+  /** The instant that explains the badge, as the record wrote it: `effective_from`, `stale_after`, or the deprecation. */
+  readonly at: string | null;
+}
+
+export interface ReviewSection {
+  readonly badge: LifecycleBadge;
+  readonly heading: string;
+  /** Why this state is on the list — the reviewer's actual next question. */
+  readonly note: string;
+  readonly items: readonly ReviewItem[];
+}
+
+/**
+ * The order a reviewer works in, not the order the enum happens to be
+ * declared in: what nobody has approved yet, then what has silently left the
+ * agent surfaces, then what is waiting to arrive, then what has a successor.
+ * The first two are the ones where doing nothing is the expensive choice.
+ */
+const ORDER: readonly LifecycleBadge[] = ["draft", "stale", "effective-from", "deprecated"];
+
+const HEADINGS: Readonly<Record<LifecycleBadge, string>> = {
+  draft: "Drafts",
+  stale: "Past their review date",
+  "effective-from": "Not yet effective",
+  deprecated: "Deprecated",
+};
+
+const NOTES: Readonly<Record<LifecycleBadge, string>> = {
+  draft:
+    "Not published anywhere. A human approves one by setting status: stable in a pull request.",
+  stale:
+    "Still readable here, and already withdrawn from every agent surface. Re-review it, or extend its stale_after.",
+  "effective-from": "Readable here, withheld from agents until the date it names.",
+  deprecated: "Superseded or withdrawn. Readable here so a link into it still explains itself.",
+};
+
+/**
+ * Group the badged documents, dropping the states with nothing in them.
+ *
+ * An empty result is a real answer and the page says so in words — never a
+ * blank that could equally mean "the list failed to load".
+ */
+export function reviewSections(items: readonly ReviewItem[]): ReviewSection[] {
+  return ORDER.flatMap((badge) => {
+    const inBadge = items.filter((item) => item.badge === badge);
+    if (inBadge.length === 0) return [];
+    const heading = HEADINGS[badge];
+    const note = NOTES[badge];
+    // `noUncheckedIndexedAccess` widens a lookup to `| undefined` even against
+    // a total Record. Read them once and narrow, rather than asserting.
+    if (heading === undefined || note === undefined) return [];
+    return [
+      {
+        badge,
+        heading,
+        note,
+        // Titles, so two reviewers reading the same list see the same order.
+        // Reading order would put the answer to "what needs me" in the place
+        // the sidebar happens to have reached, which is not an order at all.
+        items: [...inBadge].sort((a, b) => a.title.localeCompare(b.title)),
+      },
+    ];
+  });
+}
+
+/**
+ * What the page must say about DRAFTS when it is showing none.
+ *
+ * A published build excludes every draft from every surface (record spec
+ * §2.5), so "no drafts" on such a build means "this build cannot see them",
+ * not "there are none" — and a reviewer who reads the first as the second has
+ * been misled by a page whose whole job is telling them what needs looking at.
+ * `pnpm dev` and `KSOR_DRAFTS=show` are the surfaces that can.
+ */
+export function draftVisibility(drafts: "hidden" | "shown"): string | null {
+  return drafts === "shown"
+    ? null
+    : "Drafts are excluded from this build, so none can be listed here. Run pnpm dev, or build with KSOR_DRAFTS=show, to review them.";
+}

--- a/packages/ksor/templates/scaffold/system/site/lib/source.ts
+++ b/packages/ksor/templates/scaffold/system/site/lib/source.ts
@@ -7,6 +7,7 @@ import type { ReactNode } from "react";
 import { agentFrontmatter, badgeLabel, readGovernance, stampLines } from "./governance";
 import { dirOfRoute, listingOf, readingOrder } from "./index-routes";
 import type { LifecycleBadge } from "./lifecycle-rule";
+import type { ReviewItem } from "./review";
 import { appName, appTitle, appDescription, showGovernance } from "./shared";
 import {
   readStagedIndex,
@@ -170,6 +171,46 @@ export function getSortedPages(): KnowledgePage[] {
       (order.get(a.url) ?? Number.POSITIVE_INFINITY) -
         (order.get(b.url) ?? Number.POSITIVE_INFINITY) || a.url.localeCompare(b.url),
   );
+}
+
+/**
+ * Every document this build can see that carries a lifecycle badge — the
+ * review surface's input (`/review`).
+ *
+ * Reads `getSortedPages()`, which is the SAME staged, audience-filtered set
+ * the sidebar and the home page read, so this page can never enumerate a
+ * document the rest of the site hides. That is the property the visibility
+ * canary asserts about it; a listing built from its own walk of the tree is
+ * how the leak in research/visibility.md §4-§5 keeps happening.
+ *
+ * The instant is whichever one explains the badge, as the record wrote it —
+ * never reformatted, because a rendered date is a claim about a timezone the
+ * record did not make.
+ */
+export function reviewItems(): ReviewItem[] {
+  const out: ReviewItem[] = [];
+  for (const page of getSortedPages()) {
+    const badge = stagePageOf(pathOf(page))?.badge ?? null;
+    if (badge === null) continue;
+    const governance = readGovernance(page.data, page.path);
+    const at =
+      badge === "effective-from"
+        ? governance.effectiveFrom
+        : badge === "stale"
+          ? governance.staleAfter
+          : badge === "deprecated"
+            ? (governance.deprecated?.at ?? null)
+            : null;
+    out.push({
+      url: page.url,
+      title: page.data.title,
+      description: page.data.description?.trim() || null,
+      badge,
+      owner: showGovernance ? governance.owner : null,
+      at,
+    });
+  }
+  return out;
 }
 
 /**

--- a/specs/ksor/review/spec.md
+++ b/specs/ksor/review/spec.md
@@ -1,0 +1,69 @@
+---
+status: draft
+date: 2026-08-31
+claim: the governance of what an agent reads is the product, and a record whose review never happens is governed only on paper — a reviewer who has to walk the sidebar page by page is a reviewer who stops
+---
+
+# The review surface
+
+Decision 7 says the site is **preview and review, not an editor** — the agent
+writes, the human checks. Its 2026-08-25 revision made that load-bearing rather
+than descriptive: the preview is now the only surface a `draft` reaches, so the
+review step is enforced by what every build excludes.
+
+The per-page half of "checks" shipped with governance rendering: a badged page
+says what state it is in, and the sidebar, the listings and the search dialog
+carry the same word. **This is the record-level half** — one page answering
+"what in this record still wants my eyes?", which otherwise means walking the
+sidebar document by document.
+
+## Observable contract
+
+`/review` on the emitted site.
+
+|                        |                                                                                                                |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------- |
+| lists                  | every document this build can see whose `LifecycleBadge` is non-null                                           |
+| grouped by             | that badge — `draft`, then `stale`, then `effective-from`, then `deprecated`                                   |
+| per item               | title (linked), description, `ksor.owner`, and the instant that explains the badge, **as the record wrote it** |
+| ordered within a group | by title, so two reviewers see one list                                                                        |
+| when nothing is badged | says so in words                                                                                               |
+| when drafts are hidden | says the build cannot see them, never implies there are none                                                   |
+| `robots`               | `noindex, nofollow`                                                                                            |
+| linked from            | nothing — it is named in the emitted README and AGENTS.md                                                      |
+
+**No approve control, now or later.** Approval is `status: stable` plus a
+`ksor.approval` naming an actor the policy authorises, in a pull request. A
+button here would be the site performing a governance act on someone's behalf,
+which is decision 21's rule applied to the site.
+
+**One opinion per document.** The group a document appears in is the same
+`LifecycleBadge` its own page shows — `lib/lifecycle-rule.ts`, record spec §2.5.
+The page computes no state of its own.
+
+**It enumerates the staged set, never its own walk of the tree.** `reviewItems()`
+reads `getSortedPages()` — the same audience-filtered, staged list the sidebar
+and the home page read — so it cannot list a document the rest of the site
+hides. Subtracting per surface is the failure mode `research/visibility.md`
+§4–§5 names, and it is why the visibility canary now carries a badged
+`restricted` document that must never appear here and a badged `public` one that
+must.
+
+## Acceptance
+
+1. Grouping, ordering, the empty case and the draft sentence are unit-tested
+   against the pure module (`lib/review.ts`), with no site install.
+2. The canary sweep asserts both directions on a real static export: the
+   restricted badged document appears on no build that excludes it, and the
+   public badged one appears, so "filtered" is never confused with "the page
+   rendered nothing".
+3. A record with nothing badged builds a page that says so.
+
+## Out of scope
+
+- **"What changed since generation N."** Needs the kernel; belongs with
+  generation stamping.
+- **Any approve, publish or edit control.** Named here so it is not smuggled in
+  later as a convenience.
+- **A navbar link.** It is a maintainer's page on a record whose readers are
+  usually not its maintainers; the adopter owns the file and can link it.


### PR DESCRIPTION
Closes #139.

## The gap

Decision 7 calls the site *preview and review, not an editor*, and its 2026-08-25 revision made that load-bearing rather than descriptive — the preview is the only surface a `draft` reaches, so the review step is enforced by what every build excludes.

The **per-page** half shipped long ago: a badged page says what state it is in, and the sidebar, listings and search dialog carry the same word. The **record-level** half did not. A reviewer asking "what in this record still wants my eyes?" had to walk the sidebar document by document — free on the five-document starter, and the difference between review happening and review being skipped on anything larger.

## What ships

`/review`, server-rendered, no client JS, no dependency. Every badged document grouped by the state the lifecycle rule already computed — drafts, past their review date, not yet effective, deprecated — each with its owner and the instant that explains it, **as the record wrote it** (reformatting a date would be the site making a timezone claim the record did not).

Walked on a real scaffold, both states:

```
Review — What in this record still wants a human's eyes, as of 2026-08-30T19:34:13Z
  Past their review date (1)
    Still readable here, and already withdrawn from every agent surface. Re-review it, or extend its stale_after.
    An old notice · A document past its review date · team:ops · 2020-01-01T00:00:00Z
  Drafts are excluded from this build, so none can be listed here. Run pnpm dev, or build with KSOR_DRAFTS=show, to review them.
```

```
Review — …
  Nothing in this build is awaiting review — every document it can see is stable, effective and current.
```

## Three things it deliberately does not do

**No approve control, now or later.** Approving is `status: stable` plus a `ksor.approval` naming an authorised actor, in a pull request. A button here would be the site performing a governance act on somebody's behalf — decision 21's rule applied to the site. Recorded in the spec's out-of-scope so it is not smuggled in later as a convenience.

**No opinion of its own.** The group a document appears in is the same `LifecycleBadge` its own page shows (`lib/lifecycle-rule.ts`, record spec §2.5). Two surfaces disagreeing about one document's state is what decision 18 exists about.

**No navbar link.** It is a maintainer's page, it is `noindex`, and on a published build it is usually empty — so a permanent link advertises an internal surface to every reader of a public record. Named in the emitted README and AGENTS.md instead; the file is the adopter's to link.

## The visibility risk, and what closes it

This is a **listing**, which is the shape `research/visibility.md` §4–§5 says leaks, and the leak has recurred four times. `reviewItems()` reads `getSortedPages()` — the same staged, audience-filtered set the sidebar and home page read — so it cannot enumerate a document the rest of the site hides.

That is asserted rather than argued. The canary sweep already scans the whole static export, but the fixture had nothing badged, so it would have passed over an empty page. It now carries **a badged `restricted` document** that must appear on no build excluding it, and **a badged `public` one** that must appear — so "filtered" can never read the same as "the page rendered nothing".

## Two honesty rules the page enforces

- **Nothing badged says so in words.** A blank page reads the same whether nothing needs review or the list failed to build.
- **A drafts-hidden build says it cannot see them.** A build excludes every draft from every surface, so an empty draft list means "this build can't show you these", not "there are none" — and a reviewer who read the silence as the second would have been misled by the one page whose job is telling them what to look at.

## Verification

| | |
|---|---|
| unit (`lib/review.ts`, pure) | 9 tests — ordering, empty states, the draft sentence |
| visibility conformance | 9 passed, both canary directions |
| shell conformance | 8 passed |
| scaffold walkthrough | 14 passed |
| unit / integration | 1556 · 61 files, 607 passed |

Contract: `specs/ksor/review/spec.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)