### PR TITLE
Stop ruling out the one step Vercel says is required (#197)

### DIFF
--- a/.changeset/vercel-preset.md
+++ b/.changeset/vercel-preset.md
@@ -1,0 +1,21 @@
+---
+"@panaversity/ksor": patch
+---
+
+The deploy runbook stops ruling out the one step Vercel calls required.
+
+`docs/deploying.md` said the silent-404 failure "does not depend on the
+Application Preset". Vercel's own guide says the opposite: a project builds as
+services only when the preset is `Services` AND `vercel.json` carries a
+`services` key, and "if either is missing, Vercel falls back to its default
+framework detection and ignores your services configuration" — which is that
+failure exactly, and no file in the repository can set a project setting.
+
+One measurement of ours disagrees with that guide and is recorded rather than
+reconciled: two projects read back from the API, one `Services` and one `Other`,
+both built and served. Both facts are real; guessing between them is what
+produced the sentence that steered adopters away from the fix.
+
+The scaffold's runbook now sets the preset at step 2, and ends with the three
+curls that tell a live deployment from a Ready-and-404 one — `/mcp` answering
+405 is the door refusing a GET, which is how you know it is routed at all.

--- a/packages/ksor/docs/deploying.md
+++ b/packages/ksor/docs/deploying.md
@@ -141,13 +141,37 @@ What the image deliberately does NOT contain (see `.dockerignore`):
 > which is the door answering "Method Not Allowed" to a GET rather than a static
 > 404, and is how you tell the door is routed at all.
 >
-> **It does not depend on the Application Preset**, which is the first thing
-> everyone suspects and the reason to say so:
+> **Set the Framework Preset to `Services` on the import screen.** Vercel's own
+> guide states it as one of two necessary conditions:
+>
+> > "A project builds as services only when two conditions are both true: the
+> > project's framework is set to Services, and `vercel.json` contains a
+> > `services` key. If either is missing, Vercel falls back to its default
+> > framework detection and ignores your services configuration."
+> > — [vercel.com/kb/guide/vercel-services](https://vercel.com/kb/guide/vercel-services)
+>
+> That is the silent-404 shape exactly: preset `Other` → fallback detection →
+> nothing detected → an empty output that deploys, reports Ready and takes the
+> alias. And no file in your repository can set it for you: `framework` is not
+> a valid top-level key while `services` is present, so this is a project
+> setting or nothing.
+>
+> **One measurement here disagrees with that guide, and is recorded rather than
+> reconciled.** On 2026-08-27 two projects were read back from the Vercel API,
+> one reading preset `Services` and one reading `Other`, and BOTH built the
+> `services` block and served:
 >
 > | project's preset | `services` block built | serves                                 |
 > | ---------------- | ---------------------- | -------------------------------------- |
 > | `Services`       | `site` + `door`        | `/` 200 · `/llms.txt` 200 · `/mcp` 405 |
 > | `Other`          | `site` + `door`        | `/` 200 · `/llms.txt` 200 · `/mcp` 405 |
+>
+> Both facts are real and they cannot both be the whole rule. Possible readings
+> — the API's `framework` field being derived rather than the project setting,
+> or Beta behaviour changing between the guide's 2026-08-12 revision and that
+> measurement — are unverified, and guessing between them is what produced the
+> earlier version of this page, which told you the preset was RULED OUT and so
+> steered you away from the one step the vendor calls required. Set the preset.
 >
 > **One failure has been seen that none of this explains.** On a 205-document
 > record (2026-08-26, issue #197) the install ran, `ksor build` ran, every route

--- a/packages/ksor/templates/scaffold/README.md
+++ b/packages/ksor/templates/scaffold/README.md
@@ -297,7 +297,15 @@ Delete `.mcp.json`, or keep it — it holds no secret.
 Both surfaces on one domain, in about ten minutes:
 
 1. **Push the repository to GitHub.**
-2. **Import it in Vercel**, then **set Root Directory to `./`.** Vercel
+2. **Import it in Vercel**, then set **Framework Preset** to **`Services`** and
+   **Root Directory** to `./`. The preset is not cosmetic: Vercel's own guide
+   says a project builds as services only when the preset is `Services` AND
+   `vercel.json` carries a `services` key, and that "if either is missing,
+   Vercel falls back to its default framework detection and ignores your
+   services configuration" — which is the silent 404 below. No file in this
+   repository can set it for you.
+
+   As for Root Directory: Vercel
    auto-fills it with `system/site`, because that is where it finds a framework
    — and the build then reads `system/site/vercel.json`, which does not exist,
    and fails with `Project framework is set to "services", but no services are
@@ -306,6 +314,19 @@ declared`. The services ARE declared, in `vercel.json` at the repo root,
    container from the root `Dockerfile`.
 3. **Set three environment variables** in Vercel: `KSOR_DB_URL`,
    `GEMINI_API_KEY`, and `KSOR_AUTH=disabled-public`.
+4. **Check it actually serves**, before you tell anyone the URL. A Ready
+   deployment that answers 404 everywhere looks identical to a good one from
+   the dashboard:
+
+   ```sh
+   B=https://your-record.vercel.app
+   curl -o /dev/null -w '%{http_code}\n' "$B/"           # expect 200
+   curl -o /dev/null -w '%{http_code}\n' "$B/llms.txt"   # expect 200
+   curl -sI "$B/mcp" | head -1                           # expect 405
+   ```
+
+   `/mcp` answering 405 is the door refusing a GET — that is how you know it is
+   routed at all, and a 404 there means the `services` block was ignored.
 
 Three things catch people here. Two are the system being deliberate; the first
 is not, and it is the one that fails without saying so:
@@ -313,10 +334,13 @@ is not, and it is the one that fails without saying so:
 - **A deployment can report Ready and serve nothing.** The build succeeds,
   Vercel collects nothing, and the deployment takes your domain and answers
   `404: NOT_FOUND` everywhere — with one build-log line as the only signal:
-  `WARNING! Build output contains no "functions" or "static" directory`. Seen
-  once, on a large record, and **the cause is not established**; it is *not* the
-  Application Preset, which was measured. The emitted `vercel.json` itself is
-  verified working on the Git path. If you hit this, the fallback is the
+  `WARNING! Build output contains no "functions" or "static" directory`. That
+  warning is the FALLBACK collector finding nothing, which is what step 2's
+  preset exists to prevent — check it first. One measurement of ours disagrees
+  with the vendor's rule and is recorded in
+  `node_modules/@panaversity/ksor/docs/deploying.md`; the honest state is that
+  the preset is necessary by the vendor's documentation and has once appeared
+  not to be. If you hit this, the fallback is the
   classic-keys form in `node_modules/@panaversity/ksor/docs/deploying.md` — read
   it there rather than guessing, because it **moves the door off your domain**
   and `KSOR_MCP_RESOURCE_URL` and your SSO API Identifier both have to move with


### PR DESCRIPTION
Closes the documentation half of #197. No code — the fix an adopter needs is a project setting, and our docs were steering them away from it.

## The sentence that was wrong

`docs/deploying.md`, and the scaffold's own runbook:

> **It does not depend on the Application Preset**, which is the first thing everyone suspects and the reason to say so

Vercel's guide says the opposite, as one of **two necessary conditions**:

> "A project builds as services only when two conditions are both true: the project's framework is set to Services, and `vercel.json` contains a `services` key. **If either is missing, Vercel falls back to its default framework detection and ignores your services configuration.**"
> — [vercel.com/kb/guide/vercel-services](https://vercel.com/kb/guide/vercel-services)

That is the reported failure exactly: preset `Other` → fallback detection → nothing detected → an empty output that deploys, **reports Ready, takes the alias, and 404s everywhere.**

It also explains the single signal anyone saw. `WARNING! Build output contains no "functions" or "static" directory` is the **fallback** collector finding nothing — a real services build emits under `.vercel/output/services/` and warns about neither.

**And no emitted file can fix it.** `framework` is not a valid top-level key while `services` is present, so the preset is a project setting or nothing.

Reading #197 back: the failing project was patched with `outputDirectory`, `buildCommand` and `installCommand` — and **never with the preset.** The condition the vendor calls mandatory was never tested.

## Our measurement disagrees, and is recorded rather than reconciled

On 2026-08-27, two projects read back from the Vercel API — one `Services`, one `Other` — **both** built the services block and served. Both facts are real and cannot both be the whole rule. The readings that would reconcile them (a derived API field rather than the project setting; Beta behaviour changing after the guide's 2026-08-12 revision) are **unverified**.

Guessing between them is what produced the sentence being removed. The page now carries both, says which one the vendor documents, and tells you to set the preset.

## And a way to find out in sixty seconds

The scaffold's runbook sets the preset at step 2 and gains a step 4:

```sh
curl -o /dev/null -w '%{http_code}\n' "$B/"           # expect 200
curl -o /dev/null -w '%{http_code}\n' "$B/llms.txt"   # expect 200
curl -sI "$B/mcp" | head -1                           # expect 405
```

`/mcp` answering **405** is the door refusing a GET — that is how you know it is routed at all. A 404 there means the `services` block was ignored. In the runbook, rather than on somebody's domain.

## Still open

The two single-deploy experiments that would settle the mechanism — `PATCH` a Git-imported project with `framework: "services"`, and try a `vercel.json` carrying both the `services` block and top-level build keys. Those need a real Vercel project, not a test.

docs-truth, init and scaffold-scripts suites: 93 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)