### PR TITLE
Say what moves a build_id wherever one is printed

### DIFF
--- a/.changeset/tutorial-build-id-claim.md
+++ b/.changeset/tutorial-build-id-claim.md
@@ -1,0 +1,29 @@
+---
+"@panaversity/ksor": patch
+---
+
+Correct a claim the tutorial made about `build_id`, and guard the general rule.
+
+`buildIdOf` hashes `ksor_version` along with the record — deliberately, because
+"what produced this" is part of what a publication is. So a captured `build_id`
+is correct for exactly one release, and the sentence 0.0.54's tutorial fix added
+— "Your timestamp will differ; the `build_id` will not" — was already false when
+0.0.55 published it. A reader on any later ksor sees a hash that does not match
+theirs and nothing saying why.
+
+Found by walking the published package rather than by reading the diff: the same
+practice that caught the tutorial being uncompletable caught the correction being
+wrong.
+
+The tutorial now says the id carries the toolchain, names the version its
+outputs were captured on, and points at the reproducibility a reader can
+actually check — run `ksor build` twice on one tree and the id is identical.
+Both captured blocks are re-taken from a 0.0.55 walk.
+
+A guard in `docs-truth.integration.test.ts` holds the general rule rather than
+the sentence: a document printing a concrete `build_id` must say what moves one,
+within 700 characters of the id. It is PROXIMITY rather than presence — the
+first version asked whether "toolchain" appeared anywhere in the file, the file
+already used the word once for an unrelated reason, and removing the caveat left
+it green. Caught by mutation, and the tightened version immediately found a
+second uncaveated id in the same document.

--- a/docs/tutorials/00-hello-world.md
+++ b/docs/tutorials/00-hello-world.md
@@ -115,14 +115,20 @@ ksor build: 6 document(s), 5 admitted to a machine surface at 2026-09-01T19:34:4
 source: unspecified — knowledge/ is in a git repository with no commits yet, so this build cannot be traced back to a reviewed commit.
   fix: commit the record (git add knowledge && git commit) and re-run
   wrote knowledge/index.md
-  wrote build.lock.json — build_id sha256:70dae2f92647c0cdc9d98fcc681185d985a8ffa5f2ed40be47f93c9880480f92
+  wrote build.lock.json — build_id sha256:6d96d4514dcb13df48d980c1218bed9c5cf40734201f4c8d3ab361f1fbe70b75
 ```
 
-Your timestamp will differ; the `build_id` will not. Same record, same
-toolchain, same `build_id` — that is a testable claim this project holds itself
-to, and you just reproduced it. The `source: unspecified` line is the record
-telling you it cannot trace this build back to a reviewed commit, because you
-have not made one yet. We fix that in a moment.
+Your timestamp will differ. So will the `build_id` if you are on a later ksor
+than the 0.0.55 these were captured on — the id hashes the TOOLCHAIN along with
+the record, because "what produced this" is part of what a publication is. What
+you can reproduce right now is the claim itself: run `ksor build` twice without
+changing anything and the id is identical both times. Same record, same
+toolchain, same `build_id` is a property this project tests itself on rather
+than asserts.
+
+The `source: unspecified` line is the record telling you it cannot trace this
+build back to a reviewed commit, because you have not made one yet. We fix that
+in a moment.
 
 **Six documents. Five admitted.** Yours is not one of them — it is absent from
 `llms.txt`, from the markdown twins, from everything an AI agent would read.
@@ -156,13 +162,16 @@ npx ksor build
 </details>
 
 ```
-ksor build: 6 document(s), 6 admitted to a machine surface at 2026-09-01T19:37:32.457Z
-source: b3a9e18b51c21fb266f8cc5b959fcf3d58c3ce3b
-  wrote build.lock.json — build_id sha256:6af6a2ee49346bc1546af9071e39646e677375f7feddf8802dc814e7f5ad01af
+ksor build: 6 document(s), 6 admitted to a machine surface at 2026-09-01T21:38:13.441Z
+source: 4ff382518b868c7534153c9bf7963fcaad80b6db
+  wrote build.lock.json — build_id sha256:ac107998b571a92f3c2d51f1fb9eecdb7189aea92b89d81133a512596be79bf2
 ```
 
-`source` is now your commit — the build traces to a reviewed change. Your sha
-will be your own; the `build_id` is still everyone's.
+`source` is now your commit — the build traces to a reviewed change, which is
+the whole of what provenance claims: not that the content is right, but that
+this publication came from that reviewed change. Your sha will be your own, and
+so will the `build_id`, which moved because the document did and which also
+carries the toolchain that built it.
 
 That is the product. A draft reaches no machine surface, an approval is an act
 with a name and a time attached to it, and the count moved because a human

--- a/packages/ksor/src/docs-truth.integration.test.ts
+++ b/packages/ksor/src/docs-truth.integration.test.ts
@@ -744,3 +744,53 @@ describe("docs/status.md names the version that is actually published", () => {
     ).toBe(version);
   });
 });
+
+/**
+ * A printed `build_id` is version-scoped, and any document showing one has to
+ * say so.
+ *
+ * `buildIdOf` hashes `ksor_version` along with the record, deliberately — "what
+ * produced this" is part of what a publication is. So a captured id is correct
+ * for exactly one release, and a tutorial that prints one and tells the reader
+ * "your `build_id` will not differ" is false for everyone on a later version.
+ * That sentence shipped in 0.0.54's tutorial fix and was already false when
+ * 0.0.55 published it, which is how this assertion came to exist: found by
+ * walking the published package rather than by reading the diff.
+ *
+ * The rule is the general one, not the sentence: never show an id without
+ * saying what moves it.
+ */
+describe("documents that print a build_id say what moves one", () => {
+  const DOCS = [
+    "docs/tutorials/00-hello-world.md",
+    "packages/ksor/docs/building.md",
+    "packages/ksor/README.md",
+    "README.md",
+  ] as const;
+
+  for (const doc of DOCS) {
+    it(`${doc}`, () => {
+      let text: string;
+      try {
+        text = read(doc);
+      } catch {
+        return; // the document does not exist in this tree; nothing to hold
+      }
+      // PROXIMITY, not presence. The first version of this assertion asked
+      // whether the word "toolchain" appeared anywhere in the file, and the
+      // file already used it once for an unrelated reason — so removing the
+      // caveat next to the id left it green. Caught by mutation.
+      const WINDOW = 700;
+      for (const m of text.matchAll(/build_id\s+sha256:[0-9a-f]{8}/g)) {
+        const after = text.slice(m.index, m.index + WINDOW);
+        expect(
+          /toolchain/i.test(after),
+          `${doc} prints a concrete build_id at offset ${m.index} and the next ${WINDOW} ` +
+            "characters never say the id hashes the TOOLCHAIN as well as the record — so a " +
+            "reader on any other ksor version is shown a hash that will not match theirs, " +
+            "with nothing nearby explaining why",
+        ).toBe(true);
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Problem

Found by walking the **published 0.0.55**, not by reading a diff.

`buildIdOf` hashes `ksor_version` along with the record (`record/lock.ts:185`) —
deliberately: "what produced this" is part of what a publication is. So a
captured `build_id` holds for exactly one release.

The tutorial fix that shipped in this release added:

> Your timestamp will differ; the `build_id` will not.

That was already false the moment 0.0.55 published it. On a fresh scaffold from
`@latest` the first build prints `sha256:6d96d451…` where the document promises
`sha256:70dae2f9…`, with nothing explaining the difference.

## Solution

The tutorial says the id carries the toolchain, names the version its outputs
were captured on, and points the reader at the reproducibility they can actually
check — build twice on one tree, get the same id. Verified:

```
REPRODUCIBLE within 0.0.55: sha256:6d96d4514dcb13df48d980c1218bed9c5cf40734201f4c8d3ab361f1fbe70b75
```

Both captured blocks re-taken from that walk.

A guard holds the **general rule**, not the sentence: a document printing a
concrete `build_id` must say what moves one within 700 characters of it.

## Behaviour

The guard is proximity, not presence, and that distinction was earned. The first
version asked whether `toolchain` appeared anywhere in the file — the file
already used the word once for an unrelated reason, so deleting the caveat next
to the id left it **green**. Caught by mutation. The tightened version then
immediately failed on a *second* uncaveated id in the same document, at offset
5688, which I had not noticed:

```
docs/tutorials/00-hello-world.md prints a concrete build_id at offset 5688 and the
next 700 characters never say the id hashes the TOOLCHAIN as well as the record
```

Both are now caveated. Mutating either caveat turns it red; restoring both makes
it green.

Unit 1601, integration 62 files / 639 pass.