### PR TITLE
Name both MCP servers the scaffold ships, and stop the README deleting them

### DIFF
--- a/.changeset/scaffold-mcp-docs.md
+++ b/.changeset/scaffold-mcp-docs.md
@@ -1,0 +1,37 @@
+---
+"@panaversity/ksor": patch
+---
+
+Say what the scaffold's `.mcp.json` attaches to an adopter's coding agent, and
+stop the README telling them to destroy it.
+
+`ksor init` emits `.mcp.json` with two servers. The emitted README and AGENTS.md
+both said "the first is Neon" and named the second nowhere — so
+`agentfactory-system-of-record`, a Panaversity-operated endpoint, was wired into
+every adopter's coding agent with no emitted document mentioning it. `.mcp.json`
+attaches servers to the agent that OPERATES the record; a server nobody
+documented is a capability nobody reviewed.
+
+Both are now named, with what each is and that either may be deleted. The second
+is described as what it is: a read-only example record that is **not** the
+adopter's and that nothing in the project depends on.
+
+The Neon step also said only that the server exists. It acts on the Neon
+*account* — an agent holding it can create and delete projects and branches — so
+the README and AGENTS.md now say that before handing over a prompt that runs
+against real infrastructure, and point at Neon's own documentation for the
+scopes rather than paraphrasing them.
+
+And the "Test the door with an actual agent" section told the adopter to *write*
+`.mcp.json` with a file containing only `test-record` — overwriting the Neon
+entry the same README depends on two sections earlier — and then closed with
+"Delete `.mcp.json`, or keep it". It now shows the entry to **add**, and says not
+to delete the file.
+
+A guard derived from `mcp.json` itself asserts every server key appears in both
+emitted documents, so adding a server and saying nothing fails on the server
+that was added. Mutation-tested: unnaming the second server turns both red.
+
+Found by an adversarial review of this week's commits. Whether the scaffold
+should ship a second, vendor-operated MCP record at all is an owner question and
+is untouched here.

--- a/.changeset/scaffold-mcp-docs.md
+++ b/.changeset/scaffold-mcp-docs.md
@@ -17,12 +17,12 @@ is described as what it is: a read-only example record that is **not** the
 adopter's and that nothing in the project depends on.
 
 The Neon step also said only that the server exists. It acts on the Neon
-*account* — an agent holding it can create and delete projects and branches — so
+_account_ — an agent holding it can create and delete projects and branches — so
 the README and AGENTS.md now say that before handing over a prompt that runs
 against real infrastructure, and point at Neon's own documentation for the
 scopes rather than paraphrasing them.
 
-And the "Test the door with an actual agent" section told the adopter to *write*
+And the "Test the door with an actual agent" section told the adopter to _write_
 `.mcp.json` with a file containing only `test-record` — overwriting the Neon
 entry the same README depends on two sections earlier — and then closed with
 "Delete `.mcp.json`, or keep it". It now shows the entry to **add**, and says not

--- a/packages/ksor/src/init.integration.test.ts
+++ b/packages/ksor/src/init.integration.test.ts
@@ -758,3 +758,47 @@ describe("ksor init — scaffold contents (spec: emitted-tree contract)", () => 
     expect(result.stdout).toContain("corepack enable pnpm");
   });
 });
+
+/**
+ * Every MCP server the scaffold wires up is one the adopter can be told about.
+ *
+ * `.mcp.json` attaches servers to the coding agent that OPERATES the record, so
+ * a server nobody documented is a capability nobody reviewed. It shipped in
+ * 0.0.54 with two entries and prose naming one: the emitted README and AGENTS.md
+ * both said "the first is Neon", and `agentfactory-system-of-record` — a
+ * third-party endpoint, in every adopter's repo — appeared in no emitted
+ * document at all.
+ *
+ * Derived from the file rather than listed here, so ADDING a server to
+ * `.mcp.json` and saying nothing about it fails on the server that was added.
+ */
+describe("the MCP servers the scaffold attaches to an agent", () => {
+  const template = (rel: string): string => readFileSync(path.join(templatesDir, rel), "utf8");
+
+  const servers = (): readonly string[] =>
+    Object.keys(
+      (JSON.parse(template("mcp.json")) as { mcpServers: Record<string, unknown> }).mcpServers,
+    );
+
+  it("declares at least one, so the assertions below are not vacuous", () => {
+    expect(servers().length).toBeGreaterThan(0);
+  });
+
+  it.each(["README.md", "AGENTS.md"])("names every one of them in the emitted %s", (doc) => {
+    const prose = template(doc);
+    for (const name of servers()) {
+      expect(
+        prose.includes(name) || prose.includes(name.replace(/-/g, " ")),
+        `${doc} never mentions the \`${name}\` MCP server, which \`ksor init\` wires into ` +
+          `every adopter's coding agent — say what it is and that they may delete it`,
+      ).toBe(true);
+    }
+  });
+
+  it("tells the adopter what the Neon server can reach, not just that it exists", () => {
+    // It acts on the ACCOUNT: an agent holding it can create and delete
+    // projects and branches. The prompt the README hands them is one an agent
+    // executes against real infrastructure.
+    expect(template("README.md")).toMatch(/account/i);
+  });
+});

--- a/packages/ksor/templates/scaffold/AGENTS.md
+++ b/packages/ksor/templates/scaffold/AGENTS.md
@@ -118,7 +118,15 @@ text-embedding-3-small`, `dim: 1536`, key in `OPENAI_API_KEY` — and each
    Turning it on is step 4, AFTER the record is serving.
 
 2. **Get the database — your agent can do this one.** `.mcp.json` at the repo
-   root declares the MCP servers this project may reach, and the first is Neon.
+   root declares the MCP servers this project may reach. It ships with two:
+   `Neon`, which provisions the Postgres this step needs, and
+   `agentfactory-system-of-record`, a read-only KSoR record Panaversity operates
+   as an example of the surface being built here — not this project's record,
+   and not needed by anything below. Either can be deleted; the file is the
+   adopter's.
+
+   The Neon server acts on the whole Neon ACCOUNT, not on one database: it can
+   create and delete projects and branches. Show the plan before running it.
    With it connected, ask:
 
    > Using the Neon MCP server, create a project called `<your-record>` and

--- a/packages/ksor/templates/scaffold/README.md
+++ b/packages/ksor/templates/scaffold/README.md
@@ -174,7 +174,26 @@ the variable name here only if you want a different one.
 ### 2. Get a database — your agent can do this one
 
 `.mcp.json` at the repo root declares the MCP servers this project may reach.
-The first is Neon's. With it connected, ask your coding agent:
+It ships with two, and both are yours to keep or delete — it is your file:
+
+| server                           | what it is                                                                                       |
+| -------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `Neon`                           | Neon's own hosted MCP server, for provisioning the Postgres the agent surface needs (step 2)     |
+| `agentfactory-system-of-record`  | a KSoR record Panaversity operates, served over MCP — an example of the surface you are building |
+
+The second is **not** your record and is not needed to run this project. It is
+read-only and it answers about the Agent Factory curriculum, not about your
+knowledge. Delete the entry if you would rather your agent not have it; nothing
+here depends on it.
+
+**Before you connect Neon, know what you are granting.** The Neon MCP server
+acts on your Neon *account*, not on one database: an agent holding it can create
+and delete projects and branches. Point it at an account you are willing to let
+an agent change, review the plan it shows you before approving, and read Neon's
+own documentation on the server's scopes and permissions rather than taking this
+paragraph as the whole of it.
+
+With it connected, ask your coding agent:
 
 > Using the Neon MCP server, create a project called `<your-record>` and enable
 > the pgvector extension on it. Then create a branch called `dev`, and save that
@@ -254,17 +273,14 @@ separately](#the-agent-surface-deploys-separately). Any other operation is
 ### Test the door with an actual agent
 
 The MCP door is meant to be read by agents, so check it with one rather than
-with `curl`. With `pnpm serve` running, write `.mcp.json` at the repo root:
+with `curl`. With `pnpm serve` running, **add** an entry to the `.mcp.json` you
+already have — alongside `Neon`, not in place of it:
 
 ```json
-{
-  "mcpServers": {
     "test-record": {
       "type": "http",
       "url": "http://127.0.0.1:8080/mcp"
     }
-  }
-}
 ```
 
 **If you skipped `calibrate`, expect answers where this test wants refusals** —
@@ -288,7 +304,9 @@ Question 2 is the one that matters. Anything can answer questions it has the
 text for; refusing a plausible near-miss is the property that makes a system of
 record worth trusting, and it is the one that breaks quietly.
 
-Delete `.mcp.json`, or keep it — it holds no secret.
+Keep the `test-record` entry or remove it — it points at loopback and holds no
+secret either way. Do not delete `.mcp.json` itself: it is where `Neon` is
+declared, and step 2 above needs it.
 
 ---
 


### PR DESCRIPTION
## Problem

`ksor init` emits `.mcp.json` with **two** servers:

```json
"Neon":                          { "url": "https://mcp.neon.tech/mcp" },
"agentfactory-system-of-record": { "url": "https://sor.panaversity.org/mcp",
                                   "oauth": { "clientId": "zia-tutor-ai", … } }
```

Three defects around it, all shipped in 0.0.54:

**The second server is documented nowhere.** Both emitted documents say "the
first is Neon" and stop:

```
$ grep -rn "sor.panaversity\|agentfactory-system-of-record" packages/ksor/templates/ packages/ksor/docs/
packages/ksor/templates/scaffold/mcp.json:7      # the file itself, and nothing else
```

`.mcp.json` attaches servers to the coding agent that *operates* the record. A
Panaversity-operated endpoint is wired into every adopter's agent, and no
document in the repo they own tells them it is there.

**The Neon step understates what it grants.** It said the server exists and gave
a prompt to run. The server acts on the Neon *account* — an agent holding it can
create and delete projects and branches.

**The README tells the adopter to destroy the file.** "Test the door with an
actual agent" says to *write* `.mcp.json` containing only `test-record`, which
overwrites the `Neon` entry step 2 depends on, and then closes with "Delete
`.mcp.json`, or keep it".

## Solution

Both servers named, in a table, with what each is and that either may be
deleted — the second described as what it is: read-only, not the adopter's
record, and depended on by nothing here. The Neon paragraph says what account
access it asks for before handing over the prompt, and points at Neon's own docs
for the scopes rather than paraphrasing them. The test section shows the entry to
**add**, and says not to delete the file.

A guard derived from `mcp.json` asserts every server key appears in both emitted
documents — so adding a server and documenting nothing fails on the server that
was added, rather than on a list someone forgot to update. Mutation-tested:
renaming the second server so the prose no longer matches turns both assertions
red.

## Not in scope

**Whether the scaffold should ship a vendor-operated MCP record into every
adopter repo at all is an owner question**, and this PR does not answer it — it
makes the current state honest. That question is also flagged on #237.

Found by an adversarial review of this week's commits.