### PR TITLE
Tell the owner about display names, not just their agent

### DIFF
--- a/.changeset/readme-display-names.md
+++ b/.changeset/readme-display-names.md
@@ -1,0 +1,12 @@
+---
+"@panaversity/ksor": patch
+---
+
+The emitted README documents `.ksor/people.yaml`.
+
+Display names shipped documented in the scaffold's AGENTS.md and not in its
+README — so the coding agent knew about the feature and the owner did not, on
+the one feature whose entire input is a human typing their colleagues' names.
+The README now carries it beside the keys that publish a document: the map
+shape, that an actor with no entry renders exactly as stored, and that
+appearing in the file grants no authority at all.

--- a/packages/ksor/templates/scaffold/README.md
+++ b/packages/ksor/templates/scaffold/README.md
@@ -372,6 +372,29 @@ approved has to be the text that was written. That act is yours.
 Run `pnpm check` before you commit. It runs the rules as a program, and every
 failure it reports says what is wrong, why the rule exists, and how to fix it.
 
+### Names instead of handles
+
+The record stores actors as identifiers — `human:you`, `team:legal-ops` — and a
+page would otherwise lead with the slug: "Owner · human:bashiraziz". Put the
+name beside the identifier in `.ksor/people.yaml` and pages print that instead:
+
+```yaml
+people:
+  "human:bashiraziz": Bashir Aziz
+  "human:ciso": Ayesha Khan
+```
+
+Keyed by the identifier exactly as the record stores it, quoted because it
+contains a colon. There is no rule that turns a name into a handle — `ciso` is
+nobody's squashed full name — so both are written down, and an actor with no
+entry renders exactly as stored rather than being guessed at.
+
+**This is presentation, and nothing else.** It grants no authority: who may
+approve or withdraw is `.ksor/governance.yaml`, and the two files are not
+checked against each other, because someone who leaves the authority list is
+still the recorded approver of everything they approved. Optional — a record
+that declares no names reads exactly as it did before.
+
 ### Presenting a document
 
 Ask your coding agent for slides and it writes them, from the document, into the


### PR DESCRIPTION
`.ksor/people.yaml` (#199) shipped documented in the emitted **AGENTS.md** — four mentions — and in the emitted **README** not once.

So the coding agent knew the feature existed and the person who has to type their colleagues' names into it did not. That is backwards for the one feature whose entire input is a human's knowledge of who people are.

## What lands

A short section in the README where it already introduces actors, beside `approval.by`:

- the map shape, keyed by the identifier as stored
- that there is no rule turning a name into a handle — `ciso` is nobody's squashed full name — so both are written down
- that an actor with no entry renders exactly as stored rather than being guessed at
- that appearing in the file grants **no authority**, and the two files are not checked against each other, because someone who leaves the authority list is still the recorded approver of everything they approved

## What deliberately does not land

**No new document.** The question that started this was whether a governance page was missing. It is not: the emitted README already explains `.ksor/governance.yaml` as the authority, the intake replacing `human:you`, deleting the starter producer, and `approval.by` needing a listed actor; AGENTS.md carries the actor grammar and the rest. A third copy would break "one fact, one file — everywhere else is a pointer", which is the rule whose absence the tool-surface figures just demonstrated: six documents, one number, one of them stale for two releases.

**Not a starter knowledge document either.** `governance-ladder.md` names no filenames on purpose — it is a concept document and it is meant to be deleted. Tool mechanics in sample knowledge makes decision 27's disclosed risk worse, not better.

## One gap left open, deliberately

`packages/ksor/docs/` ships pages for deploying, ingesting, tool-surface, upgrading and authorization — and nothing about the governance policy. Someone evaluating ksor without scaffolding finds the product's core claim undocumented, and `authorization.md` sounds like it would cover it but is the SSO door.

That is an evaluation gap rather than an operating one, and it is a page to be written rather than a line to be fixed — left for a decision rather than smuggled in here.

Local: docs-truth, scaffold-scripts and init suites green (84 tests), guard and format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)