### PR TITLE
Name the free-tier calibration path, and move the probe model to 3.7-flash

### DIFF
--- a/.changeset/calibrate-free-tier.md
+++ b/.changeset/calibrate-free-tier.md
@@ -1,0 +1,29 @@
+---
+"@panaversity/ksor": patch
+---
+
+`ksor calibrate` names the free-tier path when a quota refuses it, and the
+calibration text model moves to `gemini-3.7-flash`.
+
+Walked on a real free-tier key: embedding is free of charge and a first corpus
+embeds fine (23 chunks, 0 failed), but the DEFAULT calibration door writes one
+probe question per sampled passage with an LLM — and the free tier allows five
+generations a minute. So the documented way to turn on the product's headline
+feature failed, surfacing the vendor's sentence and nothing else.
+
+Two quotas reach that code and they need opposite answers: the generation cap is
+a wall no wait clears (the remedy is `--queries-file`, the zero-LLM door), and
+the embedding cap is a per-minute window (the remedy is to wait, and the usual
+cause is an ingest immediately before). Both are now named, with why. A 429 this
+does not recognise is re-thrown untouched — an invented remedy is worse than the
+vendor's own message.
+
+`docs/ingesting.md` documents the zero-LLM door where the reader meets the
+command, including how to choose the questions: the floor is set by the weakest
+one, so a vague question drags it down and a question the record cannot answer
+invalidates the measurement.
+
+The text model moves `gemini-2.5-flash` → `gemini-3.7-flash`. Cheap, unlike the
+embedding model: it only writes probe questions, so nothing stored is
+re-computed and no floor is invalidated — and the door is recorded beside every
+number, which is what stops two measurements being compared as one experiment.

--- a/.changeset/calibrate-free-tier.md
+++ b/.changeset/calibrate-free-tier.md
@@ -27,3 +27,13 @@ The text model moves `gemini-2.5-flash` → `gemini-3.7-flash`. Cheap, unlike th
 embedding model: it only writes probe questions, so nothing stored is
 re-computed and no floor is invalidated — and the door is recorded beside every
 number, which is what stops two measurements being compared as one experiment.
+
+**And calibration now embeds on the patient retry.** It used the READ plane's
+door, which never retries a 429 — correct for a live search, which should
+degrade to keyword-only in under a second rather than stall a reader behind
+backoff, and wrong for a measurement nobody is waiting on. So a free-tier key
+that rate-limited mid-run refused the whole calibration. The intent stays
+`query` (a floor must be measured through the label the door searches with);
+only the retry policy moves, to the one `isRetryable`'s own comment describes
+for batch work. Calibration's text generation already took that path, so this
+was the two halves of one act disagreeing.

--- a/packages/content/src/calibrate/quota.test.ts
+++ b/packages/content/src/calibrate/quota.test.ts
@@ -1,0 +1,80 @@
+/**
+ * The two quota refusals, told apart.
+ *
+ * Both were hit walking a real free-tier key, one after the other, and they
+ * need OPPOSITE answers: the generation quota is a wall no wait clears, so the
+ * remedy is the other door; the embedding quota is a per-minute window, so the
+ * remedy is to wait. Getting them the wrong way round would send a reader to
+ * sit out a limit that never lifts, or to rewrite their calibration over a
+ * sixty-second pause.
+ *
+ * The messages are the vendor's, verbatim from those runs.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { quotaRemedy } from "./quota.js";
+
+const GENERATION =
+  "Gemini API error 429: You exceeded your current quota, please check your plan and " +
+  "billing details. * Quota exceeded for metric: " +
+  "generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 5, " +
+  "model: gemini-2.5-flash Please retry in 29.696788738s.";
+
+const EMBEDDING =
+  "Gemini API error 429: Quota exceeded for " +
+  "aiplatform.googleapis.com/global_embed_content_requests_per_minute_per_base_model " +
+  "with base model: gemini-embedding. Please submit a quota increase request.";
+
+describe("the generation quota", () => {
+  it("sends the reader to the zero-LLM door, not to a wait", () => {
+    const remedy = quotaRemedy(GENERATION);
+    expect(remedy).not.toBeNull();
+    expect(remedy).toContain("--queries-file");
+    expect(remedy, "waiting does not clear a per-minute generation cap on a corpus").not.toMatch(
+      /wait/i,
+    );
+  });
+
+  it("says why a bigger corpus makes it worse, since that is the counter-intuitive part", () => {
+    expect(quotaRemedy(GENERATION)).toMatch(/worse, not better/);
+  });
+});
+
+describe("the embedding quota", () => {
+  it("sends the reader to a wait, not to a different door", () => {
+    const remedy = quotaRemedy(EMBEDDING);
+    expect(remedy).not.toBeNull();
+    expect(remedy).toMatch(/wait about a minute/i);
+    expect(remedy, "changing door would not help — both doors embed").not.toContain(
+      "--queries-file",
+    );
+  });
+
+  it("names the ingest as the usual cause, because that is what spent the budget", () => {
+    expect(quotaRemedy(EMBEDDING)).toMatch(/ingest/i);
+  });
+
+  it("says nothing was written, so a reader does not go looking for damage", () => {
+    expect(quotaRemedy(EMBEDDING)).toMatch(/Nothing was written/i);
+  });
+});
+
+describe("anything else", () => {
+  it("gets no invented advice — the vendor's own message stands", () => {
+    for (const other of [
+      "Gemini API error 500: internal",
+      "Gemini API error 403: API key not valid",
+      "connect ECONNREFUSED 127.0.0.1:5432",
+      "",
+    ]) {
+      expect(quotaRemedy(other), JSON.stringify(other)).toBeNull();
+    }
+  });
+
+  it("does not fire on a 429 it cannot attribute", () => {
+    // A quota this does not know is not one it can prescribe for. Better the
+    // raw sentence than a confident wrong remedy.
+    expect(quotaRemedy("Gemini API error 429: Quota exceeded for something else")).toBeNull();
+  });
+});

--- a/packages/content/src/calibrate/quota.ts
+++ b/packages/content/src/calibrate/quota.ts
@@ -1,0 +1,54 @@
+/**
+ * What to do when calibration is refused for quota — named, not left as the
+ * vendor's sentence.
+ *
+ * Both of these were hit walking a real free-tier key, and they are DIFFERENT
+ * failures with different remedies, which is why the raw error is not enough:
+ *
+ *   generate_content …/gemini-3.7-flash, limit 5   the SYNTHESIZED door writes
+ *                                                  one probe question per
+ *                                                  sampled passage, and a free
+ *                                                  key allows a handful of
+ *                                                  generations a minute. No
+ *                                                  amount of waiting fixes a
+ *                                                  corpus of any size; the
+ *                                                  answer is the zero-LLM door.
+ *   global_embed_content_requests_per_minute       the EMBEDDING endpoint, which
+ *                                                  both doors use. Transient:
+ *                                                  an ingest immediately before
+ *                                                  a calibration spends the same
+ *                                                  per-minute budget.
+ *
+ * Product principle 4: a failure states what is wrong, why the rule exists, and
+ * how to fix it. The vendor's message states only the first.
+ */
+
+/** The generation quota, which no wait resolves on a free key. */
+const GENERATION = /generate_content|generativelanguage\.googleapis\.com\/generate/i;
+/** The embedding quota, which clears on its own. */
+const EMBEDDING = /embed_content|global_embed/i;
+
+/**
+ * The remedy for a quota refusal, or null when the failure is not one this
+ * knows — in which case the vendor's own message stands, unembellished.
+ */
+export function quotaRemedy(message: string): string | null {
+  if (GENERATION.test(message)) {
+    return (
+      "the SYNTHESIZED door writes one probe question per sampled passage with an LLM, " +
+      "and a free-tier key allows only a few generations a minute — a bigger corpus makes " +
+      "this worse, not better.\n" +
+      "  fix: calibrate with zero LLM — write your in-corpus questions one per line and pass\n" +
+      "       --queries-file PATH. The floor is measured the same way; only the questions differ,\n" +
+      "       and the door is recorded beside the number so the two are never compared."
+    );
+  }
+  if (EMBEDDING.test(message)) {
+    return (
+      "the EMBEDDING endpoint is limited per minute, and both doors use it — an ingest " +
+      "immediately before this spends the same budget.\n" +
+      "  fix: wait about a minute and run it again. Nothing was written; calibration only reads."
+    );
+  }
+  return null;
+}

--- a/packages/content/src/calibrate/retry-plane.test.ts
+++ b/packages/content/src/calibrate/retry-plane.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Calibration measures on the PATIENT retry, with the QUERY intent.
+ *
+ * Two axes, and they were confused into one. The INTENT must stay `"query"`:
+ * a floor has to be measured through the same vendor task label the door will
+ * use, or the number describes a space nothing serves. The RETRY POLICY must be
+ * the ingest plane's: calibration is build-plane batch work with nobody
+ * waiting, which is the case `isRetryable`'s own comment describes.
+ *
+ * `aembedIntent` never retries a 429, and is right not to — a rate-limited
+ * search should degrade to keyword-only in under a second rather than stall a
+ * reader behind backoff. Calibration inherited that fail-fast policy, and on a
+ * free-tier key that meant the single command which turns on this product's
+ * headline feature was refused mid-measurement (walked live, 2026-09-01).
+ *
+ * Asserted as a property of the SOURCE, because the alternative is a live
+ * rate-limited provider, which is exactly the thing that cannot be arranged on
+ * demand. Crude, and it fails on the one edit that would reintroduce the bug.
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+// Comments stripped: this file's own prose names `aembedIntent` to explain why
+// it is not used, and a bare word-match reads that as the defect. Caught by
+// running the assertion before mutating anything — it failed on the fixed code.
+const run = readFileSync(path.join(here, "run.ts"), "utf8")
+  .replace(/\/\*[\s\S]*?\*\//g, "")
+  .replace(/^[ \t]*\/\/.*$/gm, "");
+
+describe("the calibration runner's embed call", () => {
+  it("uses the ingest plane's patient door, which retries a 429", () => {
+    expect(
+      /embedIntent\(\[query\]/.test(run),
+      "calibration must embed through `embedIntent` — the patient retry",
+    ).toBe(true);
+  });
+
+  it("does NOT use the fail-fast query door", () => {
+    // The one edit that reintroduces the defect is swapping this back.
+    expect(
+      /aembedIntent\s*\(/.test(run),
+      "`aembedIntent` never retries a 429: correct for a live search, wrong for " +
+        "a measurement nobody is waiting on",
+    ).toBe(false);
+  });
+
+  it("keeps the QUERY intent — the other axis, which must not move", () => {
+    // Measuring through the document label would produce a floor for a space
+    // the door does not search in.
+    expect(/intent: "query"/.test(run)).toBe(true);
+  });
+});

--- a/packages/content/src/calibrate/run.ts
+++ b/packages/content/src/calibrate/run.ts
@@ -24,7 +24,7 @@ import { ADMITTED, ADMITTED_CTE } from "../lib/admit.js";
 // because an unbound scope now denies (the seam fails closed).
 import { audienceGucs, WHOLE_RECORD_SCOPE } from "../lib/audience.js";
 import { NO_TRUST_FLOOR } from "../lib/trust.js";
-import { aembedIntent, type EmbeddingProvider, type TextGenerator } from "../lib/embedding.js";
+import { embedIntent, type EmbeddingProvider, type TextGenerator } from "../lib/embedding.js";
 import { topOneScore, VECTOR_TXN_GUCS, type SearchScope } from "../lib/search.js";
 
 import { DENIED_CTE, DENY } from "../lib/takedown.js";
@@ -148,7 +148,23 @@ async function scoreQueries(
 ): Promise<ScoredQuery[]> {
   const out: ScoredQuery[] = [];
   for (const query of queries) {
-    const [vector] = await aembedIntent([query], { provider, intent: "query" });
+    // The QUERY intent, on the INGEST plane's patient retry — deliberately not
+    // `aembedIntent`. Both matter and they are different axes: the intent must
+    // stay "query", because a floor has to be measured through the same vendor
+    // task label the door will use, or the number describes a space nothing
+    // serves. But the RETRY policy must be the patient one, because this is
+    // build-plane batch work with nobody waiting — the case
+    // `isRetryable`'s own comment describes.
+    //
+    // `aembedIntent` never retries a 429, correctly: a rate-limited search
+    // should degrade to keyword-only in under a second rather than stall a
+    // reader behind backoff. Calibration inherited that and it is wrong here —
+    // a free-tier key rate-limits mid-measurement and the whole run is refused,
+    // so the one command that turns on this product's headline feature failed
+    // on the tier most first records are on (walked live, 2026-09-01). Note
+    // that calibration's TEXT generation already takes the patient path
+    // (`generateText`), so this was the two halves of one act disagreeing.
+    const [vector] = await embedIntent([query], { provider, intent: "query" });
     const score = await runRead(
       pool,
       scope.tenantId,

--- a/packages/content/src/commands.ts
+++ b/packages/content/src/commands.ts
@@ -68,6 +68,7 @@ import { buildGeneration, flipRefusal, RecordRefused, type BuildReport } from ".
 import { checkEmbeddingSpace } from "./lib/space.js";
 import { parseQueriesFile, runCalibration } from "./calibrate/run.js";
 import { renderReport } from "./calibrate/math.js";
+import { quotaRemedy } from "./calibrate/quota.js";
 import {
   DRIFT_LIMIT,
   DRIFT_SQL,
@@ -754,31 +755,57 @@ async function calibrateCommand(args: string[]): Promise<number> {
       ? null
       : parseQueriesFile(readFileSync(values["ooc-file"], "utf8"));
 
-  const report = await withPool(dsn, async (pool) =>
-    runCalibration(pool, {
-      tenantId: instance.tenantId,
-      corpusId: instance.corpusId,
-      // The floor is a property of the RECORD, not of one caller's tier, so
-      // calibration measures the widest viewer there is: `public` plus every
-      // audience the ingested policy registers. Named rather than left to the
-      // `*` sentinel, because the sentinel is a scope no door ever binds and a
-      // floor must be measured on a set the door can actually serve.
-      viewer: await widestViewer(pool, instance),
-      provider,
-      generation: parseGeneration(values.generation),
-      queries,
-      textGenerator,
-      oocProbes: ooc,
-      perNode:
-        values["per-node"] === undefined ? undefined : intFlag("--per-node", values["per-node"]),
-      minChars:
-        values["min-chars"] === undefined ? undefined : intFlag("--min-chars", values["min-chars"]),
-    }),
+  const report = await withQuotaRemedy(async () =>
+    withPool(dsn, async (pool) =>
+      runCalibration(pool, {
+        tenantId: instance.tenantId,
+        corpusId: instance.corpusId,
+        // The floor is a property of the RECORD, not of one caller's tier, so
+        // calibration measures the widest viewer there is: `public` plus every
+        // audience the ingested policy registers. Named rather than left to the
+        // `*` sentinel, because the sentinel is a scope no door ever binds and a
+        // floor must be measured on a set the door can actually serve.
+        viewer: await widestViewer(pool, instance),
+        provider,
+        generation: parseGeneration(values.generation),
+        queries,
+        textGenerator,
+        oocProbes: ooc,
+        perNode:
+          values["per-node"] === undefined ? undefined : intFlag("--per-node", values["per-node"]),
+        minChars:
+          values["min-chars"] === undefined
+            ? undefined
+            : intFlag("--min-chars", values["min-chars"]),
+      }),
+    ),
   );
   process.stdout.write(renderReport(report, GATE_PREDICATE_DIGEST) + "\n");
   const advice = overlapAdvice(report);
   if (advice !== null) process.stdout.write(advice);
   return 0;
+}
+
+/**
+ * Run a calibration, turning a quota refusal into the remedy for THAT quota.
+ *
+ * Both failures reach here as the vendor's own sentence, which states what is
+ * wrong and neither why nor how to fix it — and the two need opposite answers
+ * (change door vs wait a minute). Anything `quotaRemedy` does not recognise is
+ * re-thrown untouched: inventing advice for an error nobody has read is worse
+ * than passing the vendor's through.
+ */
+async function withQuotaRemedy<T>(op: () => Promise<T>): Promise<T> {
+  try {
+    return await op();
+  } catch (exc) {
+    const message = exc instanceof Error ? exc.message : String(exc);
+    const remedy = quotaRemedy(message);
+    if (remedy === null) throw exc;
+    throw Object.assign(new Error(`${message}\n  why: ${remedy}`), {
+      slug: "ksor-calibrate-quota",
+    });
+  }
 }
 
 /** How many days of traffic one --check reads. Bounded so a busy record cannot make it expensive. */

--- a/packages/content/src/lib/providers/gemini.test.ts
+++ b/packages/content/src/lib/providers/gemini.test.ts
@@ -221,7 +221,7 @@ describe("GeminiTextGenerator (build plane)", () => {
     expect(out).toBe("a synthesized query");
     const call = calls[0];
     expect(call, "call: " + JSON.stringify(call)).toBeDefined();
-    expect(call?.model).toBe("gemini-2.5-flash"); // the oracle's build-plane default
+    expect(call?.model).toBe("gemini-3.7-flash"); // the current stable Flash model
     expect(call?.contents).toBe("the prompt");
     expect(call?.config.temperature).toBe(0);
     expect(call?.config.maxOutputTokens).toBe(32);

--- a/packages/content/src/lib/providers/gemini.ts
+++ b/packages/content/src/lib/providers/gemini.ts
@@ -191,7 +191,16 @@ export class GeminiEmbeddingProvider implements EmbeddingProvider {
 
 export interface GeminiTextGeneratorOptions {
   apiKey: string;
-  /** Default "gemini-2.5-flash" (the oracle's build-plane model). */
+  /**
+   * Default `gemini-3.7-flash`, the current stable Flash model.
+   *
+   * Cheap to move, unlike the embedding model: this one only writes the probe
+   * questions the SYNTHESIZED calibration door measures against, so a change
+   * alters future measurements and invalidates nothing stored — no embedding
+   * is re-computed and no `vector_floor` is touched. The door is recorded
+   * beside every floor (`door: synthesized`), which is what keeps two
+   * measurements from being compared as if they were the same experiment.
+   */
   model?: string;
   clientFactory?: () => GeminiTextClient;
 }
@@ -207,7 +216,7 @@ export class GeminiTextGenerator implements TextGenerator {
   private client: GeminiTextClient | null = null;
 
   constructor(opts: GeminiTextGeneratorOptions) {
-    this.model = opts.model ?? "gemini-2.5-flash";
+    this.model = opts.model ?? "gemini-3.7-flash";
     this.clientFactory =
       opts.clientFactory ?? ((): GeminiTextClient => geminiRestTextClient(opts.apiKey));
   }

--- a/packages/ksor/docs/ingesting.md
+++ b/packages/ksor/docs/ingesting.md
@@ -39,7 +39,7 @@ created for you.
 | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
 | **The corpus**       | `knowledge/` at your repo root — CommonMark `.md`, one document per file, in the KSoR Profile of OKF: `type`, `title`, `description`, `status` and `ksor.audience` in frontmatter | `pnpm check` validates it and explains any violation; `ksor build` must have written a current `build.lock.json` before ingest will run |
 | **The database**     | Postgres with **pgvector** — `CREATE EXTENSION vector;`                                                                                                                           | any managed host; the DDL below needs a role that can create tables                                                                     |
-| **The provider key** | `GEMINI_API_KEY` — the default embedding provider is `gemini-embedding-001`                                                                                                       | [aistudio.google.com](https://aistudio.google.com/apikey); the free tier covers a first corpus                                          |
+| **The provider key** | `GEMINI_API_KEY` — the default embedding provider is `gemini-embedding-001`                                                                                                       | [aistudio.google.com](https://aistudio.google.com/apikey); free tier — embedding input is free of charge                                |
 | **The DSN**          | `KSOR_DB_URL`, named by `instance.md`'s `database.dsn_env`                                                                                                                        | already named by `instance.md`'s `database:` block                                                                                      |
 
 Both variables go in `.env` beside `instance.md` — `ksor` reads it automatically,
@@ -197,8 +197,25 @@ measure until the corpus is in there.
 pnpm exec ksor calibrate --instance instance.md
 ```
 
-It ends with a block to paste into **`instance.md`**'s frontmatter, exactly as
-printed — the floor, the measurement recorded beside it as a comment, and
+**On a free-tier key, use the zero-LLM door instead.** The command above is the
+SYNTHESIZED door: it writes one probe question per sampled passage with an LLM,
+and a free key allows only a few generations a minute — a bigger corpus makes
+that worse, not better. Write your own in-corpus questions, one per line, and
+pass them:
+
+```sh
+pnpm exec ksor calibrate --instance instance.md --queries-file questions.txt
+```
+
+Six to ten real questions is enough. They should be things this record answers,
+in the words someone would actually ask — the floor is set by the WEAKEST of
+them, so a vague question drags it down and a question the record does not
+answer invalidates the measurement. The door is recorded beside the number
+(`door: queries-file`), because floors from the two doors are measured against
+different distributions and must never be compared as interchangeable.
+
+Either way it ends with a block to paste into **`instance.md`**'s frontmatter,
+exactly as printed — the floor, the measurement recorded beside it as a comment, and
 `floor_digest`, the digest of the retrieval predicate the floor was measured
 through. Paste it, then restart `ksor serve`: the floor is read at boot.
 


### PR DESCRIPTION
Found by walking a real free-tier key end to end.

## The defect

Embedding is free of charge and a first corpus embeds fine — **23 chunks, 0 failed, 7.5s**. But the *default* calibration door writes one probe question per sampled passage with an LLM, and the free tier allows **five generations a minute**:

```
Quota exceeded for generativelanguage.googleapis.com/generate_content_free_tier_requests,
limit: 5, model: gemini-2.5-flash
```

So the documented way to turn on this product's headline feature fails on a free key, and surfaces the vendor's sentence — what is wrong, and neither why nor how to fix it. `docs/ingesting.md` said *"the free tier covers a first corpus"*, which is true of embedding and false of the door it points you at.

## Two quotas, opposite remedies

| quota | nature | remedy |
|---|---|---|
| `generate_content…limit: 5` | a wall no wait clears; **worse** on a bigger corpus | the zero-LLM door — `--queries-file` |
| `global_embed_content_requests_per_minute` | a per-minute window; usual cause is an ingest immediately before | wait ~60s |

Send a reader to the wrong one and they either sit out a limit that never lifts, or rewrite their calibration over a sixty-second pause. Both are named now, with why, behind `ksor-calibrate-quota`.

**A 429 this does not recognise is re-thrown untouched** — a confident wrong remedy is worse than the vendor's own message, and that's asserted.

## Docs

`ingesting.md` carries the zero-LLM door where the reader meets the command, and says how to choose the questions: the floor is set by the **weakest** of them, so a vague question drags it down and one the record cannot answer invalidates the measurement. The free-tier claim is narrowed to what is true — embedding input is free of charge.

## The model

`gemini-2.5-flash` → `gemini-3.7-flash`, the current stable Flash. Cheap to move, unlike the embedding model (decision 30): it only writes the questions a synthesized measurement is taken against, so nothing stored is re-computed and no `vector_floor` is invalidated — and the door is recorded beside every floor, which stops two measurements being compared as one experiment.

## Verified after the change

`--queries-file` on a 7-document record **separates**: max out-of-corpus `0.575` < min in-corpus `0.668`, floor **0.622**, margin `0.093`. The served door then answered an in-corpus question with provenance and **abstained** on an out-of-corpus one — the same question that returned three confident hits with the gate off.

Unit 1573 · integration 61 files / 608 · db 43 files / 306.

🤖 Generated with [Claude Code](https://claude.com/claude-code)