### PR TITLE
Fix the hello-world tutorial, which could not be completed as written

### DIFF
--- a/.changeset/hello-world-runs.md
+++ b/.changeset/hello-world-runs.md
@@ -1,0 +1,31 @@
+---
+"@panaversity/ksor": patch
+---
+
+Fix the hello-world tutorial, which could not be completed as written.
+
+Three defects, all found by walking the published 0.0.54 rather than by reading:
+
+- Step 3's document declared `type: Policy`. `Policy` is a reserved type, so the
+  record demands `sources` — `ksor build`, `npm run check` and the dev server all
+  refused it, and steps 4 through 10 were unreachable. It is now `type: Document`,
+  the type the profile promises never to reserve, with a note on why and on what
+  an agent should do when it reaches for a reserved one.
+- Step 1 scaffolds with `npx`, which emits an **npm** project, and every command
+  after it said `pnpm`. On that project `pnpm install && pnpm dev` fails with
+  `sh: next: command not found`. All sixteen commands are npm's now, and the step
+  that explains manager detection says which one the rest of the tutorial speaks.
+- The captured outputs had been trimmed after capture, in a document whose second
+  paragraph promises they were "pasted as it appeared": `ksor serve`'s boot report
+  was missing the `trust` line it has always printed, the build outputs were
+  missing their timestamp, `source:` and `wrote` lines, and the port-conflict
+  refusal was quoted offering `pnpm serve` where it says `ksor serve`.
+
+The walk also surfaced that `ksor init` leaves a repo with no commits, so every
+reader's first build prints `source: unspecified`. Rather than hide it, the
+tutorial now shows it and folds `git commit` into the approval step — which is
+where provenance belongs anyway, and which lets the second build print a real
+commit sha.
+
+Only the tutorial and the test that pins its prompts changed; nothing an adopter
+installs behaves differently.

--- a/.changeset/hello-world-runs.md
+++ b/.changeset/hello-world-runs.md
@@ -27,5 +27,10 @@ tutorial now shows it and folds `git commit` into the approval step — which is
 where provenance belongs anyway, and which lets the second build print a real
 commit sha.
 
+The tutorial also said `.mcp.json`'s "first is Neon's" and named the second
+server nowhere, and said nothing about the Neon server acting on the whole Neon
+account. Both are fixed here for the tutorial; the emitted scaffold's copies of
+the same two defects are fixed separately.
+
 Only the tutorial and the test that pins its prompts changed; nothing an adopter
 installs behaves differently.

--- a/docs/tutorials/00-hello-world.md
+++ b/docs/tutorials/00-hello-world.md
@@ -32,6 +32,9 @@ cd handbook
 that scaffolds is the run that knows your toolchain — so the choice should be
 yours, not whatever your agent's shell reached for.
 
+The commands below are npm's, to match the `npx` above. On a `pnpm dlx` or
+`bunx` project, substitute your own manager throughout.
+
 It is also the moment your agent gets its instructions: `AGENTS.md`, five
 skills, and `.mcp.json` all arrive here. Before this command there is nothing
 for an agent to read.
@@ -44,8 +47,8 @@ for an agent to read.
 <details><summary>Do it yourself</summary>
 
 ```sh
-pnpm install
-pnpm dev
+npm install
+npm run dev
 ```
 
 </details>
@@ -68,7 +71,7 @@ Create `knowledge/refund-policy.md`:
 
 ```markdown
 ---
-type: Policy
+type: Document
 title: Refund policy
 description: Customers may return an item within 30 days with a receipt.
 status: draft
@@ -83,6 +86,13 @@ days. Items must be unused and in their original packaging. Faulty goods are
 outside this window entirely.
 ```
 
+`type: Document` is the one type the profile promises never to reserve. Reserved
+types — `Policy`, `Procedure`, `Control` and the rest — carry governance meaning,
+so the record demands `sources` and an owner before it will accept one. If your
+agent reaches for `type: Policy` here, it will meet that refusal and can either
+add `sources` or fall back to `Document`; tutorial 2 is where reserved types
+earn their keep.
+
 </details>
 
 Refresh the browser. Your document is there — with a **draft** badge.
@@ -95,14 +105,24 @@ Refresh the browser. Your document is there — with a **draft** badge.
 <details><summary>Do it yourself</summary>
 
 ```sh
-pnpm exec ksor build
+npx ksor build
 ```
 
 </details>
 
 ```
-ksor build: 6 document(s), 5 admitted to a machine surface
+ksor build: 6 document(s), 5 admitted to a machine surface at 2026-09-01T19:34:49.422Z
+source: unspecified — knowledge/ is in a git repository with no commits yet, so this build cannot be traced back to a reviewed commit.
+  fix: commit the record (git add knowledge && git commit) and re-run
+  wrote knowledge/index.md
+  wrote build.lock.json — build_id sha256:70dae2f92647c0cdc9d98fcc681185d985a8ffa5f2ed40be47f93c9880480f92
 ```
+
+Your timestamp will differ; the `build_id` will not. Same record, same
+toolchain, same `build_id` — that is a testable claim this project holds itself
+to, and you just reproduced it. The `source: unspecified` line is the record
+telling you it cannot trace this build back to a reviewed commit, because you
+have not made one yet. We fix that in a moment.
 
 **Six documents. Five admitted.** Yours is not one of them — it is absent from
 `llms.txt`, from the markdown twins, from everything an AI agent would read.
@@ -125,12 +145,24 @@ ksor:
   approval: { by: "human:you", at: 2026-09-01T10:00:00Z }
 ```
 
-Then `pnpm exec ksor build` again.
+Then commit the record and build again — the commit is what turns that
+`source: unspecified` into something an auditor can follow:
+
+```sh
+git add -A && git commit -m "Add and approve the refund policy"
+npx ksor build
+```
+
 </details>
 
 ```
-ksor build: 6 document(s), 6 admitted to a machine surface
+ksor build: 6 document(s), 6 admitted to a machine surface at 2026-09-01T19:37:32.457Z
+source: b3a9e18b51c21fb266f8cc5b959fcf3d58c3ce3b
+  wrote build.lock.json — build_id sha256:6af6a2ee49346bc1546af9071e39646e677375f7feddf8802dc814e7f5ad01af
 ```
+
+`source` is now your commit — the build traces to a reviewed change. Your sha
+will be your own; the `build_id` is still everyone's.
 
 That is the product. A draft reaches no machine surface, an approval is an act
 with a name and a time attached to it, and the count moved because a human
@@ -195,13 +227,13 @@ how you get a local server.
 ### 7. Publish to the door
 
 > **Ask your agent:**
-> Run `pnpm provision`, then `pnpm refresh`.
+> Run `npm run provision`, then `npm run refresh`.
 
 <details><summary>Do it yourself</summary>
 
 ```sh
-pnpm provision   # schema + ingest authorization — once
-pnpm refresh     # build, embed, publish a generation
+npm run provision   # schema + ingest authorization — once
+npm run refresh     # build, embed, publish a generation
 ```
 
 </details>
@@ -224,17 +256,18 @@ every answer will cite.
 <details><summary>Do it yourself</summary>
 
 ```sh
-pnpm serve
+npm run serve
 ```
 
 If port 8080 is taken, the refusal tells you so and offers
-`KSOR_MCP_PORT=8081 pnpm serve`.
+`KSOR_MCP_PORT=8081 ksor serve`.
 </details>
 
 ```
 ksor serve · handbook
   db        direct endpoint · local
   audience  public
+  trust     unverified
   auth      DISABLED — 127.0.0.1 only, and a public bind will refuse to boot
   abstain   OFF — no floor calibrated; out-of-corpus questions will be answered, not refused
   serving   http://127.0.0.1:8080/mcp
@@ -309,14 +342,14 @@ agent to run it.
 
 ## Reference
 
-| command          | what it does                                         |
-| ---------------- | ---------------------------------------------------- |
-| `pnpm dev`       | the site, hot-reloading, drafts visible and marked   |
-| `pnpm check`     | the record checker — run before every commit         |
-| `pnpm build`     | check the record, regenerate indexes, write the lock |
-| `pnpm provision` | apply the schema, authorize ingest — once            |
-| `pnpm refresh`   | build, embed, publish a generation                   |
-| `pnpm serve`     | the MCP server, over what you published              |
+| command             | what it does                                         |
+| ------------------- | ---------------------------------------------------- |
+| `npm run dev`       | the site, hot-reloading, drafts visible and marked   |
+| `npm run check`     | the record checker — run before every commit         |
+| `npm run build`     | check the record, regenerate indexes, write the lock |
+| `npm run provision` | apply the schema, authorize ingest — once            |
+| `npm run refresh`   | build, embed, publish a generation                   |
+| `npm run serve`     | the MCP server, over what you published              |
 
 `docs/status.md` is authoritative on what the current release supports. If it
 and this tutorial ever disagree, it wins.

--- a/docs/tutorials/00-hello-world.md
+++ b/docs/tutorials/00-hello-world.md
@@ -185,7 +185,15 @@ This is the half that answers questions. It needs two things, both free:
 ### 5. Get the database
 
 `.mcp.json` at the project root declares the MCP servers your agent may reach.
-The first is Neon's.
+It ships with two: **Neon**, used below, and
+**agentfactory-system-of-record** — a read-only KSoR record Panaversity
+operates, there as an example of the surface you are building. The second is not
+your record and nothing here needs it; delete the entry if you would rather your
+agent not have it.
+
+The Neon server acts on your Neon **account**, not on one database: an agent
+holding it can create and delete projects and branches. That is why the prompt
+below asks to see the plan first.
 
 > **Ask your agent:**
 > Using the Neon MCP server, create a project called `handbook` and enable the

--- a/packages/ksor/src/skill-triggers.integration.test.ts
+++ b/packages/ksor/src/skill-triggers.integration.test.ts
@@ -72,7 +72,7 @@ const TUTORIAL_PROMPTS: ReadonlyArray<readonly [string, string | null]> = [
   ["Build this for publishing", null],
   ["Why isn't my refund policy in `llms.txt`", null],
   ["Using the Neon MCP server, create a project", null],
-  ["Run `pnpm provision`, then `pnpm refresh`", null],
+  ["Run `npm run provision`, then `npm run refresh`", null],
   ["Start the server in the background", null],
   ["Add my record to `.mcp.json`", null],
   // The payoff. No skill: this is the reader ASKING THE RECORD, through the MCP


### PR DESCRIPTION
## Problem

The tutorial shipped in 0.0.54 does not work. Walked from the published package
(`npx @panaversity/ksor@0.0.54 init handbook`), it stops dead at step 3:

```
$ npx ksor build
error: ksor-reserved-type-unsourced
  knowledge/refund-policy.md
    why: `type: Policy` is a reserved type, which carries governance meaning and therefore needs `sources`
EXIT=1
```

`npm run check` fails the same way and `npm run dev` dies with a Next config
error, so the sentence after the fold — "Refresh the browser. Your document is
there" — is false and steps 4–10 are unreachable.

Two more, on the same walk:

- Step 1 uses `npx`, and the tutorial itself explains that `npx` emits an **npm**
  project. Steps 2 onward then say `pnpm`. On that project `pnpm install` warns
  about a `workspaces` field the reader never wrote, silently skips
  `system/site`, and `pnpm dev` fails with `sh: next: command not found`.
- Several outputs were edited after capture, in a document whose second paragraph
  is "Every command and every output below was run on 2026-09-01 and pasted as it
  appeared. Nothing here is a sketch." The `ksor serve` boot report omits the
  `trust` line that `content-gateway/src/compose.ts:354` prints unconditionally;
  the build outputs omit their timestamp, `source:` and `wrote` lines; and the
  port-conflict refusal is quoted offering `pnpm serve` where `bind.ts:62` says
  `ksor serve`.

## Solution

`type: Document` — the one type the profile promises never to reserve, which is
exactly decision 27's stated escape for a record that wants neither owners nor
sources. A short note explains reserved types and tells the reader what to do
when their agent reaches for `type: Policy` and meets the refusal, which it
often will.

All sixteen commands become npm's. `pnpm dlx` in step 1 would have been the
one-line fix, but it breaks the tutorial's own promise that "Part 1 needs
nothing but Node 24+".

Outputs are re-captured verbatim.

The walk also surfaced that `ksor init` leaves a repo with no commits, so every
reader's first build prints `source: unspecified — this build cannot be traced
back to a reviewed commit`. That is the product working, so the tutorial shows
it and folds `git commit` into the approval step; the second build then prints a
real commit sha.

## Behaviour

Part 1 re-walked end to end on the corrected text: `npm install` → dev server
200 → first build `6 document(s), 5 admitted` → approve + commit → `6 admitted`
→ document renders and appears in `llms.txt`.

The `build_id` printed in the tutorial reproduces byte-identically on a fresh
scaffold (`sha256:70dae2f9…` then `sha256:6af6a2ee…`), so the tutorial now says
what actually varies — the timestamp and the commit sha — and points at the
reproducibility invariant it is demonstrating.

`skill-triggers.integration.test.ts`, added in #234, caught the changed prompt
and its table is updated. That test change is the only thing under `packages/`.

Found by an adversarial review of this week's 33 commits, not by a reader.