### PR TITLE
Abort on a spent balance instead of quarantining the record

### DIFF
--- a/.changeset/openai-provider-gaps.md
+++ b/.changeset/openai-provider-gaps.md
@@ -1,0 +1,50 @@
+---
+"@panaversity/ksor": patch
+---
+
+Stop a spent OpenAI balance from quarantining content and flipping a generation,
+and name the right variable when a provider key is missing.
+
+**The serious one.** `insufficient_quota` — OpenAI's answer to an exhausted
+balance, which arrives as 429 like an ordinary rate limit — was classified
+non-retryable, correctly, because no amount of waiting adds credit. But
+"non-retryable" is what the ingest drain reads as **poison chunk**: it
+binary-splits the batch down to singletons and marks each `failed`. A spent
+balance arrives on *every* chunk, so a run walked the queue quarantining
+everything it touched; if the failed fraction stayed under
+`MAX_FAILED_FRACTION` (2%), `generationReady` admitted it and the generation
+**flipped** — publishing a record in which exactly the passages the owner had
+just edited were unsearchable, `ksor ingest` exit 0, the billing reason visible
+only in `chunks.embed_error`. The same event on Gemini aborts the run, so
+switching provider silently changed what a spent quota does.
+
+The drain now has three answers instead of two: retryable (abort, chunks stay
+pending), **fatal** (abort the same way, but without spending five backoffs
+first — the account is what is wrong, not the passage), and everything else
+(binary-split to the poison chunk). `isFatal` is optional on `EmbeddingProvider`,
+so a provider that cannot tell keeps the old two-kind behaviour and Gemini's
+path is unchanged.
+
+**The missing-key refusal names the variable.** `ksor serve` on an
+`embedding.provider: openai` record said `embedding provider "openai" needs an
+API key and none was supplied` and stopped — while `ksor serve --help`,
+`env.example` and `docs/deploying.md` all named `GEMINI_API_KEY`, which that
+door does not read. The registry row already held `keyEnv`; it now reaches the
+operator (`— set OPENAI_API_KEY`), and all three documents describe the choice
+instead of one vendor.
+
+**`ksor calibrate`'s Gemini requirement is stated rather than papered over.**
+Question synthesis is Gemini-only today, so a record embedding with
+`OPENAI_API_KEY` is still refused for a Google key when calibrating through the
+synthesized door. That gap is now said plainly in the refusal and in
+`docs/ingesting.md`, which taught calibration without mentioning it. The
+`--queries-file` door avoids it entirely.
+
+**The OpenAI live test announces itself.** It is gated on `OPENAI_API_KEY`, no
+workflow supplied one, and a false `describe.runIf` contributes nothing to a run
+— so the suite its own header calls "the tripwire for vendor drift" was absent
+from CI and reported as absent by nobody. It now prints `skipped — set
+OPENAI_API_KEY`, the way Gemini's does, and CI passes the secret so the tripwire
+arms the moment one is added.
+
+Found by an adversarial review of this week's commits.

--- a/.changeset/openai-provider-gaps.md
+++ b/.changeset/openai-provider-gaps.md
@@ -10,7 +10,7 @@ balance, which arrives as 429 like an ordinary rate limit — was classified
 non-retryable, correctly, because no amount of waiting adds credit. But
 "non-retryable" is what the ingest drain reads as **poison chunk**: it
 binary-splits the batch down to singletons and marks each `failed`. A spent
-balance arrives on *every* chunk, so a run walked the queue quarantining
+balance arrives on _every_ chunk, so a run walked the queue quarantining
 everything it touched; if the failed fraction stayed under
 `MAX_FAILED_FRACTION` (2%), `generationReady` admitted it and the generation
 **flipped** — publishing a record in which exactly the passages the owner had

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,14 +186,19 @@ jobs:
       - uses: ./.github/actions/setup
       - run: pnpm build
       # The kernel's database tier (decision 11): ingest → retrieve round
-      # trips against real Postgres + pgvector. The Gemini-live suite
-      # (gemini.live.db.test.ts — the one real embedding call, proving the
-      # provider seam and catching vendor API drift) gates separately on
-      # GEMINI_API_KEY and skips without it; the secret is configured.
+      # trips against real Postgres + pgvector. The live provider suites — one
+      # real embedding call each, proving the seam and catching vendor API
+      # drift — gate separately on their own keys and announce themselves as
+      # skipped without one. GEMINI_API_KEY is configured. OPENAI_API_KEY is
+      # passed so the OpenAI tripwire arms the moment that secret is added;
+      # until then its suite reports "skipped — set OPENAI_API_KEY" rather
+      # than vanishing from the run, which is how it went a week unarmed while
+      # its own header called it the proof the seam is vendor-neutral.
       - run: pnpm test:db
         env:
           KSOR_DB_URL: postgresql://ksor:ksor@localhost:5432/ksor
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
   init-windows:
     name: Init acceptance (Windows)

--- a/packages/content/src/commands.ts
+++ b/packages/content/src/commands.ts
@@ -755,7 +755,10 @@ async function calibrateCommand(args: string[]): Promise<number> {
       return refuse(
         "bad-args",
         "the synthesized door needs GEMINI_API_KEY (it writes one probe question per sampled " +
-          "passage) — or calibrate with zero LLM: --queries-file PATH (one in-corpus question per line)",
+          "passage) — or calibrate with zero LLM: --queries-file PATH (one in-corpus question per line).\n" +
+          "  note: this is the TEXT generator, not the embedding provider. A record on " +
+          "`embedding.provider: openai` still embeds with OPENAI_API_KEY; only question " +
+          "synthesis is Gemini-only today, and --queries-file avoids it entirely",
       );
     }
     textGenerator = new GeminiTextGenerator({ apiKey });

--- a/packages/content/src/ingest/build.ts
+++ b/packages/content/src/ingest/build.ts
@@ -939,6 +939,9 @@ export async function buildGeneration(
         await c.query(FAIL_SQL, [reason, chunkId]);
       }),
     isRetryable: (exc) => provider.isRetryable(exc), // the ingest plane's PATIENT taxonomy (429 = retry)
+    // …and the third answer, when the provider has one: abort rather than
+    // quarantine a chunk for a failure that belongs to the account.
+    isFatal: (exc) => provider.isFatal?.(exc) === true,
   });
   log(`embedded ${embedded}, failed ${failed}`);
 

--- a/packages/content/src/ingest/worker.test.ts
+++ b/packages/content/src/ingest/worker.test.ts
@@ -96,6 +96,55 @@ describe("drain", () => {
     ).rejects.toThrow("429");
   });
 
+  // The kind that made two kinds insufficient. A spent balance is not a poison
+  // chunk: it arrives on EVERY chunk, and quarantining is a claim about the
+  // passage. Without this the run walked the whole queue splitting batches to
+  // singletons, marked each `failed`, and — if the failed fraction stayed under
+  // MAX_FAILED_FRACTION — FLIPPED a generation missing exactly what had changed.
+  it("a FATAL error aborts the run: nothing quarantined, the queue left pending", async () => {
+    const failedIds: string[] = [];
+    let calls = 0;
+    const spent = Object.assign(new Error("You have no credits remaining."), { spent: true });
+    await expect(
+      drain(pendingOf(64), {
+        embedBatch: async () => {
+          calls += 1;
+          throw spent;
+        },
+        writeBatch: async () => {
+          throw new Error("must not write");
+        },
+        markFailed: async (_reason, chunkId) => {
+          failedIds.push(chunkId);
+        },
+        // Not retryable — waiting does not add credit — and not the chunk's fault.
+        isRetryable: () => false,
+        isFatal: (exc) => (exc as { spent?: boolean }).spent === true,
+      }),
+    ).rejects.toThrow("no credits remaining");
+    expect(failedIds, "a billing failure must quarantine nothing").toEqual([]);
+    expect(calls, "and must not binary-split its way through the queue first").toBe(1);
+  });
+
+  it("still quarantines when the provider offers no third answer", async () => {
+    // `isFatal` is optional: a provider that cannot tell keeps the two-kind
+    // behaviour, so this change cannot alter Gemini's.
+    const failedIds: string[] = [];
+    const result = await drain(pendingOf(2), {
+      embedBatch: async (texts) => {
+        if (texts.some((t) => t.includes("text 1"))) throw new Error("degenerate embedding");
+        return texts.map(() => "[0.1]");
+      },
+      writeBatch: async () => {},
+      markFailed: async (_reason, chunkId) => {
+        failedIds.push(chunkId);
+      },
+      isRetryable: () => false,
+    });
+    expect(failedIds).toEqual(["id-1"]);
+    expect(result.embedded).toBe(1);
+  });
+
   it("batches sequentially at BATCH=32 and commits per batch", async () => {
     expect(BATCH).toBe(32);
     const batchSizes: number[] = [];

--- a/packages/content/src/ingest/worker.ts
+++ b/packages/content/src/ingest/worker.ts
@@ -5,10 +5,23 @@
  * The three quarried rules, carried: read the WHOLE pending set once on a
  * short connection; embed each batch holding NO connection; write each batch
  * through a short transaction (commit per batch — a re-run touches only what
- * is still pending). Failures: a RETRYABLE batch error aborts the run loudly
- * (chunks stay pending — never mass-quarantine on a provider blip); a
- * non-transient error BINARY-SPLITS down to the single poison chunk, which
+ * is still pending).
+ *
+ * Failures come in THREE kinds, because two was one too few. A RETRYABLE batch
+ * error aborts the run loudly (chunks stay pending — never mass-quarantine on
+ * a provider blip). A FATAL one aborts it the same way but without the retry
+ * wrapper's patience first: the ACCOUNT, not the passage, is what is wrong, so
+ * waiting cannot help and quarantining would be a lie about which chunk is bad.
+ * Everything else BINARY-SPLITS down to the single poison chunk, which
  * quarantines as `failed` with its reason.
+ *
+ * The third kind is not decoration. `insufficient_quota` — a spent OpenAI
+ * balance — arrives as 429 on every chunk in the run. Classified merely
+ * non-retryable it took the poison path: each batch split to singletons, each
+ * singleton quarantined, and a run whose failed fraction stayed under
+ * MAX_FAILED_FRACTION then FLIPPED — publishing a generation in which exactly
+ * the passages the owner had just edited were unsearchable, exit 0, with the
+ * billing reason visible only in `chunks.embed_error` (review, 2026-09-01).
  */
 
 import { embedInput } from "../lib/embedding.js";
@@ -72,6 +85,14 @@ export interface DrainIo {
   readonly markFailed: (reason: string, chunkId: string) => Promise<void>;
   /** The ingest plane's PATIENT taxonomy (429 = retry) — the provider's own classifier. */
   readonly isRetryable: (exc: unknown) => boolean;
+  /**
+   * Is this a failure of the ACCOUNT rather than of the passage? Such an error
+   * aborts the run with everything unwritten left pending, exactly like a
+   * retryable one — but it is asked separately because the retry wrapper must
+   * NOT spend five backoffs on it first. Optional: a provider that cannot tell
+   * says nothing and keeps the two-kind behaviour.
+   */
+  readonly isFatal?: (exc: unknown) => boolean;
 }
 
 export interface DrainResult {
@@ -96,6 +117,9 @@ export async function drain(pending: readonly PendingRow[], io: DrainIo): Promis
       literals = await io.embedBatch(batch.map(([, text]) => text));
     } catch (exc) {
       if (io.isRetryable(exc)) throw exc; // abort the RUN; everything unwritten stays pending (resume = rerun)
+      // Not the passage's fault and not a blip: abort with the queue intact, so
+      // a re-run after the account is fixed embeds what this run did not.
+      if (io.isFatal?.(exc) === true) throw exc;
       if (batch.length === 1) {
         await io.markFailed(failureReason(exc), batch[0]![0]);
         failed += 1;

--- a/packages/content/src/lib/embedding.ts
+++ b/packages/content/src/lib/embedding.ts
@@ -62,6 +62,14 @@ export interface EmbeddingProvider {
   isRetryable(exc: unknown): boolean;
   /** The READ plane's classification — fail-fast; MUST NOT count a rate limit as retryable. */
   isRetryableQuery(exc: unknown): boolean;
+  /**
+   * OPTIONAL third answer: a failure of the ACCOUNT rather than of the passage
+   * — a spent balance, a revoked key. The ingest drain aborts on it with the
+   * queue left pending, because the alternative is quarantining chunks for a
+   * reason that has nothing to do with them. A provider that cannot tell omits
+   * this and keeps the two-kind behaviour.
+   */
+  isFatal?(exc: unknown): boolean;
   /** DROP the stale client reference so the next call builds a fresh one. NEVER
    * close an in-flight client: concurrent callers keep their references and finish. */
   reset(): void;

--- a/packages/content/src/lib/providers/openai.live.db.test.ts
+++ b/packages/content/src/lib/providers/openai.live.db.test.ts
@@ -110,3 +110,21 @@ describe.runIf(apiKey !== "")("openai provider — live", () => {
     expect(provider.recipe, "no other vendor's task label").not.toContain("RETRIEVAL");
   });
 });
+
+/**
+ * The other half of "gated", which this file shipped without.
+ *
+ * A `describe.runIf` that is false contributes NOTHING to a run — no test, no
+ * skip line, nothing. So this suite, which the header above calls "the proof"
+ * that the seam is vendor-neutral and "the tripwire for vendor drift", was
+ * absent from every CI run and reported as absent by nobody: `grep -rn OPENAI
+ * .github/` returns nothing, and the workflows pass `GEMINI_API_KEY` alone.
+ * A green board therefore said the tripwire was armed when it had never fired.
+ *
+ * Gemini's live suite already does this. Honest absence, never silent weakness.
+ */
+describe.runIf(apiKey === "")("openai provider — live (gated)", () => {
+  it("skipped — set OPENAI_API_KEY to run the live embedding-space proof", () => {
+    expect(apiKey).toBe("");
+  });
+});

--- a/packages/content/src/lib/providers/openai.test.ts
+++ b/packages/content/src/lib/providers/openai.test.ts
@@ -20,7 +20,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { OpenAiEmbeddingProvider, isRetryable, isRetryableQuery } from "./openai.js";
+import { OpenAiEmbeddingProvider, isFatal, isRetryable, isRetryableQuery } from "./openai.js";
 import {
   OpenAiHttpError,
   openAiRestEmbedClient,
@@ -213,5 +213,39 @@ describe("reset", () => {
     p.reset();
     await p.embed(["a"], { intent: "document" });
     expect(built).toBe(2);
+  });
+});
+
+describe("the third answer: a failure of the ACCOUNT, not of the passage", () => {
+  // The ingest drain has two behaviours for a batch error: abort the run
+  // (retryable — chunks stay pending), or binary-split down to the single
+  // poison chunk and quarantine it. `insufficient_quota` is neither. It
+  // arrives on EVERY chunk, so the poison path split each batch to singletons
+  // and marked them `failed`; a run whose failed fraction stayed under
+  // MAX_FAILED_FRACTION then FLIPPED, publishing a generation in which exactly
+  // the passages the owner had just edited were unsearchable — exit 0, with
+  // the billing reason only in `chunks.embed_error`. Gemini aborts on the same
+  // event, so switching provider silently changed what a spent quota does.
+  it("marks a spent balance fatal, so the drain aborts instead of quarantining", () => {
+    const broke = new OpenAiHttpError(429, "You have no credits remaining.", PERMANENT_QUOTA);
+    expect(isFatal(broke)).toBe(true);
+    expect(isRetryable(broke), "and still not worth waiting on").toBe(false);
+  });
+
+  it("does NOT mark an ordinary rate limit fatal — that one is worth waiting on", () => {
+    expect(isFatal(new OpenAiHttpError(429, "Rate limit reached", "rate_limit_error"))).toBe(false);
+  });
+
+  it("does not mark a real poison chunk fatal, which must still be isolated", () => {
+    // A 400 on one passage is the case binary-split exists for. Calling it
+    // fatal would abort the whole run on one bad chunk — the opposite defect.
+    expect(isFatal(new OpenAiHttpError(400, "invalid input"))).toBe(false);
+    expect(isFatal(new Error("degenerate embedding"))).toBe(false);
+  });
+
+  it("is reachable through the provider the framework actually holds", () => {
+    const p = new OpenAiEmbeddingProvider(opts);
+    expect(p.isFatal(new OpenAiHttpError(429, "no credits", PERMANENT_QUOTA))).toBe(true);
+    expect(p.isFatal(new OpenAiHttpError(503, "unavailable"))).toBe(false);
   });
 });

--- a/packages/content/src/lib/providers/openai.ts
+++ b/packages/content/src/lib/providers/openai.ts
@@ -64,6 +64,15 @@ export function isRetryable(exc: unknown): boolean {
  * project stays rate-limited on the next second, so a search degrades to
  * keyword-only now rather than stalling a reader behind backoff.
  */
+/**
+ * An ACCOUNT-level failure: no amount of waiting and no other passage changes
+ * it. The drain must abort on this rather than quarantine, because the chunk
+ * it happened to be holding is not what is wrong — see `ingest/worker.ts`.
+ */
+export function isFatal(exc: unknown): boolean {
+  return exc instanceof OpenAiHttpError && exc.kind === PERMANENT_QUOTA;
+}
+
 export function isRetryableQuery(exc: unknown): boolean {
   if (isTransportBlip(exc)) return true;
   const status = httpStatusOf(exc);
@@ -141,5 +150,9 @@ export class OpenAiEmbeddingProvider implements EmbeddingProvider {
 
   isRetryableQuery(exc: unknown): boolean {
     return isRetryableQuery(exc);
+  }
+
+  isFatal(exc: unknown): boolean {
+    return isFatal(exc);
   }
 }

--- a/packages/content/src/lib/providers/registry.ts
+++ b/packages/content/src/lib/providers/registry.ts
@@ -73,12 +73,23 @@ export interface ProviderEntry {
  */
 export class MissingProviderKeyError extends Error {
   readonly providerName: string;
-  constructor(providerName: string) {
+  readonly keyEnv: string | null;
+  /**
+   * `keyEnv` is not decoration. The message named the PROVIDER and nothing
+   * else, so an operator whose `ksor serve` exited 3 on an OpenAI record was
+   * told "provider openai needs an API key" and left to guess which variable —
+   * while `ksor serve --help`, `env.example` and `docs/deploying.md` all named
+   * `GEMINI_API_KEY`, which the door does not read (review, 2026-09-01). The
+   * registry row already held the answer; this is it reaching the operator.
+   */
+  constructor(providerName: string, keyEnv: string | null = null) {
     super(
-      `embedding provider ${JSON.stringify(providerName)} needs an API key and none was supplied`,
+      `embedding provider ${JSON.stringify(providerName)} needs an API key and none was supplied` +
+        (keyEnv === null ? "" : ` — set ${keyEnv}`),
     );
     this.name = "MissingProviderKeyError";
     this.providerName = providerName;
+    this.keyEnv = keyEnv;
   }
 }
 
@@ -158,7 +169,7 @@ export function buildShippedProvider(
 ): EmbeddingProvider {
   const entry = entryFor(name);
   if (entry.needsApiKey && !opts.apiKey) {
-    throw new MissingProviderKeyError(name);
+    throw new MissingProviderKeyError(name, entry.keyEnv);
   }
   return entry.build({
     apiKey: opts.apiKey ?? "",

--- a/packages/ksor/docs/deploying.md
+++ b/packages/ksor/docs/deploying.md
@@ -286,8 +286,14 @@ are doing it wrong" — and only the first tier is true.
 | variable                                  | why                                                  |
 | ----------------------------------------- | ---------------------------------------------------- |
 | `KSOR_DB_URL`                             | the record's Postgres store                          |
-| `GEMINI_API_KEY`                          | embeds the incoming query, so retrieval works at all |
+| the provider key                          | embeds the incoming query, so retrieval works at all |
 | `KSOR_AUTH`, **or** a configured SSO door | see below                                            |
+
+The provider key is whichever variable `embedding.provider` in `instance.md`
+names — `GEMINI_API_KEY` for `gemini` (the default), `OPENAI_API_KEY` for
+`openai`. A record reads exactly one, and the boot refusal names the one it
+wanted: `embedding provider "openai" needs an API key and none was supplied —
+set OPENAI_API_KEY`.
 
 `KSOR_AUTH` takes one of two values, and the value IS the decision:
 

--- a/packages/ksor/docs/ingesting.md
+++ b/packages/ksor/docs/ingesting.md
@@ -197,11 +197,16 @@ measure until the corpus is in there.
 pnpm exec ksor calibrate --instance instance.md
 ```
 
-**On a free-tier key, use the zero-LLM door instead.** The command above is the
-SYNTHESIZED door: it writes one probe question per sampled passage with an LLM,
-and a free key allows only a few generations a minute — a bigger corpus makes
-that worse, not better. Write your own in-corpus questions, one per line, and
-pass them:
+**The synthesized door needs `GEMINI_API_KEY`, whatever your embedding provider
+is.** The command above writes one probe question per sampled passage with an
+LLM, and question synthesis is Gemini-only today — so a record on
+`embedding.provider: openai` embeds with `OPENAI_API_KEY` and would still be
+refused here for a Google key. That is a real gap, stated rather than papered
+over; the zero-LLM door below avoids it entirely and is the better choice on a
+free-tier key anyway, because a free key allows only a few generations a minute
+and a bigger corpus makes that worse, not better.
+
+Write your own in-corpus questions, one per line, and pass them:
 
 ```sh
 pnpm exec ksor calibrate --instance instance.md --queries-file questions.txt

--- a/packages/ksor/src/cli.ts
+++ b/packages/ksor/src/cli.ts
@@ -59,7 +59,9 @@ serves nothing. Runs in this process and holds it; SIGTERM/SIGINT drains.
 Configured by environment — .env beside the record is read automatically:
 
   <database.dsn_env>       the Postgres DSN, under the NAME instance.md gives
-  GEMINI_API_KEY           iff the instance's embedding provider needs a key
+  <provider key>           iff the instance's embedding provider needs one:
+                           GEMINI_API_KEY for gemini, OPENAI_API_KEY for openai.
+                           The refusal names the variable your record needs
   KSOR_AUTH                disabled-local (loopback dev) | disabled-public.
                            Serve REFUSES to boot with neither this nor a
                            configured SSO door — never open by accident

--- a/packages/ksor/templates/scaffold/env.example
+++ b/packages/ksor/templates/scaffold/env.example
@@ -10,8 +10,13 @@
 # explicitly instead of relying on a driver default that is due to change.
 KSOR_DB_URL=postgresql://user:password@host:5432/dbname
 
-# The embedding provider key. instance.md defaults to gemini-embedding-001.
+# The embedding provider key — ONE of these, whichever `embedding.provider` in
+# instance.md names. It defaults to gemini, so that is the one uncommented; on
+# `provider: openai`, comment this out and set OPENAI_API_KEY instead. A record
+# reads exactly one of them, and `ksor serve` names the one it wanted when it
+# is missing.
 GEMINI_API_KEY=
+# OPENAI_API_KEY=
 
 # ── Who may ask ─────────────────────────────────────────────────────────────
 # ONE variable, and its VALUE is the decision. `ksor serve` refuses to boot


### PR DESCRIPTION
## Problem

Four gaps in the OpenAI provider that shipped this week. The first is the one
that matters.

### A spent balance quarantined content and flipped a generation

`insufficient_quota` is OpenAI's answer to an exhausted balance, and it arrives
as **429** — the same status as an ordinary rate limit. It was classified
non-retryable, which is right: no amount of waiting adds credit.

But `ingest/worker.ts` reads "non-retryable" as **poison chunk**. Its own header
says so:

> a RETRYABLE batch error aborts the run loudly (chunks stay pending — never
> mass-quarantine on a provider blip); a non-transient error BINARY-SPLITS down
> to the single poison chunk, which quarantines as `failed`

A spent balance is not a property of one passage — it arrives on every chunk. So
the run split each batch to singletons, marked each `failed`, and kept going. If
the failed fraction stayed under `MAX_FAILED_FRACTION` (2%), `generationReady`
admitted the result and the generation **flipped**:

```
run 5: building generation 4 (embed openai:…)
embedded 0, failed 1
FLIPPED active generation -> 4
CLI-EXIT=0
```

The published record is then missing exactly the passages the owner just edited,
`ksor ingest` exits 0, and the billing reason lives only in `chunks.embed_error`.
The identical event on Gemini aborts the run with nothing published — so
switching provider silently changed what a spent quota does.

### Three smaller ones

- `ksor serve` refused with `embedding provider "openai" needs an API key and
  none was supplied` — naming no variable, while `ksor serve --help`,
  `env.example` and `docs/deploying.md` all named `GEMINI_API_KEY`, which that
  door does not read. Setting it changes nothing.
- `ksor calibrate`'s synthesized door requires `GEMINI_API_KEY` whatever the
  embedding provider is, so an OpenAI adopter following `docs/ingesting.md` to
  turn on the abstention gate is refused for a vendor their record does not use.
  Nothing said so.
- `openai.live.db.test.ts` — "the proof" the seam is vendor-neutral and "the
  tripwire for vendor drift" — runs nowhere: no workflow supplies
  `OPENAI_API_KEY`, and a false `describe.runIf` contributes *nothing* to a run,
  so its absence was reported by nobody.

## Solution

The drain gets a third answer. Retryable → abort, chunks pending. **Fatal** →
abort the same way, but without the retry wrapper's five backoffs first, because
the account is what is wrong. Everything else → binary-split to the poison chunk.
`isFatal` is **optional** on `EmbeddingProvider`, so a provider that cannot tell
keeps the two-kind behaviour and Gemini's path is untouched.

`keyEnv` was already on the registry row; it now reaches the operator. The
calibrate gap is stated in the refusal and in the docs rather than discovered.
The live suite prints `skipped — set OPENAI_API_KEY`, and CI passes the secret so
it arms the moment one is added.

## Behaviour

```
$ ksor serve   # embedding.provider: openai, no key
error: embedding provider "openai" needs an API key and none was supplied — set OPENAI_API_KEY
```

Mutation-tested — removing `if (io.isFatal?.(exc) === true) throw exc` turns the
new drain test red, and only that one:

```
× a FATAL error aborts the run: nothing quarantined, the queue left pending
  Tests  1 failed | 12 passed (13)
```

A companion test pins that a provider offering no third answer still quarantines,
so this cannot quietly change Gemini. Unit 1592, integration 62 files / 634, db
43 files / 307 — all pass.

## Needs the owner

`OPENAI_API_KEY` is referenced in `ci.yml` but the repository secret does not
exist yet; until it is added the suite keeps reporting itself skipped, which is
the honest state rather than a silent one. Making `ksor calibrate` work without
a Gemini key needs an OpenAI `TextGenerator` — a feature, not a fix, and left
out deliberately.

Found by an adversarial review of this week's commits.