### PR TITLE
Add the hello world — hands on the keyboard from line 24

### DIFF
--- a/docs/tutorials/00-hello-world.md
+++ b/docs/tutorials/00-hello-world.md
@@ -1,0 +1,322 @@
+# Hello world — a governed record, in about fifteen minutes
+
+By the end of this you will have written one document, watched the record refuse
+to publish it until a human approved it, and then asked your own coding agent a
+question and had it answer **from that document**, naming which document and
+which publication the answer came from.
+
+Every command and every output below was run on 2026-09-01 and pasted as it
+appeared. Nothing here is a sketch.
+
+**Part 1 needs nothing but [Node 24+](https://nodejs.org/en/download).** Part 2
+needs two more things, both free, and says so before it asks.
+
+Each step gives you a prompt for your coding agent. If you would rather type the
+commands yourself, they are under the **Do it yourself** fold beneath each one —
+the same commands, no shortcuts.
+
+---
+
+## Part 1 · The human surface
+
+### 1. Create the project — this one is yours to run
+
+```sh
+npx @panaversity/ksor@latest init handbook
+cd handbook
+```
+
+**Run this yourself rather than asking your agent**, for a reason worth knowing:
+`init` reads which package manager invoked it and emits that manager's project.
+`npx` gives you an npm project, `pnpm dlx` a pnpm one, `bunx` a bun one. The run
+that scaffolds is the run that knows your toolchain — so the choice should be
+yours, not whatever your agent's shell reached for.
+
+It is also the moment your agent gets its instructions: `AGENTS.md`, five
+skills, and `.mcp.json` all arrive here. Before this command there is nothing
+for an agent to read.
+
+### 2. Start it
+
+> **Ask your agent:**
+> Install the dependencies and start the site, then tell me what to open.
+
+<details><summary>Do it yourself</summary>
+
+```sh
+pnpm install
+pnpm dev
+```
+
+</details>
+
+Open **http://localhost:3000**. You have a documentation site rendering five
+starter documents about KSoR itself. They are scratch paper — you will delete
+them in tutorial 2.
+
+### 3. Write your first document
+
+> **Ask your agent:**
+> Add a document to `knowledge/` about our refund policy: customers can return
+> an item within 30 days with a receipt, refunds land within 5 working days,
+> items must be unused, and faulty goods are exempt from the window. Then tell
+> me what to refresh.
+
+<details><summary>Do it yourself</summary>
+
+Create `knowledge/refund-policy.md`:
+
+```markdown
+---
+type: Policy
+title: Refund policy
+description: Customers may return an item within 30 days with a receipt.
+status: draft
+ksor:
+  owner: "human:you"
+  audience: [public]
+---
+
+A customer may return an item within **30 days** of delivery, with proof of
+purchase. Refunds are issued to the original payment method within 5 working
+days. Items must be unused and in their original packaging. Faulty goods are
+outside this window entirely.
+```
+
+</details>
+
+Refresh the browser. Your document is there — with a **draft** badge.
+
+### 4. The moment this whole product exists for
+
+> **Ask your agent:**
+> Build this for publishing.
+
+<details><summary>Do it yourself</summary>
+
+```sh
+pnpm exec ksor build
+```
+
+</details>
+
+```
+ksor build: 6 document(s), 5 admitted to a machine surface
+```
+
+**Six documents. Five admitted.** Yours is not one of them — it is absent from
+`llms.txt`, from the markdown twins, from everything an AI agent would read.
+Nobody has approved it.
+
+> **Ask your agent:**
+> Why isn't my refund policy in `llms.txt`? Then approve it and build again.
+
+<details><summary>Do it yourself</summary>
+
+Change `status: draft` to `status: stable`, and add the two acts that publishing
+requires — who produced the text, and who approved it:
+
+```yaml
+status: stable
+generated: { by: "human:you", at: 2026-09-01T09:00:00Z }
+ksor:
+  owner: "human:you"
+  audience: [public]
+  approval: { by: "human:you", at: 2026-09-01T10:00:00Z }
+```
+
+Then `pnpm exec ksor build` again.
+</details>
+
+```
+ksor build: 6 document(s), 6 admitted to a machine surface
+```
+
+That is the product. A draft reaches no machine surface, an approval is an act
+with a name and a time attached to it, and the count moved because a human
+decided something — not because a build ran.
+
+**Part 1 is done.** You have a governed record and a website, and you spent
+nothing.
+
+---
+
+## Part 2 · The agent surface
+
+This is the half that answers questions. It needs two things, both free:
+
+|                          |          |                                         |
+| ------------------------ | -------- | --------------------------------------- |
+| a Postgres with pgvector | **free** | your agent can create it                |
+| an embedding API key     | **free** | you paste it — no agent can do this one |
+
+### 5. Get the database
+
+`.mcp.json` at the project root declares the MCP servers your agent may reach.
+The first is Neon's.
+
+> **Ask your agent:**
+> Using the Neon MCP server, create a project called `handbook` and enable the
+> pgvector extension on it. Then create a branch called `dev`, and save that
+> branch's connection string to `.env` as `KSOR_DB_URL`. Never print my API key.
+> Show me the plan before you run anything.
+
+<details><summary>Do it yourself, or use any Postgres</summary>
+
+Neon is the path that has an MCP server, not a requirement — any Postgres with
+pgvector works:
+
+```sh
+docker run -e POSTGRES_PASSWORD=x -p 5432:5432 pgvector/pgvector:pg17
+```
+
+Then put its URL in `.env` as `KSOR_DB_URL`.
+</details>
+
+### 6. Paste the key — the one step no agent can do
+
+Get a key from
+[aistudio.google.com/apikey](https://aistudio.google.com/apikey). **Embedding
+input is free of charge**; this is a signup, not a bill. No vendor mints an API
+key over a protocol, so no agent can do it for you.
+
+Your `.env` now needs three lines:
+
+```sh
+KSOR_DB_URL=postgres://…
+GEMINI_API_KEY=…
+KSOR_AUTH=disabled-local
+```
+
+That last line is not optional. `ksor serve` refuses to boot unauthenticated —
+deliberately, so nobody leaves a record open by accident. Saying it out loud is
+how you get a local server.
+
+### 7. Publish to the door
+
+> **Ask your agent:**
+> Run `pnpm provision`, then `pnpm refresh`.
+
+<details><summary>Do it yourself</summary>
+
+```sh
+pnpm provision   # schema + ingest authorization — once
+pnpm refresh     # build, embed, publish a generation
+```
+
+</details>
+
+```
+run 1: building generation 1 (embed gemini:gemini-embedding-001/d1536/RETRIEVAL_DOCUMENT)
+embedded 23, failed 0
+ingest: generation 1 — 7 nodes, 23 chunks; embedded 23, carried 0, failed 0
+FLIPPED active generation -> 1
+```
+
+Seven seconds, and your record is published as **generation 1** — the number
+every answer will cite.
+
+### 8. Serve it
+
+> **Ask your agent:**
+> Start the server in the background and tell me the URL.
+
+<details><summary>Do it yourself</summary>
+
+```sh
+pnpm serve
+```
+
+If port 8080 is taken, the refusal tells you so and offers
+`KSOR_MCP_PORT=8081 pnpm serve`.
+</details>
+
+```
+ksor serve · handbook
+  db        direct endpoint · local
+  audience  public
+  auth      DISABLED — 127.0.0.1 only, and a public bind will refuse to boot
+  abstain   OFF — no floor calibrated; out-of-corpus questions will be answered, not refused
+  serving   http://127.0.0.1:8080/mcp
+```
+
+Read that `abstain` line — it is telling you the truth about what this record
+cannot do yet. We come back to it at the end.
+
+### 9. Point your agent at your own record
+
+> **Ask your agent:**
+> Add my record to `.mcp.json` as `handbook`, pointing at that URL.
+
+<details><summary>Do it yourself</summary>
+
+```json
+"handbook": { "type": "http", "url": "http://127.0.0.1:8080/mcp" }
+```
+
+</details>
+
+### 10. Restart your agent, and ask it
+
+**Start a new session.** MCP servers are read when a session begins, so your
+agent cannot see the one you just added until it restarts. This is the one piece
+of ceremony in the whole tutorial, and it is real.
+
+> **Ask your agent:**
+> How long does a customer have to return something?
+
+It answers from your record, and the answer carries where it came from:
+
+```json
+"provenance": {
+  "corpus_id":  "handbook",
+  "stable_id":  "knowledge/refund-policy",
+  "generation": 1,
+  "retrieved_at": "2026-09-01T12:02:45Z"
+},
+"governance": {
+  "status": "stable",
+  "trust_tier": "unverified",
+  "approval": { "by": "human:you", "checked": "policy" }
+}
+```
+
+That is the whole point. Not "an AI said 30 days" — **this document, in this
+publication, approved by this person, said 30 days**, and you can open it.
+
+---
+
+## What you do not have yet
+
+Two honest gaps, each with a tutorial behind it.
+
+**This record answers everything it can find.** The boot report said
+`abstain OFF`, and it meant it: ask it something your record knows nothing about
+and it will return its closest guess rather than declining. Teaching a record to
+say _"I don't know"_ is a **measurement**, not a setting: you give it real
+questions your record answers, it measures where those score against questions
+it does not, and it prints a floor. That measurement is its own tutorial, not
+yet written — until then, `packages/ksor/docs/ingesting.md` carries the whole
+procedure under "Turning the abstention gate on".
+
+**The record is still mostly about KSoR.** Five of your seven documents are
+starter scratch paper. Replacing them with your organisation's actual knowledge
+— and retiring the tool that approved them — is the next tutorial, not yet
+written. The scaffold ships an `intake-interview` skill that starts it: ask your
+agent to run it.
+
+---
+
+## Reference
+
+| command          | what it does                                         |
+| ---------------- | ---------------------------------------------------- |
+| `pnpm dev`       | the site, hot-reloading, drafts visible and marked   |
+| `pnpm check`     | the record checker — run before every commit         |
+| `pnpm build`     | check the record, regenerate indexes, write the lock |
+| `pnpm provision` | apply the schema, authorize ingest — once            |
+| `pnpm refresh`   | build, embed, publish a generation                   |
+| `pnpm serve`     | the MCP server, over what you published              |
+
+`docs/status.md` is authoritative on what the current release supports. If it
+and this tutorial ever disagree, it wins.

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -17,6 +17,21 @@ If a tutorial and `docs/status.md` ever disagree about what runs today, `docs/st
 
 ## Start here
 
+### [Hello world — a governed record, in about fifteen minutes](./00-hello-world.md)
+
+Hands on the keyboard from the first line. You write one document, watch the
+record refuse to publish it until a human approves it, then ask your own coding
+agent a question and get an answer that names which document and which
+publication it came from.
+
+Two parts, matching the two surfaces a record serves. **Part 1 needs nothing but
+Node** — no database, no key, no account. Part 2 adds the agent surface and
+needs two more things, both free. Every command and output in it was run and
+pasted as it appeared.
+
+Start here if you want to see what this is. Read the introduction below if you
+want to understand why it exists.
+
 ### [Tutorial 1 — KSoR: One Governed Knowledge Record for Humans and AI Agents](./01-introduction-to-ksor.md)
 
 The introduction. No technical background required.


### PR DESCRIPTION
Nothing in this repository got a reader from nothing to a cited answer. Tutorial 1 is **6,223 words** with its first command at **75%**, and a reader finishes it without ever authoring a governed document.

This is that document: `docs/tutorials/00-hello-world.md`, ~15 minutes, listed first.

## Every output in it was run

On 2026-09-01, pasted as it appeared. The admitted counts, the ingest line, the boot report, and the `provenance` / `governance` blocks a real search hit carries.

That matters because the root README's one section titled "Example" is written in the conditional — *"the agent **should** retrieve … **should** not invent a policy"* — for behaviour that **is built**. This does the opposite.

## The spine is the draft-to-approved moment

```
ksor build: 6 document(s), 5 admitted to a machine surface
```

Yours is absent from `llms.txt`, the twins, everything an agent reads. Then a human approves it:

```
ksor build: 6 document(s), 6 admitted to a machine surface
```

The whole product, in one page refresh, costing **nothing** — no database, no key, no account.

## Structure, and the reasons

**Two parts, matching the two surfaces** — the record's own vocabulary: `surfaces/for-people.md` and `surfaces/for-agents.md` are two of the five starter documents.

**Part 1 needs only Node**, and says so. A reader can stop there with a governed record and a site.

**`ksor init` is the reader's own command, not a prompt** — and the tutorial says why: `init` reads `npm_config_user_agent`, so the run that scaffolds decides the project's package manager. That should not be whatever the agent's shell reached for. It is also the moment the agent *gets* its instructions, so there is nothing for one to read before it.

**Every step has a prompt, with the commands under a `<details>` fold.** Prompt primary because "conversation is the interface" is a product decision; fold one click away because an evaluator without an agent must not hit a wall.

**Part 2 ends on the payoff:** you point `.mcp.json` at your own record, restart the session (MCP servers load at session start — real, not ceremony), and your agent answers from the document you wrote ten minutes earlier, naming it and its generation.

## Calibration is deliberately absent

A hello-world reader cannot read AURC, a separation margin and a zero-FA floor. And pasting a floor measured on someone else's corpus is what the product invariants forbid outright — *"never copy a calibrated constant between corpora."*

So the tutorial ends on the honest state: the boot report says `abstain OFF`, the closing section explains what that costs, and the measurement gets its own tutorial. No links to tutorials that don't exist — the two gaps name what to read today instead.

## Verified

Integration 61 files / 608 passed; guard, corpus, format clean. The sequence itself was walked end to end on a real free-tier key before a word was written — including the parts this tutorial deliberately leaves out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)