### PR TITLE
Carry docs/status.md with the version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,23 @@ jobs:
         with:
           # v2 renamed these inputs from publish/version to *-script.
           publish-script: pnpm changeset publish
-          version-script: pnpm changeset version
+          # Scope: all 6 workspace projects
+✓ Lockfile passes supply-chain policies (verified 6d ago)
+Lockfile is up to date, resolution step is skipped
+Already up to date
+
+. prepare$ git config core.hooksPath .githooks || echo hooks-skipped
+. prepare: Done
+Done in 593ms using pnpm v11.22.0
+🦋 changeset v3.0.0
+
+No unreleased changesets found.
+🦋 Exited with code 1
+
+[ELIFECYCLE] Command failed with exit code 1. is  PLUS the sync that points
+          # docs/status.md at what is about to publish. They are one act: the
+          # docs-truth assertion holds the two equal, and a bump that left the
+          # document behind blocked the release (found live, 0.0.54).
+          version-script: pnpm run version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,20 +49,7 @@ jobs:
         with:
           # v2 renamed these inputs from publish/version to *-script.
           publish-script: pnpm changeset publish
-          # Scope: all 6 workspace projects
-✓ Lockfile passes supply-chain policies (verified 6d ago)
-Lockfile is up to date, resolution step is skipped
-Already up to date
-
-. prepare$ git config core.hooksPath .githooks || echo hooks-skipped
-. prepare: Done
-Done in 593ms using pnpm v11.22.0
-🦋 changeset v3.0.0
-
-No unreleased changesets found.
-🦋 Exited with code 1
-
-[ELIFECYCLE] Command failed with exit code 1. is  PLUS the sync that points
+          # `pnpm run version` is `changeset version` PLUS the sync that points
           # docs/status.md at what is about to publish. They are one act: the
           # docs-truth assertion holds the two equal, and a bump that left the
           # document behind blocked the release (found live, 0.0.54).

--- a/docs/status.md
+++ b/docs/status.md
@@ -6,7 +6,7 @@ updated: 2026-09-01.
 
 ## Published package
 
-`@panaversity/ksor` **0.0.53** on npm (trusted publishing, provenance
+`@panaversity/ksor` **0.0.54** on npm (trusted publishing, provenance
 attached). It ships the working `ksor init` described below — including the
 visibility model and the deploy story — AND the bundled content kernel, so
 `ksor build`, `ksor migrate`, `ksor serve`, `ksor ingest`, `ksor schema`,

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test:db": "vitest run --config vitest.db.config.ts",
     "publint": "pnpm -r publint",
     "changeset": "changeset",
+    "version": "pnpm changeset version && node scripts/sync-status-version.mjs",
     "prepare": "git config core.hooksPath .githooks || echo hooks-skipped"
   },
   "devDependencies": {

--- a/scripts/sync-status-version.mjs
+++ b/scripts/sync-status-version.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+/**
+ * Point `docs/status.md` at the version the Version PR is about to publish.
+ *
+ * Authority rule 3 makes that file "the only authority on what is actually
+ * built", and it went ELEVEN releases stale before anyone noticed. A
+ * docs-truth assertion now holds it equal to `packages/ksor/package.json` —
+ * and that assertion, on its own, would block every release: `changeset
+ * version` bumps the manifest and touches no document, so the release gate saw
+ * a mismatch it had no way to close (found live, on the release it blocked).
+ *
+ * The fix is not to weaken the assertion. A document that has to be updated by
+ * remembering is a document that goes stale; this runs INSIDE `changeset
+ * version`, so the bump and the sentence move in one commit, in the Version PR
+ * a human still reviews.
+ *
+ * Rewrites exactly the published-package sentence and nothing else.
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const version = JSON.parse(
+  readFileSync(path.join(repoRoot, "packages/ksor/package.json"), "utf8"),
+).version;
+
+const statusPath = path.join(repoRoot, "docs/status.md");
+const before = readFileSync(statusPath, "utf8");
+const SENTENCE = /(`@panaversity\/ksor`\s+\*\*)([0-9]+\.[0-9]+\.[0-9]+)(\*\*\s+on npm)/;
+
+const found = SENTENCE.exec(before);
+if (found === null) {
+  // Loud, never silent: the assertion this feeds reads the same sentence, so a
+  // rename here would leave the release blocked with no explanation.
+  console.error(
+    "sync-status-version: docs/status.md has no `@panaversity/ksor` **x.y.z** on npm sentence.\n" +
+      "  why: docs/status.md is the authority on what is built, and the release gate reads that\n" +
+      "       exact sentence to check it against packages/ksor/package.json\n" +
+      "  fix: restore the sentence, or update this script and the assertion together",
+  );
+  process.exit(1);
+}
+
+if (found[2] === version) {
+  console.log(`sync-status-version: docs/status.md already names ${version}`);
+} else {
+  writeFileSync(statusPath, before.replace(SENTENCE, `$1${version}$3`));
+  console.log(`sync-status-version: docs/status.md ${found[2]} -> ${version}`);
+}


### PR DESCRIPTION
The **0.0.54 release failed its own gate**, and the gate was right:

```
docs/status.md says the published package is 0.0.53; package.json says 0.0.54
```

`changeset version` bumps the manifest and touches no document. So the assertion added hours earlier — holding `status.md` equal to `package.json` — had no way to be satisfied, and would have blocked **every** release. Found on the release it blocked, which is the cheapest place to find it.

## The fix is not to weaken the assertion

Authority rule 3 makes that file *"the only authority on what is actually built"*, and it went **eleven releases stale** precisely because keeping it current depended on someone remembering. Weakening the check restores that.

So the bump and the sentence become **one act**: `pnpm run version` is `changeset version` plus a sync that rewrites the published-package sentence, and `release.yml` calls that instead of `changeset version` directly. Both land in the Version PR a human still reviews.

## The sync

- rewrites **exactly** the `` `@panaversity/ksor` **x.y.z** on npm `` sentence, nothing else
- **idempotent** — `already names 0.0.54` on a second run
- **refuses loudly** if the sentence is missing, exit 1, rather than silently doing nothing:

```
sync-status-version: docs/status.md has no `@panaversity/ksor` **x.y.z** on npm sentence.
  why: docs/status.md is the authority on what is built, and the release gate reads that
       exact sentence to check it against packages/ksor/package.json
  fix: restore the sentence, or update this script and the assertion together
```

That last one matters: the assertion reads the same sentence, so a rename would otherwise leave the release blocked with no explanation of why.

All three behaviours verified. `docs/status.md` is set to 0.0.54 in this PR so the pending release can proceed.

Repo tooling outside `packages/ksor` — no changeset (`.github/`, `package.json`, `scripts/`, `docs/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)