### PR TITLE
Show the product on the first screen

### DIFF
--- a/.changeset/readme-shows-the-product.md
+++ b/.changeset/readme-shows-the-product.md
@@ -1,0 +1,14 @@
+---
+"@panaversity/ksor": patch
+---
+
+The npm page shows what the product does, on the first screen.
+
+It asserted the headline behaviour — a cited answer, an honest refusal — and
+demonstrated it nowhere. A reader had no way to tell a real mechanism from a
+prompt instruction, which is exactly the skepticism this product exists to
+answer. It now shows three things, all of them real output: the admitted count
+moving when a human approves a draft, the `provenance` and `governance` a search
+hit carries, and an abstention envelope. It also links the hello world.
+
+Nothing was added to the tarball; this is the README npm renders.

--- a/README.md
+++ b/README.md
@@ -101,11 +101,29 @@ bunx @panaversity/ksor@latest init my-knowledge-sor
 cd my-knowledge-sor && bun install && bun run dev
 ```
 
-Open `http://localhost:3000`. Your knowledge site is running, and it reloads
-as you edit the Markdown files in `knowledge/`. What you have is a complete,
-ordinary project — your knowledge, a working website, a CI workflow, and
-instructions for coding agents — and it is entirely yours: nothing is
-downloaded at build time, and nothing phones home.
+Open `http://localhost:3000`. The site is running, and it reloads as you edit
+the Markdown files in `knowledge/`. What you have is a complete, ordinary
+project — a working website, a CI workflow, and instructions for coding agents
+— and it is entirely yours: nothing is downloaded at build time, and nothing
+phones home. The five documents in it are KSoR's own starters, there to be
+deleted as your knowledge arrives.
+
+Ask it to publish and you meet the point of all this:
+
+```console
+$ pnpm exec ksor build
+ksor build: 6 document(s), 5 admitted to a machine surface
+```
+
+Six documents, five admitted. The one you just wrote is a `draft`, so it
+reaches no surface an AI agent reads — not `llms.txt`, not the markdown twins,
+nothing — until a human approves it. Approve it and the count moves.
+
+**[Hello world](docs/tutorials/00-hello-world.md) walks that end to end in
+about fifteen minutes**, from an empty directory to your own coding agent
+answering from your own document and naming which document and which
+publication it came from. Every command and output in it was run and pasted as
+it appeared.
 
 **Next, open the project in the coding agent you already use** (Claude Code,
 Cursor, Copilot — any of them) **and tell it what this knowledge base is

--- a/packages/ksor/README.md
+++ b/packages/ksor/README.md
@@ -16,6 +16,36 @@ pnpm install
 pnpm dev        # the site, live at http://localhost:3000
 ```
 
+Then write a document and publish it:
+
+```console
+$ pnpm exec ksor build
+ksor build: 6 document(s), 5 admitted to a machine surface
+```
+
+**Six documents, five admitted.** The one you just wrote is a `draft`, so it
+reaches nothing an AI agent reads — not `llms.txt`, not the markdown twins —
+until a human approves it. Approve it and the count moves. That is the whole
+product, and it costs nothing: no database, no API key, no account.
+
+Climb one rung and an agent asks the record a question. The answer carries
+where it came from:
+
+```json
+"provenance": { "stable_id": "knowledge/refund-policy", "generation": 1 },
+"governance": { "status": "stable", "approval": { "by": "human:you" } }
+```
+
+…and a question the record does not cover is declined rather than guessed at:
+
+```json
+{ "ok": false, "abstained": true, "gate": { "floor": 0.622 } }
+```
+
+**[Hello world](https://github.com/panaversity/ksor/blob/main/docs/tutorials/00-hello-world.md)**
+walks all of that in about fifteen minutes. Every command and output in it was
+run and pasted as it appeared — including the ones above.
+
 One command emits a complete governed project: the record (`knowledge/`,
 plain CommonMark), a working documentation site with hot reload, offline
 search and `llms.txt`, adopter CI, a dependency-free format checker


### PR DESCRIPTION
Across 2,816 lines of adopter-facing README, the headline behaviour — a cited answer and an honest refusal — is asserted dozens of times and **rendered zero times**. The one section titled "Example" is written in the conditional: *"the agent **should** retrieve … **should** not invent a policy"* — the modal voice this repo's own working rule 3 forbids for unbuilt behaviour, applied to behaviour that **is** built.

A reader had no way to tell a real mechanism from a prompt instruction. That is precisely the skepticism this product exists to answer.

## What lands

Both READMEs now show it, with output that was **run**, not written:

```console
$ pnpm exec ksor build
ksor build: 6 document(s), 5 admitted to a machine surface
```

…and on the npm page — the highest-traffic surface this project has — what an answer actually carries:

```json
"provenance": { "stable_id": "knowledge/refund-policy", "generation": 1 },
"governance": { "status": "stable", "approval": { "by": "human:you" } }
```

…and what a question outside the record gets:

```json
{ "ok": false, "abstained": true, "gate": { "floor": 0.622 } }
```

Both link the hello world. **The proof was always free** — no database, no key, no account, ten seconds.

## An overclaim, corrected

The root README said *"Your knowledge site is running … what you have is your knowledge."* A fresh scaffold contains five documents **about KSoR**. The scaffold's own README is honest about it — *"treat the starters as scratch paper"* — and the front door was not. Now it says what they are and that they're there to be deleted.

## A correction to something I claimed earlier

I reported that the root README carried two competing walkthroughs — "Start here" at 77 and "Quick Start" at 829 — and that one should be cut. **Reading them disproves it.** `Requirements` says outright:

> "Creating a project, running the site locally, and building it are covered in [Start here](#start-here) at the top of this page — this section continues where it leaves off."

That's a deliberate getting-started/reference split, not duplication. My claim came from two headings that look alike in a grep. **Nothing was cut**, and the scope shrank to the two real defects above.

## Verification

Integration 61 files / 608 passed, guard and corpus clean. (Three files timed out on a first pass under load from three concurrent CI re-runs; they pass alone — 128 tests — and a README edit cannot cause a 30s spawn timeout in `ksor migrate`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)