### PR TITLE
ksor calibrate --check: is the declared abstention floor still holding?

### DIFF
--- a/.changeset/floor-drift-check.md
+++ b/.changeset/floor-drift-check.md
@@ -1,0 +1,29 @@
+---
+"@panaversity/ksor": patch
+---
+
+`ksor calibrate --check` reports whether a declared abstention floor is still
+holding, from the record's own traffic.
+
+A floor is measured once and the record then grows. As it does, questions that
+used to be out-of-corpus start scoring above a fixed number, so the record
+answers what it used to refuse — no error, nothing logged, and the same
+`gate: { floor: … }` in every envelope. AGENTS.md forbids copying a calibrated
+constant between corpora; the same reasoning applies across time within one
+corpus, and nothing enforced it (#182).
+
+It needs no telemetry and no new dependency: every search already leaves an
+audit row carrying the gate's own signal, on both sides of the gate, so this is
+one indexed query — no provider key, no embedding call, no LLM. It reports the
+abstain rate, the percentiles of answered top scores, and how many answers
+landed within 0.01 of the floor (the size of the decision in this project's own
+gold, not a threshold somebody picked).
+
+**It never fails a run**, and that is the design rather than a limitation. A
+stale floor wants re-measuring; failing a build for one would make the shortest
+way out deleting `vector_floor` — turning the abstention gate off entirely to
+clear the error, which is the escape `build/lifecycle-notice.ts` refuses to
+create for a passed review date. It is also a monitor and not a measurement: it
+can say a floor has gone permissive against real traffic, never that it is too
+strict for questions nobody asked, and it says so rather than reporting a
+healthy-looking nothing on a record no one queries.

--- a/packages/content/src/calibrate/drift.db.test.ts
+++ b/packages/content/src/calibrate/drift.db.test.ts
@@ -1,0 +1,125 @@
+/**
+ * The drift query against a real log.
+ *
+ * `drift.test.ts` covers what the numbers MEAN. This covers the half only
+ * Postgres can answer: that the SQL reads both sides of the gate, that it
+ * refuses to count a row whose `top_cosine` is missing or not a number, and
+ * that it does not read another tenant's traffic.
+ *
+ * The shed row is the one worth the tier. `logRead` sheds under saturation and
+ * the detail key is recent, so rows without it exist — and counting one as a
+ * zero would drag every statistic toward a score nobody measured, silently, in
+ * the direction that makes a floor look safer than it is.
+ */
+
+import { randomBytes } from "node:crypto";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import pg from "pg";
+
+import { applySchema } from "../schema.js";
+import { DRIFT_LIMIT, DRIFT_SQL, driftReport, type DriftSample } from "./drift.js";
+
+const adminDsn = process.env["KSOR_DB_URL"] ?? "";
+const DB = `ksor_drift_${Date.now().toString(36)}_${randomBytes(3).toString("hex")}`;
+const TENANT = "acme";
+const OTHER = "other";
+
+describe.runIf(adminDsn !== "")("the floor-drift query (db)", () => {
+  let admin: pg.Pool;
+  let pool: pg.Pool;
+
+  const log = async (
+    tenant: string,
+    action: "similarity_searched" | "search_abstained",
+    detail: Record<string, unknown>,
+    agoDays = 0,
+    corpus?: string,
+  ): Promise<void> => {
+    await pool.query(
+      `INSERT INTO retrieval_log (tenant_id, corpus_id, actor, action, detail, created_at)
+       VALUES ($1, $5, 'human:test', $2, $3::jsonb, now() - ($4 || ' days')::interval)`,
+      [tenant, action, JSON.stringify(detail), String(agoDays), corpus ?? tenant],
+    );
+  };
+
+  const read = async (days: number): Promise<DriftSample[]> => {
+    const { rows } = await pool.query<{ top_cosine: number; abstained: boolean }>(DRIFT_SQL, [
+      TENANT,
+      TENANT,
+      String(days),
+      DRIFT_LIMIT,
+    ]);
+    return rows.map((r) => ({ topCosine: r.top_cosine, abstained: r.abstained }));
+  };
+
+  beforeAll(async () => {
+    admin = new pg.Pool({ connectionString: adminDsn, max: 1 });
+    await admin.query(`CREATE DATABASE ${DB}`);
+    const url = new URL(adminDsn);
+    url.pathname = `/${DB}`;
+    pool = new pg.Pool({ connectionString: url.toString(), max: 2 });
+    await applySchema(pool, 8);
+
+    await log(TENANT, "similarity_searched", { top_cosine: 0.9, k: 5 });
+    await log(TENANT, "similarity_searched", { top_cosine: 0.56 });
+    await log(TENANT, "search_abstained", { top_cosine: 0.2 });
+    // Shed / pre-detail rows: present in the table, absent from the statistics.
+    await log(TENANT, "similarity_searched", { k: 5 });
+    await log(TENANT, "similarity_searched", { top_cosine: null });
+    await log(TENANT, "similarity_searched", { top_cosine: "0.9" });
+    // Another act entirely, and another tenant.
+    await log(TENANT, "search_abstained", { top_cosine: 0.1 }, 400);
+    await log(OTHER, "similarity_searched", { top_cosine: 0.99 });
+    // Same tenant, a SECOND corpus: one record's floor must never be measured
+    // against the other's traffic (the scope readLedger records the reason for).
+    await log(TENANT, "similarity_searched", { top_cosine: 0.98 }, 0, "second-corpus");
+  }, 180_000);
+
+  afterAll(async () => {
+    await pool?.end().catch(() => undefined);
+    await admin?.query(`DROP DATABASE IF EXISTS ${DB} WITH (FORCE)`).catch(() => undefined);
+    await admin?.end().catch(() => undefined);
+  });
+
+  it("reads both sides of the gate", async () => {
+    const samples = await read(30);
+    expect(
+      samples.map((s) => `${s.topCosine}${s.abstained ? " abstained" : ""}`).sort(),
+      "an answered search and a refused one both carry the gate's own signal",
+    ).toEqual(["0.2 abstained", "0.56", "0.9"]);
+  });
+
+  it("counts no row whose top_cosine is missing, null, or not a number", async () => {
+    // Three such rows were written; if any were counted the sample count moves.
+    expect((await read(30)).length).toBe(3);
+  });
+
+  it("does not read another tenant's traffic, nor another corpus of this one", async () => {
+    const samples = await read(30);
+    expect(
+      samples.some((s) => s.topCosine === 0.99),
+      "another tenant's search",
+    ).toBe(false);
+    expect(
+      samples.some((s) => s.topCosine === 0.98),
+      "the same tenant's OTHER corpus — a floor measured against the wrong traffic",
+    ).toBe(false);
+  });
+
+  it("honours the window", async () => {
+    const wide = await read(500);
+    expect(wide.length, "the 400-day-old row is inside a 500-day window").toBe(4);
+  });
+
+  it("feeds a report that reads the traffic it was given", async () => {
+    const report = driftReport(0.55, await read(30));
+    expect(report.answered).toBe(2);
+    expect(report.abstained).toBe(1);
+    // 0.56 is within 0.01 of a 0.55 floor; 0.9 is not.
+    expect(report.marginal).toBe(1);
+    // Three samples is under MIN_SAMPLES, so it declines a verdict — and still
+    // reports the counts.
+    expect(report.verdict).toBe("no-data");
+  });
+});

--- a/packages/content/src/calibrate/drift.test.ts
+++ b/packages/content/src/calibrate/drift.test.ts
@@ -1,0 +1,125 @@
+/**
+ * What the drift monitor may and may not say.
+ *
+ * The hard part is not the arithmetic, it is the REFUSALS: this reads traffic,
+ * so it must never characterise a distribution it does not have, and it must
+ * never let a verdict read as a calibration. Those are the assertions worth
+ * mutating.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { driftReport, renderDrift, MARGIN_BAND, MIN_SAMPLES, type DriftSample } from "./drift.js";
+
+/** `n` answered searches at `score`. */
+const answered = (n: number, score: number): DriftSample[] =>
+  Array.from({ length: n }, () => ({ topCosine: score, abstained: false }));
+
+/** `n` refused searches, necessarily below the floor. */
+const abstained = (n: number, score: number): DriftSample[] =>
+  Array.from({ length: n }, () => ({ topCosine: score, abstained: true }));
+
+describe("it declines to characterise traffic it does not have", () => {
+  it("says no-data for an empty log rather than reading as healthy", () => {
+    const report = driftReport(0.55, []);
+    expect(report.verdict).toBe("no-data");
+    expect(report.samples).toBe(0);
+  });
+
+  it("says no-data one sample below the floor, and changes its mind one above", () => {
+    const below = driftReport(0.55, answered(MIN_SAMPLES - 1, 0.9));
+    expect(below.verdict, "below the sample floor").toBe("no-data");
+    const at = driftReport(0.55, [...answered(MIN_SAMPLES - 1, 0.9), ...abstained(1, 0.2)]);
+    expect(at.verdict, "at the sample floor it will characterise").not.toBe("no-data");
+  });
+
+  it("reports the counts even when it declines a verdict — the evidence is not withheld", () => {
+    const report = driftReport(0.55, [...answered(3, 0.9), ...abstained(2, 0.1)]);
+    expect(report.samples).toBe(5);
+    expect(report.answered).toBe(3);
+    expect(report.abstained).toBe(2);
+  });
+});
+
+describe("marginal answers — the ones that would flip if the number moved", () => {
+  it("counts an answer inside the band and not one outside it", () => {
+    const floor = 0.55;
+    const report = driftReport(floor, [
+      ...answered(20, floor + MARGIN_BAND / 2), // inside
+      ...answered(20, floor + MARGIN_BAND * 5), // outside
+      ...abstained(10, 0.2),
+    ]);
+    expect(report.marginal).toBe(20);
+    expect(report.marginalShare).toBeCloseTo(0.5, 5);
+  });
+
+  it("counts a score exactly on the band, which floats would otherwise exclude", () => {
+    // 0.56 - 0.55 is 0.010000000000000009 in IEEE. "Within 0.01 of the floor"
+    // has to mean what it says rather than what binary subtraction leaves.
+    const report = driftReport(0.55, [...answered(40, 0.56), ...abstained(10, 0.2)]);
+    expect(report.marginal).toBe(40);
+  });
+
+  it("watches when the answer set turns on the exact number", () => {
+    const floor = 0.55;
+    const report = driftReport(floor, [
+      ...answered(30, floor + MARGIN_BAND / 2),
+      ...answered(20, 0.9),
+      ...abstained(10, 0.2),
+    ]);
+    expect(report.verdict).toBe("watch");
+    expect(report.why).toContain("within");
+  });
+
+  it("is steady when answers sit clear of the floor and the gate still refuses", () => {
+    const report = driftReport(0.55, [...answered(50, 0.9), ...abstained(10, 0.2)]);
+    expect(report.verdict).toBe("steady");
+  });
+});
+
+describe("a gate that has stopped refusing anything", () => {
+  it("is watched, because the two causes are indistinguishable from here", () => {
+    const report = driftReport(0.55, answered(60, 0.95));
+    expect(report.verdict).toBe("watch");
+    // The claim it makes must be the honest one: not "your floor is stale".
+    expect(report.why).toContain("only a re-measurement tells them apart");
+  });
+
+  it("is not watched merely for a low abstain rate, which is an ordinary record", () => {
+    const report = driftReport(0.55, [...answered(99, 0.95), ...abstained(1, 0.2)]);
+    expect(report.verdict).toBe("steady");
+  });
+});
+
+describe("the percentiles describe ANSWERS, not the whole log", () => {
+  it("ignores refused searches, whose scores are below the floor by definition", () => {
+    const report = driftReport(0.55, [...answered(50, 0.8), ...abstained(50, 0.1)]);
+    expect(report.p05).toBeCloseTo(0.8, 5);
+    expect(report.p50).toBeCloseTo(0.8, 5);
+    expect(report.p95).toBeCloseTo(0.8, 5);
+  });
+
+  it("answers null rather than 0 when nothing was answered", () => {
+    const report = driftReport(0.55, abstained(40, 0.1));
+    expect(report.p50, "0 would read as a measured score").toBeNull();
+  });
+});
+
+describe("what it prints", () => {
+  it("leads with the numbers and names the remedy when it watches", () => {
+    const text = renderDrift(driftReport(0.55, answered(60, 0.95)), "last 30 days");
+    expect(text).toContain("declared vector_floor  0.550");
+    expect(text).toContain("WATCH");
+    expect(text).toContain("ksor calibrate");
+    // It must not present itself as a calibration.
+    expect(text).toContain("traffic, not a calibration");
+  });
+
+  it("prints no remedy when it is steady — advice nobody needs is noise", () => {
+    const text = renderDrift(
+      driftReport(0.55, [...answered(50, 0.9), ...abstained(10, 0.2)]),
+      "last 30 days",
+    );
+    expect(text).not.toContain("ksor calibrate");
+  });
+});

--- a/packages/content/src/calibrate/drift.ts
+++ b/packages/content/src/calibrate/drift.ts
@@ -1,0 +1,226 @@
+/**
+ * Has the declared floor gone stale? — read off the record's own traffic.
+ *
+ * `vector_floor` is measured once, against the corpus as it stood that day.
+ * The record then grows and nothing re-examines the number, which matters here
+ * more than a drifting constant usually would: the floor IS the abstention
+ * guarantee. AGENTS.md forbids copying a calibrated constant BETWEEN corpora;
+ * the same reasoning applies across TIME within one corpus, and there nothing
+ * enforced it (#182).
+ *
+ * It fails in the dangerous direction and in silence. As the corpus grows,
+ * questions that were out-of-corpus start scoring above a fixed floor, so the
+ * record answers what it used to refuse — no error, no log line, and an
+ * envelope still reporting `gate: { floor: … }` exactly as before.
+ *
+ * WHAT THIS READS, and why it is nearly free: every serving act already leaves
+ * a row (schema §7), and `detail.top_cosine` is on both sides of the gate —
+ * `search_abstained` carried it from the start and `similarity_searched` gained
+ * it with the audit-detail work. So the distribution #182 asks for is already
+ * in the database. One query, no provider key, no embedding call, no LLM, no
+ * exporter, and no dependency on the unimplemented telemetry binding (#180).
+ *
+ * WHAT IT IS NOT. This is a MONITOR, not a calibration: it measures the
+ * questions people actually asked, so it can say the floor has gone permissive
+ * against real traffic and it can never say the floor is too strict for
+ * questions nobody asks. The authoritative answer is re-running
+ * `ksor calibrate` against the corpus. It also needs traffic — a record nobody
+ * queries reports nothing, and says so rather than reading as healthy.
+ *
+ * AND IT NEVER GATES. A stale floor is a "this wants re-measuring" state, and
+ * refusing a build for one would make the shortest way out deleting
+ * `vector_floor` — turning the abstention gate off entirely to clear the
+ * error, which destroys the guarantee the check exists to protect. The same
+ * reasoning `build/lifecycle-notice.ts` records for a passed review date, where
+ * the escape was deleting `stale_after`.
+ */
+
+/** One logged search: the gate's own signal, and which side of it the search fell. */
+export interface DriftSample {
+  readonly topCosine: number;
+  readonly abstained: boolean;
+}
+
+/**
+ * How close to the floor an answer has to be to count as marginal.
+ *
+ * 0.01 is not a tuned threshold — it is the size of the decision in this
+ * record's own gold, quoted rather than invented: in-corpus at 0.730 / 0.671
+ * against a scope-adjacent near-miss at 0.683 (`evals/behavioural.db.test.ts`),
+ * so a hundredth of a cosine is the smallest difference that has ever changed
+ * an answer here. An answer inside that band is one the floor barely admitted.
+ */
+export const MARGIN_BAND = 0.01;
+
+/**
+ * Below this many searches the shape of a distribution is noise, so the report
+ * declines to characterise it. A number that describes 4 searches, printed
+ * beside a governance guarantee, would be read as evidence.
+ */
+export const MIN_SAMPLES = 30;
+
+/** Enough to absorb one subtraction of two cosines, and far below any difference that means anything. */
+const FLOAT_SLACK = 1e-9;
+
+export type DriftVerdict = "no-data" | "watch" | "steady";
+
+export interface DriftReport {
+  readonly floor: number;
+  readonly samples: number;
+  readonly abstained: number;
+  readonly answered: number;
+  /** Answered searches whose top score sat within MARGIN_BAND above the floor. */
+  readonly marginal: number;
+  /** Of the ANSWERED searches, the share that were marginal; 0 when none were answered. */
+  readonly marginalShare: number;
+  /** Of ALL searches, the share the gate refused. */
+  readonly abstainRate: number;
+  /** Top scores of the ANSWERED searches; null when nothing was answered. */
+  readonly p05: number | null;
+  readonly p50: number | null;
+  readonly p95: number | null;
+  readonly verdict: DriftVerdict;
+  readonly why: string;
+}
+
+/** Nearest-rank percentile over a sorted ascending list. */
+function percentile(sorted: readonly number[], q: number): number | null {
+  if (sorted.length === 0) return null;
+  const rank = Math.min(sorted.length - 1, Math.max(0, Math.ceil(q * sorted.length) - 1));
+  return sorted[rank] ?? null;
+}
+
+/**
+ * Characterise the traffic against the declared floor.
+ *
+ * Two numbers carry the verdict, and both are reported whatever it says,
+ * because the verdict is a reading aid and the numbers are the evidence:
+ *
+ *   the ABSTAIN RATE       — a gate that has stopped refusing anything is
+ *                            either serving a record that now covers its
+ *                            traffic, or a floor that has fallen behind it.
+ *   the MARGINAL SHARE     — answers the floor barely admitted. These are the
+ *                            ones that would flip if the number moved at all,
+ *                            so a large share means the answer set turns on a
+ *                            constant measured against a smaller corpus.
+ *
+ * `watch` is deliberately not called "stale". This cannot tell the two causes
+ * apart — only a re-measurement can — so it names what it saw and says what to
+ * run.
+ */
+export function driftReport(floor: number, samples: readonly DriftSample[]): DriftReport {
+  const answeredScores = samples
+    .filter((s) => !s.abstained)
+    .map((s) => s.topCosine)
+    .sort((a, b) => a - b);
+  const abstained = samples.length - answeredScores.length;
+  // Inclusive, with a float tolerance, because the words are "within
+  // MARGIN_BAND of the floor" and a reader is entitled to have that mean what
+  // it says: 0.56 against a 0.55 floor subtracts to 0.010000000000000009 in
+  // IEEE, so a strict `<` would report exactly-on-the-band as outside it —
+  // an artifact of binary floats masquerading as a judgement about a score.
+  const marginal = answeredScores.filter(
+    (score) => score - floor <= MARGIN_BAND + FLOAT_SLACK,
+  ).length;
+  const marginalShare = answeredScores.length === 0 ? 0 : marginal / answeredScores.length;
+  const abstainRate = samples.length === 0 ? 0 : abstained / samples.length;
+
+  const base = {
+    floor,
+    samples: samples.length,
+    abstained,
+    answered: answeredScores.length,
+    marginal,
+    marginalShare,
+    abstainRate,
+    p05: percentile(answeredScores, 0.05),
+    p50: percentile(answeredScores, 0.5),
+    p95: percentile(answeredScores, 0.95),
+  };
+
+  if (samples.length < MIN_SAMPLES) {
+    return {
+      ...base,
+      verdict: "no-data",
+      why: `only ${samples.length} logged search(es) — too few to characterise; this reports traffic, so a record nobody queries says nothing rather than looking healthy`,
+    };
+  }
+  // A fifth of answers sitting inside the band the gold says decides an answer
+  // is enough to say the floor is load-bearing at its exact value. The band is
+  // quoted from a measurement; this share is a REPORTING threshold chosen so
+  // the line fires rarely, and it is named as such rather than dressed up.
+  if (marginalShare >= 0.2) {
+    return {
+      ...base,
+      verdict: "watch",
+      why: `${marginal} of ${answeredScores.length} answers scored within ${MARGIN_BAND} of the floor — the answer set turns on this exact number`,
+    };
+  }
+  if (abstained === 0) {
+    return {
+      ...base,
+      verdict: "watch",
+      why: `the gate refused none of ${samples.length} searches — either the record now covers its traffic, or the floor has fallen behind it, and only a re-measurement tells them apart`,
+    };
+  }
+  return {
+    ...base,
+    verdict: "steady",
+    why: `${abstained} of ${samples.length} searches were refused, and ${marginal} answer(s) sat within ${MARGIN_BAND} of the floor`,
+  };
+}
+
+/** The report as the CLI prints it. Numbers first; the verdict is a reading aid. */
+export function renderDrift(report: DriftReport, window: string): string {
+  const pct = (n: number): string => `${(n * 100).toFixed(1)}%`;
+  const score = (n: number | null): string => (n === null ? "—" : n.toFixed(3));
+  const lines = [
+    `floor drift — ${window}`,
+    `  declared vector_floor  ${report.floor.toFixed(3)}`,
+    `  searches logged        ${report.samples}  (${report.answered} answered, ${report.abstained} abstained)`,
+    `  abstain rate           ${pct(report.abstainRate)}`,
+    `  answered top score     p05 ${score(report.p05)}  p50 ${score(report.p50)}  p95 ${score(report.p95)}`,
+    `  within ${MARGIN_BAND} of floor    ${report.marginal}  (${pct(report.marginalShare)} of answers)`,
+    `  verdict                ${report.verdict.toUpperCase()} — ${report.why}`,
+  ];
+  if (report.verdict === "watch") {
+    lines.push(
+      "",
+      "  This is traffic, not a calibration: it cannot tell a record that grew",
+      "  from a floor that fell behind. Re-measure to find out —",
+      "    ksor calibrate --instance instance.md --queries-file <your questions>",
+      "  and paste the floor it prints if it differs from the declared one.",
+    );
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+/**
+ * The logged searches for this corpus, newest `days` days.
+ *
+ * Only rows carrying a NUMERIC `top_cosine`: an audit row shed under
+ * saturation, or one written before that detail existed, is ABSENT rather than
+ * counted as a zero — a shed row is a gap in the evidence, and scoring it as
+ * zero would drag every statistic here toward a number nobody measured, in the
+ * direction that makes a floor look safer than it is.
+ *
+ * Scoped by CORPUS as well as tenant, for the reason `readLedger` records: a
+ * tenant serving two corpora would otherwise measure one record's floor
+ * against the other's traffic. Read through `runAuditRead` — the serving role
+ * has no SELECT on this table at all, deliberately, and widening that to read
+ * a monitor would trade an audit guarantee for a convenience.
+ */
+export const DRIFT_SQL = `
+SELECT (detail->>'top_cosine')::float8 AS top_cosine,
+       action = 'search_abstained'     AS abstained
+  FROM retrieval_log
+ WHERE tenant_id = $1
+   AND corpus_id = $2
+   AND action IN ('similarity_searched','search_abstained')
+   AND created_at > now() - ($3 || ' days')::interval
+   AND jsonb_typeof(detail->'top_cosine') = 'number'
+ ORDER BY created_at DESC
+ LIMIT $4`;
+
+/** How many rows one check reads at most — a bound, so a busy record cannot make this expensive. */
+export const DRIFT_LIMIT = 5000;

--- a/packages/content/src/commands.ts
+++ b/packages/content/src/commands.ts
@@ -18,7 +18,7 @@ import { dirname, join, resolve } from "node:path";
 import { parseArgs } from "node:util";
 import pg from "pg";
 
-import { contentPool, ContentStoreError, INGEST_ROLE, runIngest } from "./db.js";
+import { contentPool, ContentStoreError, INGEST_ROLE, runAuditRead, runIngest } from "./db.js";
 import { assertGovernanceServable } from "./governance-gate.js";
 import { flip } from "./ingest/generation.js";
 import {
@@ -68,6 +68,13 @@ import { buildGeneration, flipRefusal, RecordRefused, type BuildReport } from ".
 import { checkEmbeddingSpace } from "./lib/space.js";
 import { parseQueriesFile, runCalibration } from "./calibrate/run.js";
 import { renderReport } from "./calibrate/math.js";
+import {
+  DRIFT_LIMIT,
+  DRIFT_SQL,
+  driftReport,
+  renderDrift,
+  type DriftSample,
+} from "./calibrate/drift.js";
 import { GATE_PREDICATE_DIGEST } from "./lib/search.js";
 import { widestViewer } from "./lib/policy-row.js";
 import { overlapAdvice } from "./calibrate/overlap.js";
@@ -94,9 +101,14 @@ Usage:
       when the tree is in a repository; --source-commit overrides it.
   ksor calibrate --instance PATH [--queries-file PATH] [--ooc-file PATH]
                  [--generation N] [--per-node N] [--min-chars N]
+  ksor calibrate --instance PATH --check [--days N]
       Measure the abstention floor for this corpus and report it. A
       measurement that does not separate in-corpus from out-of-corpus prints
       the diagnosis and NO floor: there is no safe number to paste.
+      --check reads the record's OWN logged searches instead and reports how
+      the declared floor is holding against them — no provider key, no
+      embedding call, no LLM. A monitor, never a gate: it says what to
+      re-measure and always exits 0.
   ksor grant --instance PATH [--revoke]
       Authorize ingest for the instance's tenant (the row row-level security
       requires), or withdraw it. Idempotent; reports the state it established.
@@ -709,12 +721,15 @@ async function calibrateCommand(args: string[]): Promise<number> {
       generation: { type: "string" },
       "per-node": { type: "string" },
       "min-chars": { type: "string" },
+      check: { type: "boolean", default: false },
+      days: { type: "string" },
     },
   });
   const instance = loadInstance(values.instance);
   if (typeof instance === "number") return instance;
   const dsn = resolveDsn(instance);
   if (typeof dsn === "number") return dsn;
+  if (values.check === true) return await checkFloorDrift(instance, dsn, values.days);
   const provider = composeProvider(instance);
   if (typeof provider === "number") return provider;
 
@@ -763,6 +778,70 @@ async function calibrateCommand(args: string[]): Promise<number> {
   process.stdout.write(renderReport(report, GATE_PREDICATE_DIGEST) + "\n");
   const advice = overlapAdvice(report);
   if (advice !== null) process.stdout.write(advice);
+  return 0;
+}
+
+/** How many days of traffic one --check reads. Bounded so a busy record cannot make it expensive. */
+const DRIFT_DEFAULT_DAYS = 30;
+
+interface DriftRow {
+  readonly top_cosine: number;
+  readonly abstained: boolean;
+}
+
+/**
+ * `ksor calibrate --check` — is the declared floor still holding?
+ *
+ * Reads the record's OWN logged searches (`retrieval_log.detail.top_cosine`,
+ * which is written on both sides of the gate) instead of measuring the corpus
+ * again, so it needs no provider key, no embedding call and no LLM. That is
+ * why it runs BEFORE the provider is composed: a check that demanded a vendor
+ * key would be one an adopter never puts in CI.
+ *
+ * ALWAYS EXITS 0. A stale floor wants re-measuring; failing a run for one would
+ * make the shortest way out deleting `vector_floor`, which turns the abstention
+ * gate off entirely to clear the error — the same escape `lifecycle-notice.ts`
+ * refuses to create for a passed review date.
+ */
+async function checkFloorDrift(
+  instance: ContentInstance,
+  dsn: string,
+  daysArg: string | undefined,
+): Promise<number> {
+  const floor = instance.abstain.vectorFloor;
+  if (floor === null) {
+    // Honest absence, never silent weakness: nothing has drifted because
+    // nothing is gating, and the surface already says so at boot.
+    process.stdout.write(
+      "floor drift: no floor declared — this record's gate is OFF, so out-of-corpus questions are answered rather than refused.\n" +
+        "  fix: run `ksor calibrate` and paste the retrieval block it prints\n",
+    );
+    return 0;
+  }
+  if (floor === "uncalibrated") {
+    process.stdout.write(
+      "floor drift: vector_floor is `uncalibrated` — the door refuses every search until a measured number replaces it.\n" +
+        "  fix: run `ksor calibrate` and paste the retrieval block it prints\n",
+    );
+    return 0;
+  }
+  const days = daysArg === undefined ? DRIFT_DEFAULT_DAYS : intFlag("--days", daysArg);
+  const rows = await withPool(dsn, (pool) =>
+    runAuditRead<readonly DriftRow[]>(pool, instance.tenantId, async (client) => {
+      const result = await client.query<DriftRow>(DRIFT_SQL, [
+        instance.tenantId,
+        instance.corpusId,
+        String(days),
+        DRIFT_LIMIT,
+      ]);
+      return result.rows;
+    }),
+  );
+  const samples: DriftSample[] = rows.map((row) => ({
+    topCosine: row.top_cosine,
+    abstained: row.abstained,
+  }));
+  process.stdout.write(renderDrift(driftReport(floor, samples), `last ${days} day(s)`));
   return 0;
 }
 

--- a/packages/ksor/docs/ingesting.md
+++ b/packages/ksor/docs/ingesting.md
@@ -230,6 +230,53 @@ belongs on the in-corpus side — moving it separates the measurement. Sometimes
 it is a genuine near-miss the corpus cannot separate, and then the floor
 correctly stays uncalibrated.
 
+### The floor goes stale as the record grows
+
+A floor is measured once, against the corpus as it stood that day, and then the
+record grows. As it does, questions that used to be out-of-corpus start scoring
+above a fixed number — so the record answers what it used to refuse, with no
+error, nothing logged, and the same `gate: { floor: … }` in every envelope. The
+guarantee weakens in silence, in the dangerous direction.
+
+You do not need telemetry to see it. Every search already leaves a row carrying
+the gate's own signal, on both sides of it, so the check reads the record's own
+traffic:
+
+```sh
+pnpm exec ksor calibrate --instance instance.md --check
+```
+
+No provider key, no embedding call, no LLM — one indexed query:
+
+```
+floor drift — last 30 day(s)
+  declared vector_floor  0.550
+  searches logged        112  (100 answered, 12 abstained)
+  abstain rate           10.7%
+  answered top score     p05 0.552  p50 0.810  p95 0.890
+  within 0.01 of floor    40  (40.0% of answers)
+  verdict                WATCH — 40 of 100 answers scored within 0.01 of the floor
+```
+
+Two numbers carry it. The **abstain rate**: a gate that has stopped refusing
+anything is either serving a record that now covers its traffic, or a floor that
+has fallen behind it. And the **share of answers within 0.01 of the floor** —
+the ones that would flip if the number moved at all, 0.01 being the size of the
+decision in this project's own gold rather than a threshold somebody picked.
+
+Run it on a schedule, or in your own CI beside `ksor build`. Three things to
+know about what it is:
+
+- **It never fails a run.** It always exits 0. A stale floor wants
+  re-measuring, and failing a build for one would make the shortest way out
+  deleting `vector_floor` — turning the gate off entirely to clear the error.
+- **It reads traffic, so it needs traffic**, and it says so rather than
+  reporting a healthy-looking nothing. It also cannot see questions nobody
+  asked: it can tell you the floor has gone permissive, never that it is too
+  strict.
+- **It is not a calibration.** When it says WATCH, re-run `ksor calibrate` —
+  that is the measurement, and it is the thing that produces a new number.
+
 ## Withdrawing a document
 
 A takedown is a committed ledger entry FIRST and a database row second, written

--- a/packages/ksor/src/cli.integration.test.ts
+++ b/packages/ksor/src/cli.integration.test.ts
@@ -150,6 +150,58 @@ describe("ksor CLI (built artifact)", () => {
     expect(init.stdout, "the form that scaffolds in place").toContain("ksor init .");
   });
 
+  /**
+   * `calibrate --check` NEVER fails a run.
+   *
+   * A stale abstention floor is a "this wants re-measuring" state. Refusing for
+   * one would make the shortest way out deleting `vector_floor` — turning the
+   * gate off entirely to clear the error — which is the same escape
+   * `build/lifecycle-notice.ts` refuses to create for a passed review date, and
+   * it would destroy the guarantee the check exists to protect (#182).
+   *
+   * Both branches here are asserted against an UNREACHABLE database on purpose:
+   * a record with no floor has nothing to measure, so the check must answer
+   * without opening a connection at all. If it ever starts connecting first,
+   * this goes red rather than becoming slow in an adopter's CI.
+   */
+  it("calibrate --check reports rather than refuses, and does not connect when there is nothing to measure", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "ksor-drift-"));
+    try {
+      writeFileSync(
+        path.join(root, "instance.md"),
+        [
+          "---",
+          "format: 2",
+          "name: acme",
+          'title: "Acme"',
+          'description: "One sentence."',
+          "database:",
+          "  dsn_env: KSOR_DB_URL",
+          "---",
+          "",
+          "Body.",
+          "",
+        ].join("\n"),
+      );
+      const r = spawnSync(
+        process.execPath,
+        [distCli, "calibrate", "--instance", path.join(root, "instance.md"), "--check"],
+        {
+          encoding: "utf8",
+          // Unreachable: nothing may connect here, and connecting would hang or
+          // fail rather than exit 0 with a sentence.
+          env: { ...process.env, KSOR_DB_URL: "postgres://nobody@127.0.0.1:1/none" },
+        },
+      );
+      expect(r.status, `${r.stdout}${r.stderr}`).toBe(0);
+      expect(r.stdout).toContain("no floor declared");
+      expect(r.stdout).toContain("ksor calibrate");
+      expect(r.stderr).toBe("");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, 30_000);
+
   it("every write-plane refusal opens with `error: <slug>`, the contract docs/index.md states", () => {
     // `ksor build` printed `error: ksor-instance-format`; `ksor schema` printed
     // its sentence with no slug at all, so an agent branching on the first

--- a/packages/ksor/templates/scaffold/AGENTS.md
+++ b/packages/ksor/templates/scaffold/AGENTS.md
@@ -215,6 +215,22 @@ Stand it up in this order (each step's errors explain how to fix themselves):
    the intent to gate WITHOUT a measurement, and every serve refuses until a
    number replaces it; that is the fail-closed posture, not a starting point.
 
+   **The same applies across TIME, not only across corpora.** A floor measured
+   against 5 documents is a copied constant once the record holds 200, and it
+   weakens in silence: questions that used to be out-of-corpus start scoring
+   above a fixed number, so the record answers what it used to refuse.
+
+   ```sh
+   pnpm exec ksor calibrate --instance instance.md --check
+   ```
+
+   reads the record's own logged searches and reports how the declared floor is
+   holding — no provider key, no LLM, one query, and it always exits 0. Run it
+   on a schedule; when it says WATCH, re-run `ksor calibrate` to get a new
+   number. It is a monitor, not a measurement: it can say the floor has gone
+   permissive against real traffic, never that it is too strict for questions
+   nobody asked.
+
 ```sh
 pnpm schema      # apply the DDL (once)
 pnpm grant       # authorize ingest for this corpus (once)


### PR DESCRIPTION
Closes #182.

## The problem

`vector_floor` is measured once, against the corpus as it stood that day. The record then grows and nothing re-examines the number — and it fails **quietly, in the dangerous direction**: questions that used to be out-of-corpus start scoring above a fixed floor, so the record answers what it used to refuse. No error, nothing logged, and the same `gate: { floor: … }` in every envelope.

AGENTS.md forbids copying a calibrated constant *between* corpora. The same reasoning applies *across time within one corpus*, and there nothing enforced it.

## It needs no telemetry — which is why it can ship now

The issue offered two routes: a metric (blocked on the unimplemented observability binding, #180) or re-running `calibrate` (needs a provider key and, by default, an LLM). **Neither is the cheapest route any more.**

Every search already leaves an audit row carrying the gate's own signal, and `detail.top_cosine` is on **both** sides of the gate — abstentions carried it from the start, answered searches gained it with the audit-detail work. The distribution #182 asks for is already in the database.

**One indexed query. No provider key, no embedding call, no LLM, no exporter, no new dependency.**

```
floor drift — last 30 day(s)
  declared vector_floor  0.550
  searches logged        112  (100 answered, 12 abstained)
  abstain rate           10.7%
  answered top score     p05 0.552  p50 0.810  p95 0.890
  within 0.01 of floor    40  (40.0% of answers)
  verdict                WATCH — 40 of 100 answers scored within 0.01 of the floor — the answer set turns on this exact number

  This is traffic, not a calibration: it cannot tell a record that grew
  from a floor that fell behind. Re-measure to find out —
    ksor calibrate --instance instance.md --queries-file <your questions>
```

## It never gates — the design, not a limitation

A stale floor is a "this wants re-measuring" state. Failing a run for one would make the shortest way out **deleting `vector_floor`** — turning the abstention gate off entirely to clear the error. That is precisely the escape `build/lifecycle-notice.ts` refuses to create for a passed review date:

> *"refusing the build would turn 'this needs reviewing' into 'your record will not compile', and the shortest way out of that would be deleting the `stale_after` — spending the governance to clear the error."*

So it always exits 0, and that is asserted against an **unreachable database**: a record with no floor has nothing to measure, so the check must answer without opening a connection. If it ever starts connecting first, the test goes red rather than the behaviour becoming slow in an adopter's CI.

## Where the numbers come from

- **0.01** is quoted, not chosen: it is the size of the decision in this record's own gold — in-corpus 0.730 / 0.671 against a scope-adjacent near-miss at 0.683 (`evals/behavioural.db.test.ts`), the same figures decision 20 cites.
- **The 20% share** that triggers WATCH *is* a reporting choice, and its comment says so rather than dressing it as measured.
- **Below 30 searches it declines a verdict** and says why — a record nobody queries must not read as healthy.

## Two things found while building it

**The serving role cannot read `retrieval_log`** — no SELECT grant, deliberately. The first cut used `runRead` and was refused by the database. Reading through `runAuditRead` instead is correct; widening the grant would have traded an audit guarantee for a convenience.

**Scoped by corpus, not just tenant** — the reason `readLedger` already records: a tenant serving two corpora would otherwise measure one record's floor against the other's traffic. Asserted in the db tier.

## What it is not, stated in the code and the docs

A **monitor**, not a calibration. It reads the questions people asked, so it can say a floor has gone permissive against real traffic and can never say one is too strict for questions nobody asks. When it says WATCH, the remedy is `ksor calibrate` — the measurement.

## Dropped from the plan

I proposed a line in the `serve` boot report so the check needed no adopter action. **Cut**: that would put a 5,000-row scan on the cold-start path decision 17 exists to keep cheap, for a signal that changes on the timescale of weeks. `driftLine` was written and tested, then deleted rather than shipped as a tested dead export — the mistake I made with `SCRATCH_LITERAL` two PRs ago. A scheduled `--check` is the right shape, and the docs say so.

## Verification

Walked end to end on a real record and a real Postgres in all four states — no floor, `uncalibrated`, steady, drifted.

| tier | |
|---|---|
| unit | 1560 (13 new, pure) |
| integration | 61 files, 608 passed |
| db | 42 files, 304 passed (5 new) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)