### PR TITLE
Bring docs/status.md current, and gate it so it cannot drift again

### DIFF
--- a/.changeset/status-version-gate.md
+++ b/.changeset/status-version-gate.md
@@ -1,0 +1,12 @@
+---
+"@panaversity/ksor": patch
+---
+
+Repo documentation and a test only — nothing an adopter installs changes.
+
+`docs/status.md` named 0.0.42 while the published package was 0.0.53. Authority
+rule 3 makes that file the only authority on what is built, and it is the first
+thing an evaluator's coding agent reads. It is current now, and a docs-truth
+assertion holds it equal to `packages/ksor/package.json` so a Version PR cannot
+bump one without the other. It also records that the full kernel walk was re-run
+against 0.0.53 — it had last run against 0.0.18, thirty-five releases earlier.

--- a/docs/status.md
+++ b/docs/status.md
@@ -2,11 +2,11 @@
 
 **This document is the only authority on what is implemented.** The README is
 the concept; the released package version and this page are the facts. Last
-updated: 2026-08-26.
+updated: 2026-09-01.
 
 ## Published package
 
-`@panaversity/ksor` **0.0.42** on npm (trusted publishing, provenance
+`@panaversity/ksor` **0.0.53** on npm (trusted publishing, provenance
 attached). It ships the working `ksor init` described below — including the
 visibility model and the deploy story — AND the bundled content kernel, so
 `ksor build`, `ksor migrate`, `ksor serve`, `ksor ingest`, `ksor schema`,
@@ -29,15 +29,37 @@ schema 2.5 and the governed door described below; **0.0.42** filled in
 `database.dsn_env` in the emitted `instance.md` so climbing to the served rung
 needs no edit, and recorded decision 29.
 
+0.0.43-0.0.48 were the readability and refusal pass — a document page that
+reads at a glance, a `pnpm preview` for the static build to land in, refusals
+that say the right thing to the right audience, and the intake interview asking
+its three questions in the owner's words. **0.0.49** carried six fixes found by
+walking a real record: the site builds with webpack (a bare `next build` dies
+on Vercel's default machine once a record prerenders a few hundred routes),
+`ksor schema --apply` no longer loses a ROLE when two run at once, `pnpm
+preview` survives a URL it cannot parse, and two audit rows gained the field
+that makes them auditable. **0.0.51** pinned Next `16.3.3`, clearing three
+high-severity advisories a fresh `npm install` reported, stopped Next writing
+its own `AGENTS.md` into the site, moved the scaffold to Fumadocs `16.15.4`,
+and stopped `ksor migrate --write-site` deleting dependencies an adopter added.
+**0.0.52** added `ksor calibrate --check` (is a declared floor still holding,
+read from the record's own logged searches — no provider key), disclosed a shed
+audit row in the served envelope, and taught the site to print natural names
+for actors. **0.0.53** documented `.ksor/people.yaml` for the owner.
+
 Everything under the next heading is RELEASED and in adopters' hands as of
 0.0.41. It was developed on the `okf-native-spec` branch, which merged in
 PR #161.
 
 Verified end to end against each published version. The full KERNEL walk was
-last run against **0.0.18** (2026-08-22: fresh `npm install` into a bare
-project, driven by the real `@modelcontextprotocol/client` SDK over live
-Postgres 17.7 + pgvector 0.8.2 with real Gemini embeddings) and has not been
-re-run since. 0.0.19–0.0.22 changed the site surface; 0.0.24–0.0.29 DID change
+**re-run against 0.0.53 on 2026-09-01** — `ksor init` from the published
+package, `pnpm install`, a hand-written document held out of every machine
+surface as a draft (`6 document(s), 5 admitted`) and admitted once approved
+(`6 admitted`), then live Postgres 17.7 + pgvector 0.8.2, real Gemini
+embeddings on a free-tier key (`embedded 23, failed 0`), a flipped generation,
+a calibrated floor measured through the zero-LLM door (`separable`, 0.622), and
+the served door answering an in-corpus question with provenance and ABSTAINING
+on an out-of-corpus one. Before that it had last run against **0.0.18**
+(2026-08-22, driven by the real `@modelcontextprotocol/client` SDK). 0.0.19–0.0.22 changed the site surface; 0.0.24–0.0.29 DID change
 the door's registration and auth surfaces, and those were proven differently —
 live, from claude.ai as a real MCP client against a real deployment (the next
 section). This page says which walk covered what rather than letting a version

--- a/packages/ksor/src/docs-truth.integration.test.ts
+++ b/packages/ksor/src/docs-truth.integration.test.ts
@@ -666,3 +666,37 @@ describe("the emitted docs are true about the artefact they ship with", () => {
     ).toBe(true);
   });
 });
+
+/**
+ * `docs/status.md` names the version an adopter can actually install.
+ *
+ * Authority rule 3 makes that file "the only authority on what is actually
+ * built", and it is the first thing a serious evaluator's coding agent reads.
+ * It went ELEVEN releases stale before anyone noticed — which is the failure
+ * mode of a fact kept in prose and nowhere else, in a repository shipping
+ * several releases a day.
+ *
+ * Asserted against `packages/ksor/package.json`, the version the tarball
+ * carries. A Version PR that bumps one and not the other now fails here rather
+ * than shipping a document that misdescribes the artefact beside it.
+ */
+describe("docs/status.md names the version that is actually published", () => {
+  it("matches packages/ksor/package.json", () => {
+    const version = (JSON.parse(read("packages/ksor/package.json")) as { version: string }).version;
+    // Anchored on the PUBLISHED-PACKAGE sentence, not on the version appearing
+    // anywhere in the file: the release summary below it names every version
+    // ever shipped, so a bare `toContain` passes while the line an evaluator
+    // actually reads is eleven releases stale. Found by mutation — the first
+    // version of this assertion did not fail on the state it was written for.
+    const published = /`@panaversity\/ksor`\s+\*\*([0-9]+\.[0-9]+\.[0-9]+)\*\*\s+on npm/.exec(
+      read("docs/status.md"),
+    );
+    expect(published, "docs/status.md must name the published package version").not.toBeNull();
+    expect(
+      published?.[1],
+      `docs/status.md says the published package is ${published?.[1]}; package.json says ` +
+        `${version}. It is the authority on what is built, and the first thing an ` +
+        "evaluator's agent reads.",
+    ).toBe(version);
+  });
+});


### PR DESCRIPTION
`docs/status.md` said the published package was **0.0.42**. It was **0.0.53** — eleven releases, in a repo shipping several a day.

Authority rule 3 makes that file *"the only authority on what is actually built"*, and it is the first thing a serious evaluator's coding agent reads. A fact kept in prose and nowhere else drifts; this one did.

## What changed

**The version, and 0.0.43-0.0.53 summarised from the changelog** rather than from memory — the readability and refusal pass, the six defects 0.0.49 found by walking a real record, the Next `16.3.3` security pin and the `agentRules` fix, `ksor calibrate --check`, the shed-audit-row disclosure, actor display names.

**The kernel walk is re-dated, and that is the bigger correction.** The file said the full walk had last run against **0.0.18** and *"has not been re-run since"* — thirty-five releases and one record redesign ago. It ran today against **0.0.53**:

- `ksor init` from the published package, `pnpm install`
- a hand-written document held out of every machine surface as a draft — `6 document(s), 5 admitted` — and admitted once approved — `6 admitted`
- live Postgres 17.7 + pgvector 0.8.2, real Gemini embeddings on a free-tier key — `embedded 23, failed 0`, generation flipped
- a floor measured through the zero-LLM door — `separable`, `0.622`
- the served door answering an in-corpus question with provenance, and **abstaining** out of corpus

## The gate

A `docs-truth` assertion against `packages/ksor/package.json`, so a Version PR that bumps one and not the other fails here.

**Anchored on the published-package *sentence*, not on the version appearing anywhere in the file** — and that distinction was found by mutation, not by design. The first version of this assertion **passed on exactly the stale state it was written to catch**: the release summary below names every version ever shipped, so `toContain("**0.0.53**")` was satisfied while the line an evaluator reads still said 0.0.42.

```
AssertionError: docs/status.md says the published package is 0.0.42;
package.json says 0.0.53.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)