### PR TITLE
Correct the per-request-scoping claim, and ship .mcp.json

### DIFF
--- a/.changeset/mcp-config-and-auth-doc.md
+++ b/.changeset/mcp-config-and-auth-doc.md
@@ -1,0 +1,31 @@
+---
+"@panaversity/ksor": patch
+---
+
+Two things: a false claim removed from a shipped page, and the scaffold gains
+`.mcp.json`.
+
+**The false claim.** `docs/deploying.md` told adopters "The MCP surface already
+applies the audience scope **per request**", under the heading of the very
+requirement it does not meet. It does not: `content-gateway/src/compose.ts`
+reads `KSOR_AUDIENCE` from the environment once at boot into a per-process
+viewer, and the request path never touches it — `docs/authorization.md` says so
+plainly ("Any caller holding a valid token gets the whole record") and
+`specs/ksor/serve/spec.md` names per-request visibility filtering as out of
+scope. A reader who believed the page would point every caller at one door and
+serve them the restricted half. The page now says what the door does — one
+viewer per door, so one process per audience — and separates the audit it does
+give (a `retrieval_log` row naming the verified caller) from the authorization
+it does not. A docs-truth assertion now fails on the claim itself, not merely on
+a command that no longer exists.
+
+**`.mcp.json`.** The scaffold's closed root set gains one member: the MCP
+servers a coding agent may reach from the project. It ships with Neon's, which
+turns the step the tool could never do for an adopter — provision a Postgres,
+enable pgvector, produce a connection string — into four real tool calls
+(`create_project`, `run_sql`, `create_branch`, `get_connection_string`) and one
+sentence to the agent. The scaffold's README and AGENTS.md carry that sentence,
+and both now say plainly which step no agent can do at any price: the embedding
+API key, which no vendor mints over a protocol. Committed rather than ignored,
+because both entries authenticate interactively and the file carries no secret —
+stated, because pasting an API key into it would change that.

--- a/packages/ksor/docs/deploying.md
+++ b/packages/ksor/docs/deploying.md
@@ -427,12 +427,21 @@ Plain `pnpm build` is `[public]`, so the safe thing is the default.
 
 Two supported answers, and a third that is yours.
 
-**Read through the door instead.** This is the one ksor is built for. The MCP
-surface already applies the audience scope **per request** and writes a
-`retrieval_log` row carrying the actor for every read — per-person governance
-with an audit trail, which a static site cannot have at any price. If the
-requirement is "who read what, and were they allowed to", that is the door, not
-the website.
+**Run a door per audience.** The door does NOT decide per request: it serves
+ONE viewer list, read from `KSOR_AUDIENCE` once at boot
+(`content-gateway/src/compose.ts`) and validated against the policy before it
+widens past `public`. Every caller holding a valid token for that door gets the
+same view of the record — `docs/authorization.md` says so plainly, and
+per-request visibility filtering is named out of scope in
+`specs/ksor/serve/spec.md`. So the answer is one process per viewer list, each
+with its own `KSOR_AUDIENCE`, behind whatever routing already decides who
+reaches which URL.
+
+What the door gives that a static site cannot is the **audit**, not the
+authorization: every read writes a `retrieval_log` row naming the verified
+caller, so "who read what" is answerable afterwards. That is worth having, and
+it is a different thing from "were they allowed to", which is still decided by
+which door they can reach.
 
 **Or split the record.** Content needing per-person confidentiality inside one
 tier is usually content that belongs in its own record, with its own gate. That

--- a/packages/ksor/src/docs-truth.integration.test.ts
+++ b/packages/ksor/src/docs-truth.integration.test.ts
@@ -666,3 +666,50 @@ describe("the emitted docs are true about the artefact they ship with", () => {
     ).toBe(true);
   });
 });
+
+/**
+ * No document may claim the door decides audience PER REQUEST.
+ *
+ * It does not. `content-gateway/src/compose.ts` reads `KSOR_AUDIENCE` from the
+ * environment once at boot into a per-process viewer; the request path never
+ * touches it, so every caller holding a valid token for a door gets a
+ * byte-identical view of the record. `docs/authorization.md` says exactly that
+ * ("Any caller holding a valid token gets the whole record"), and
+ * `specs/ksor/serve/spec.md` names per-request visibility filtering as out of
+ * scope — and one shipped page said the opposite anyway, under the heading of
+ * the requirement it fails.
+ *
+ * That is the most expensive kind of documentation defect this product can
+ * have: it would walk an adopter with genuinely restricted documents into
+ * pointing every reader at one door and serving them the internal half. The
+ * earlier guards check that a named command EXISTS; this checks the CLAIM,
+ * which is the half that was wrong (the same shape as the scaffold's "no
+ * document claims that serving publishes").
+ */
+describe("no document claims the door scopes audience per request", () => {
+  /** Shapes that assert it, in any phrasing a rewrite is likely to reach for. */
+  const CLAIMS: readonly RegExp[] = [
+    /audience scope\s+(?:\*\*)?per[- ]request/i,
+    /per[- ]request\s+(?:\*\*)?audience/i,
+    /scopes?\s+the\s+audience\s+per\s+request/i,
+    /applies\s+the\s+audience[^.]{0,40}per\s+request/i,
+  ];
+
+  const pages = readdirSync(path.join(repoRoot, "packages/ksor/docs"))
+    .filter((name) => name.endsWith(".md"))
+    .map((name) => `packages/ksor/docs/${name}`)
+    .concat([`${SCAFFOLD}/README.md`, `${SCAFFOLD}/AGENTS.md`, "README.md"]);
+
+  it.each(pages)("%s", (rel) => {
+    const text = read(rel);
+    for (const shape of CLAIMS) {
+      const hit = shape.exec(text);
+      expect(
+        hit,
+        `${rel} says the door scopes audience per request: ${JSON.stringify(hit?.[0] ?? "")}. ` +
+          "It does not — compose.ts resolves the viewer once at boot. A reader who believes " +
+          "this points every caller at one door and serves them the restricted half.",
+      ).toBeNull();
+    }
+  });
+});

--- a/packages/ksor/src/init.integration.test.ts
+++ b/packages/ksor/src/init.integration.test.ts
@@ -37,6 +37,7 @@ const EMITTED_NAMES: ReadonlyMap<string, string> = new Map([
   ["gitignore", ".gitignore"],
   ["env.example", ".env.example"],
   ["dockerignore", ".dockerignore"],
+  ["mcp.json", ".mcp.json"],
 ]);
 
 function emittedPath(templateRel: string): string {
@@ -597,6 +598,10 @@ describe("ksor init — scaffold contents (spec: emitted-tree contract)", () => 
         // The Governance Policy and, once a takedown exists, the ledger —
         // the record's root of authority beside the bundle (record spec §1).
         ".ksor",
+        // The MCP servers a coding agent may reach from this project — the
+        // database it will provision, and a live record to read. Carries no
+        // secret: both entries authenticate interactively.
+        ".mcp.json",
         "AGENTS.md",
         "CLAUDE.md",
         // The MCP door as a portable container — no host named in it

--- a/packages/ksor/src/init/materialize.ts
+++ b/packages/ksor/src/init/materialize.ts
@@ -30,6 +30,10 @@ const EMITTED_NAMES: ReadonlyMap<string, string> = new Map([
   // so the template ships bare and init restores the dot.
   ["env.example", ".env.example"],
   ["dockerignore", ".dockerignore"],
+  // The MCP servers a coding agent may reach from this project. Ships bare for
+  // the same packing reason, and it carries no secret — both entries
+  // authenticate interactively — so it is committed rather than ignored.
+  ["mcp.json", ".mcp.json"],
 ]);
 
 const TEXT_EXTENSIONS = new Set([

--- a/packages/ksor/templates/scaffold/AGENTS.md
+++ b/packages/ksor/templates/scaffold/AGENTS.md
@@ -133,9 +133,12 @@ Stand it up in this order (each step's errors explain how to fix themselves):
 pgvector/pgvector:pg17`.
 
    **`GEMINI_API_KEY` is the one step no agent can do.** No vendor mints an API
-   key over a protocol; it comes from a browser at `aistudio.google.com` and a
-   human pastes it. An agent working through this list should ask for it by name
-   and stop, rather than trying.
+   key over a protocol; it comes from a browser at
+   [aistudio.google.com/apikey](https://aistudio.google.com/apikey) and a human
+   pastes it. An agent working through this list should ask for it by name and
+   stop, rather than trying — and should say that the FREE TIER is enough:
+   embedding input on `gemini-embedding-001` is free of charge, so this is a
+   signup, not a bill.
 
 3. **Copy `.env.example` to `.env`** and fill it in — `ksor` reads it
    automatically, so nothing needs exporting, and `.env` is already gitignored.

--- a/packages/ksor/templates/scaffold/AGENTS.md
+++ b/packages/ksor/templates/scaffold/AGENTS.md
@@ -114,7 +114,30 @@ Stand it up in this order (each step's errors explain how to fix themselves):
    Leave `retrieval:` out for now — the gate is off and the server says so.
    Turning it on is step 4, AFTER the record is serving.
 
-2. **Copy `.env.example` to `.env`** and fill it in — `ksor` reads it
+2. **Get the database — your agent can do this one.** `.mcp.json` at the repo
+   root declares the MCP servers this project may reach, and the first is Neon.
+   With it connected, ask:
+
+   > Using the Neon MCP server, create a project called `<your-record>` and
+   > enable the pgvector extension on it. Then create a branch called `dev`,
+   > and save that branch's connection string to `.env` as `KSOR_DB_URL`.
+   > Never print my API key. Show me the plan before you run anything.
+
+   That is `create_project`, `run_sql` (`CREATE EXTENSION vector`),
+   `create_branch` and `get_connection_string` — four real tools, no dashboard.
+   Prefer the OAuth flow: an API key pasted into `.mcp.json` would be committed,
+   because that file carries no secret and is not gitignored.
+
+   Any Postgres with pgvector works — Neon is the path with an MCP server, not a
+   requirement. Locally: `docker run -e POSTGRES_PASSWORD=x -p 5432:5432
+pgvector/pgvector:pg17`.
+
+   **`GEMINI_API_KEY` is the one step no agent can do.** No vendor mints an API
+   key over a protocol; it comes from a browser at `aistudio.google.com` and a
+   human pastes it. An agent working through this list should ask for it by name
+   and stop, rather than trying.
+
+3. **Copy `.env.example` to `.env`** and fill it in — `ksor` reads it
    automatically, so nothing needs exporting, and `.env` is already gitignored.
    A real environment variable still wins over the file, so CI and production
    overrides behave normally.
@@ -134,7 +157,7 @@ Stand it up in this order (each step's errors explain how to fix themselves):
      intended dev shape. A PUBLIC deployment configures the SSO door instead —
      see the comments in `.env.example` and "Serving safely" below.
 
-3. **Bring it up.** Once, then every time:
+4. **Bring it up.** Once, then every time:
 
    ```sh
    pnpm provision  # schema (or migrate) + grant — the privileged acts, run once
@@ -219,7 +242,7 @@ Stand it up in this order (each step's errors explain how to fix themselves):
    serves, or a DBA who holds the credentials that authorize ingest — not as a
    daily choice.
 
-4. **Turn the abstention gate on — deliberately, once it serves.** This is the
+5. **Turn the abstention gate on — deliberately, once it serves.** This is the
    step that makes "not in this corpus" a real answer, and it is measured, never
    guessed:
 

--- a/packages/ksor/templates/scaffold/README.md
+++ b/packages/ksor/templates/scaffold/README.md
@@ -171,7 +171,27 @@ That is the whole required config. `embedding:` defaults to Gemini at 1536
 dimensions, and `retrieval:` is written for you by step 3's `calibrate`. Change
 the variable name here only if you want a different one.
 
-### 2. Fill in the environment
+### 2. Get a database — your agent can do this one
+
+`.mcp.json` at the repo root declares the MCP servers this project may reach.
+The first is Neon's. With it connected, ask your coding agent:
+
+> Using the Neon MCP server, create a project called `<your-record>` and enable
+> the pgvector extension on it. Then create a branch called `dev`, and save that
+> branch's connection string to `.env` as `KSOR_DB_URL`. Never print my API key.
+> Show me the plan before you run anything.
+
+Prefer the OAuth flow. `.mcp.json` is committed and carries no secret; an API
+key pasted into it would be.
+
+Any Postgres with pgvector works — Neon is the path that has an MCP server, not
+a requirement. Locally:
+`docker run -e POSTGRES_PASSWORD=x -p 5432:5432 pgvector/pgvector:pg17`.
+
+**`GEMINI_API_KEY` is the one step no agent can do for you** — no vendor mints
+an API key over a protocol. Get it from `aistudio.google.com` and paste it.
+
+### 3. Fill in the environment
 
 ```sh
 cp .env.example .env
@@ -191,7 +211,7 @@ refusal tells you to _export_ a variable, putting it in `.env` is the same
 thing. `KSOR_AUTH=disabled-local` is required for a local run: serve refuses to
 boot unauthenticated on purpose, so a server is never open by accident.
 
-### 3. Bring it up
+### 4. Bring it up
 
 ```sh
 pnpm provision  # once: apply the schema, authorize ingest

--- a/packages/ksor/templates/scaffold/README.md
+++ b/packages/ksor/templates/scaffold/README.md
@@ -189,7 +189,11 @@ a requirement. Locally:
 `docker run -e POSTGRES_PASSWORD=x -p 5432:5432 pgvector/pgvector:pg17`.
 
 **`GEMINI_API_KEY` is the one step no agent can do for you** — no vendor mints
-an API key over a protocol. Get it from `aistudio.google.com` and paste it.
+an API key over a protocol. Get it from
+[aistudio.google.com/apikey](https://aistudio.google.com/apikey) and paste it.
+**The free tier costs nothing and is enough**: embedding input on
+`gemini-embedding-001` is free of charge, and a first corpus is a few thousand
+tokens. This is a signup, not a bill.
 
 ### 3. Fill in the environment
 

--- a/packages/ksor/templates/scaffold/mcp.json
+++ b/packages/ksor/templates/scaffold/mcp.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "Neon": {
+      "type": "http",
+      "url": "https://mcp.neon.tech/mcp"
+    },
+    "agentfactory-system-of-record": {
+      "type": "http",
+      "url": "https://sor.panaversity.org/mcp",
+      "oauth": { "clientId": "zia-tutor-ai", "callbackPort": 3118 }
+    }
+  }
+}


### PR DESCRIPTION
Two changes, both about what the project tells whoever reads it next.

## 1. A false claim on a shipped page

`docs/deploying.md` told adopters:

> The MCP surface already applies the audience scope **per request**

…under the heading of the very requirement it does not meet. It does not. `content-gateway/src/compose.ts:166` reads `KSOR_AUDIENCE` from the environment **once at boot** into a per-process viewer; the request path never touches it.

The project already said so, twice:
- `docs/authorization.md:42-48` — *"Any caller holding a valid token gets the whole record"*
- `specs/ksor/serve/spec.md:223` — per-request visibility filtering, named **out of scope**

A reader who believed the page would point every caller at one door and serve them the restricted half. That was the only live exposure found in a six-pass audit.

**The page now says what the door does:** one viewer per door, so one process per audience, behind whatever routing already decides who reaches which URL. And it separates the audit the door genuinely gives — a `retrieval_log` row naming the verified caller for every read — from the authorization it does not.

**A docs-truth assertion now fails on the CLAIM.** The existing guards check that a named command *exists*; the half that was wrong here was the sentence attached to it — the same shape as the scaffold's "no document claims that serving publishes". Proved by restoring the shipped wording and watching it go red:

```
AssertionError: packages/ksor/docs/deploying.md says the door scopes audience per request:
"audience scope **per request". It does not — compose.ts resolves the viewer once at boot.
```

## 2. `.mcp.json` in the scaffold

The closed root set gains one member, on the reasoning decision 8's `.env.example` revision already gives: an empty directory is an unanswered question, and a named, committed declaration of the MCP servers a coding agent may reach is an answered one.

It ships with Neon's, which turns the step this tool could never do for an adopter — provision a Postgres, enable pgvector, produce a connection string — into four real tool calls (`create_project`, `run_sql`, `create_branch`, `get_connection_string`) and one sentence to the agent. That sentence is now in the emitted README and AGENTS.md:

> Using the Neon MCP server, create a project called `<your-record>` and enable the pgvector extension on it. Then create a branch called `dev`, and save that branch's connection string to `.env` as `KSOR_DB_URL`. Never print my API key. Show me the plan before you run anything.

**Both documents now also say which step no agent can do at any price** — the embedding API key, because no vendor mints one over a protocol. Nothing in the adopter-facing docs previously said where an agent must stop (`grep` for *"ask the owner | a human must | sign up"* across every adopter-facing doc returned **zero** hits), so an agent had no way to know, and would burn turns on a step no competence satisfies.

Neon is the path that has an MCP server, not a requirement: the docs name any pgvector Postgres, with the `docker run pgvector/pgvector:pg17` one-liner that until now existed only in this project's own CI.

Committed rather than gitignored, because both entries authenticate interactively and the file carries no secret — written down, because pasting an API key into it would change that.

## Verification

Emitted scaffold carries `.mcp.json` at the root, `git check-ignore` confirms it is committed. Closed-root-set test and the template-identity test both updated (the test keeps its own copy of the rename map deliberately — *"a test that shares the map with the implementation cannot catch the implementation losing it"*).

Unit 1566 · integration 61 files / 617 passed · guard, corpus, format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)