### PR TITLE
Tutorial 2, Make it yours: from hello world's record to one that is only the owner's

### DIFF
--- a/.changeset/tutorial-2-make-it-yours.md
+++ b/.changeset/tutorial-2-make-it-yours.md
@@ -1,0 +1,18 @@
+---
+"@panaversity/ksor": patch
+---
+
+Tutorial 2, _Make it yours_: the walk from hello world's record to one that is
+only the owner's — every output run and pasted as it appeared.
+
+The intake interview and what it does to the placeholder approver; one policy
+brought in from a real PDF, with the shipped check catching the one number the
+conversion got wrong; one procedure that only ever lived in someone's head,
+written with the thing they were not sure of as an open question rather than
+prose; the read-back on the site and the approval act; then the samples go and
+the tool that approved them leaves the policy. Two refusals do work on the way,
+and the tutorial says exactly which state each fires on.
+
+The prompt-accounting test now covers both tutorials from one table, so a new
+prompt in either fails until someone names the skill that answers it. Only that
+test changes under `packages/`; nothing an adopter installs behaves differently.

--- a/docs/tutorials/00-hello-world.md
+++ b/docs/tutorials/00-hello-world.md
@@ -55,7 +55,7 @@ npm run dev
 
 Open **http://localhost:3000**. You have a documentation site rendering five
 starter documents about KSoR itself. They are scratch paper — you will delete
-them in tutorial 2.
+them in [tutorial 2](./02-make-it-yours.md).
 
 ### 3. Write your first document
 
@@ -90,8 +90,8 @@ outside this window entirely.
 types — `Policy`, `Procedure`, `Control` and the rest — carry governance meaning,
 so the record demands `sources` and an owner before it will accept one. If your
 agent reaches for `type: Policy` here, it will meet that refusal and can either
-add `sources` or fall back to `Document`; tutorial 2 is where reserved types
-earn their keep.
+add `sources` or fall back to `Document`; [tutorial 2](./02-make-it-yours.md) is where
+reserved types earn their keep.
 
 </details>
 
@@ -351,9 +351,10 @@ procedure under "Turning the abstention gate on".
 
 **The record is still mostly about KSoR.** Five of your seven documents are
 starter scratch paper. Replacing them with your organisation's actual knowledge
-— and retiring the tool that approved them — is the next tutorial, not yet
-written. The scaffold ships an `intake-interview` skill that starts it: ask your
-agent to run it.
+— and retiring the tool that approved them — is
+[tutorial 2, Make it yours](./02-make-it-yours.md). It starts with the
+`intake-interview` skill the scaffold ships, brings in one file of yours and
+one thing nobody ever wrote down, and ends with a record that is only yours.
 
 ---
 

--- a/docs/tutorials/02-make-it-yours.md
+++ b/docs/tutorials/02-make-it-yours.md
@@ -1,0 +1,377 @@
+# Make it yours — your knowledge, your record, in about half an hour
+
+You finished [hello world](./00-hello-world.md) with a record that publishes
+six documents: five samples about KSoR itself, and one refund policy you wrote.
+By the end of this, the samples are gone, every document is about **your**
+organisation, every one of them was approved by a person with a name, and the
+tool that approved the samples has no authority left over anything.
+
+Along the way you will do the two things a system of record exists for:
+bring in knowledge that already lives in a file without losing a single number,
+and write down knowledge that has only ever lived in someone's head — and see
+the record refuse, twice, on your behalf.
+
+Every command and every output below was run on 2026-09-02 and pasted as it
+appeared, with one convention: a `build_id` is shown as `sha256:…`, because it
+hashes the toolchain version along with the record and yours will not match.
+The document counts and everything else will.
+
+**You need:** the `handbook` from hello world, and one thing of yours — a
+policy PDF, a Word document, a page — or nothing but what you know. For a PDF,
+[`pdftotext`](https://poppler.freedesktop.org/) (`brew install poppler`,
+`apt install poppler-utils`) makes the check in step 2 mechanical; without it
+your agent reads the PDF directly and says so.
+
+Each step gives you a prompt for your coding agent, and the same work under a
+**Do it yourself** fold.
+
+---
+
+## Where you are
+
+```sh
+cd handbook
+npx ksor build
+```
+
+```
+ksor build: 6 document(s), 6 admitted to a machine surface at 2026-09-02T04:28:55.709Z
+```
+
+Six published. One is yours, approved by `human:you` — the placeholder the
+scaffold ships. That placeholder is about to matter.
+
+## 1. Tell the record who you are
+
+> **Ask your agent:**
+> Get me started — run the intake interview.
+
+Three questions, asked one at a time, in your words: what this record is the
+final word on, what sits just outside it, and who signs off on a document. Then
+it writes `instance.md` with you, and replaces `human:you` in the policy with
+your real handle.
+
+<details><summary>Do it yourself</summary>
+
+Answer the three questions in `instance.md`'s body, then in
+`.ksor/governance.yaml` replace `human:you` with your handle in **both**
+authority lists — and leave `ksor-starter/…` where it is, for now:
+
+```yaml
+approval_authorities:
+  - actors: [human:priya, ksor-starter/0.0.55]
+takedown_authorities:
+  actors: [human:priya]
+```
+
+Give the handle a printed name in `.ksor/people.yaml`:
+
+```yaml
+version: "0.1"
+people:
+  "human:priya": Priya Patel
+```
+
+</details>
+
+**Now the placeholder matters.** Your refund policy is approved by `human:you`,
+and `human:you` just stopped being anyone the policy names. Build it in that
+state and the record refuses — its own first document, by name:
+
+```
+error: ksor-approver-unauthorised
+ksor build: 1 problem(s) — nothing written:
+
+  knowledge/refund-policy.md
+```
+
+That is correct: an approval by an actor the policy does not authorise is
+exactly what a system of record must not publish. It is also the same person.
+So the interview re-attributes every act recorded under `human:you` to your
+handle in the same change — approver, generator, owner — and the record is
+green again:
+
+```
+ksor build: 6 document(s), 6 admitted to a machine surface at 2026-09-02T04:28:56.671Z
+```
+
+Commit it. The record is now Acme's, with the samples still in it.
+
+## 2. Bring in something that already exists
+
+Put a file of yours in the project — `src/expense-policy.pdf` here, a
+two-page finance policy with page numbers and running headers, the kind of
+thing every organisation has.
+
+> **Ask your agent:**
+> Here is our expense policy, `src/expense-policy.pdf`. Add it to the record
+> under `finance/`, and tell me what it leaves open.
+
+Watch what it does, because this is the point. It does not read the PDF and
+write from memory. It **extracts** the text to a scratch file, converts from
+that, and then runs a check that every number, date and name in what it wrote
+appears in the extraction.
+
+<details><summary>Do it yourself</summary>
+
+Extract — outside `knowledge/`, which holds markdown and images only:
+
+```sh
+pdftotext -layout src/expense-policy.pdf /tmp/expense.txt
+```
+
+Write `knowledge/finance/expense-policy.md` from `/tmp/expense.txt`: the
+document's own headings as `##`, the page furniture ("Page 1 of 2") dropped,
+and a `sources` entry that names the manual precisely:
+
+```yaml
+---
+type: Policy
+title: Expense policy
+description: What an employee may claim, the limits, and who approves it.
+status: draft
+order: 1
+sources:
+  - id: fin-2026-s7
+    title: Finance manual §7, 2026 edition
+    resource: "Finance manual §7, 2026 edition (expense-policy.pdf)"
+ksor:
+  owner: "human:priya"
+  audience: [public]
+---
+```
+
+`type: Policy` is a reserved type, so `sources` and `ksor.owner` are required
+— that is what makes it one. Cite the source from the body with a footnote
+`[^fin-2026-s7]`.
+
+Then verify, against the extraction:
+
+```sh
+node .agents/skills/add-sources/verify.mjs /tmp/expense.txt knowledge/finance/expense-policy.md
+```
+
+</details>
+
+Here is that check running on the document as it was first written:
+
+```
+$ node .agents/skills/add-sources/verify.mjs /tmp/expense.txt knowledge/finance/expense-policy.md
+14
+EXIT=1
+```
+
+One line: `14`. The manual says claims are paid within **10** working days;
+the document said 14. Nothing else about the page was wrong — the headings,
+the thresholds, the names all matched — and a reader would never have noticed.
+Fix it, and:
+
+```
+$ node .agents/skills/add-sources/verify.mjs /tmp/expense.txt knowledge/finance/expense-policy.md
+EXIT=0
+```
+
+What the check promises is narrow and worth knowing exactly: every number,
+date and capitalised name in the body is in the source. It cannot see a
+sentence that was left out, and it cannot tell a paraphrase from an invention.
+That is what reading it back on the site is for.
+
+```
+ksor build: 7 document(s), 6 admitted to a machine surface at 2026-09-02T04:28:57.523Z
+```
+
+Seven documents. Six admitted — the new one is a draft, and a draft reaches no
+machine surface.
+
+**Then the question that finds the missing pages.** Your agent should ask,
+once the file is in: _what does this not cover?_ Every organisation has an
+answer. Ours was late claims.
+
+## 3. Bring in something nobody ever wrote down
+
+> **Ask your agent:**
+> Nobody ever wrote down how we handle a late expense claim. Interview me and
+> write it up.
+
+Now it drives. Who decides a late claim is late? What happens then? Who
+approves it, and is a director different? What is the exception? It follows up
+until someone who was not in the room could act on the answer — and it writes
+your sentences, tightened, never its own inference about what you must have
+meant.
+
+<details><summary>Do it yourself</summary>
+
+Write `knowledge/finance/late-claims.md`. The source is the conversation, and
+it is named like any other source — who, their role, when, and who asked:
+
+```yaml
+sources:
+  - id: priya-2026-09-02
+    title: Interview with Priya Patel, Head of Finance
+    resource: "Interview with human:priya (Head of Finance), 2026-09-02T10:00:00Z, conducted by human:you"
+```
+
+Anything you were not sure of does not become prose. It becomes a line the
+reader can see:
+
+```markdown
+Open question: is there an absolute cut-off after which a claim is never paid?
+Priya thought there was one "around six months" but did not want that written
+down without checking.
+```
+
+</details>
+
+```
+ksor build: 8 document(s), 6 admitted to a machine surface at 2026-09-02T04:28:58.002Z
+```
+
+Eight. Still six admitted. Two drafts are waiting on you.
+
+That `Open question:` line is the honest shape of institutional knowledge. The
+record now says _exactly_ what Priya was sure of, and says out loud what she
+was not — where a wiki page would have quietly written "six months" and been
+cited for years.
+
+**If a second person tells it differently**, both statements stay, each with
+its own footnote, and the disagreement is flagged to you. Which one becomes
+`stable` is a decision someone with approval authority makes — an act with a
+name on it, not an edit.
+
+## 4. Read it back, then approve
+
+> **Ask your agent:**
+> Show me both on the site.
+
+`pnpm dev`, and open the two pages. They are marked as drafts. This is the
+review surface — the actual page, not a message in a terminal — and it is
+where you decide whether the record says what you meant.
+
+> **Ask your agent:**
+> Approved — record both as me.
+
+<details><summary>Do it yourself</summary>
+
+On each document, `status: stable` plus the two acts publishing requires:
+
+```yaml
+status: stable
+generated: { by: "human:priya", at: 2026-09-02T09:00:00Z }
+ksor:
+  owner: "human:priya"
+  audience: [public]
+  approval: { by: "human:priya", at: 2026-09-02T11:00:00Z }
+```
+
+Then commit and build.
+
+</details>
+
+```
+ksor build: 8 document(s), 8 admitted to a machine surface at 2026-09-02T04:28:58.600Z
+source: a05bfee025c3bca26fa07bb099db4433fdfcf9a5
+  wrote build.lock.json — build_id sha256:…
+```
+
+Eight admitted. Both approvals carry your handle and the instant you gave them,
+and `people.yaml` prints your name on the page.
+
+## 5. Retire the samples
+
+Five documents about KSoR are still published on Acme's record. Now that
+something of yours is in, they can go.
+
+> **Ask your agent:**
+> Delete the five starter documents, then take the tool that approved them out
+> of the policy.
+
+<details><summary>Do it yourself</summary>
+
+```sh
+rm -r knowledge/what-is-a-ksor.md knowledge/what-is-a-ksor.summary.md \
+      knowledge/governance-ladder.md knowledge/surfaces
+npx ksor build
+```
+
+</details>
+
+```
+ksor build: 3 document(s), 3 admitted to a machine surface at 2026-09-02T04:28:59.083Z
+source: a05bfee025c3bca26fa07bb099db4433fdfcf9a5 (dirty) — an input differs from that commit, so it does not contain the bytes this build published.
+```
+
+Three documents, all yours. Read the second line: the build says its `source`
+commit does not contain what it just published, because you have not committed
+the deletion. That is provenance being precise rather than polite. Commit, and
+it will name a commit that does.
+
+Two things to know before you do this in anger. **The order mattered**: a
+record is never empty, so deleting the five before writing one of yours refuses
+`ksor-record-empty` and writes nothing. And **the starter actor stays until the
+last sample goes** — it approved them, and a policy that stops naming it while
+one is still published refuses that document, exactly as `human:you` did in
+step 1.
+
+Now the last sample is gone, so:
+
+<details><summary>Do it yourself</summary>
+
+In `.ksor/governance.yaml`, remove `ksor-starter/…` from inside the list —
+not the whole line, which would take you with it:
+
+```yaml
+approval_authorities:
+  - actors: [human:priya]
+```
+
+</details>
+
+```
+ksor build: 3 document(s), 3 admitted to a machine surface at 2026-09-02T04:28:59.663Z
+source: f22879939064c74c7f38b79d713324cc39f28171
+  wrote build.lock.json — build_id sha256:…
+```
+
+Committed, clean, and nothing in this record was approved by anything but a
+person.
+
+## What you have
+
+```
+knowledge/
+├── finance/
+│   ├── expense-policy.md     ← converted from a PDF, every value verified
+│   └── late-claims.md        ← elicited, with one honest open question
+└── refund-policy.md          ← from hello world, re-attributed to you
+```
+
+Three documents, three approvals with names on them, one source that is a file
+and one that is a person — both named precisely enough that someone could go
+and check. `llms.txt` and the door serve exactly these and nothing else.
+
+Two refusals did work for you: `ksor-approver-unauthorised` when the policy
+and a document disagreed about who may approve, and `ksor-record-empty` if you
+had cleared the shelf before stocking it. Neither is an error. Each is the
+record declining to publish something it could not stand behind, which is the
+whole job.
+
+**What is not done yet.** The abstention floor is still unmeasured, so the
+door answers questions outside the record instead of declining them — that is
+tutorial 4, with the served rung. And `late-claims.md` has an open question
+with Priya's name on it. She should answer it, and the answer should arrive the
+way everything else did: her words, a new approval, a new build.
+
+---
+
+## Reference
+
+| command                                                  | what it does                                            |
+| -------------------------------------------------------- | ------------------------------------------------------- |
+| `pdftotext -layout in.pdf /tmp/in.txt`                   | extract a PDF's text to verify against                  |
+| `pandoc in.docx -t gfm -o /tmp/in.md`                    | the same for Word, HTML, ODT, EPUB                      |
+| `node .agents/skills/add-sources/verify.mjs EXTRACT DOC` | every number, date and name in DOC's body is in EXTRACT |
+| `npm run check`                                          | the record checker — every refusal names its fix        |
+| `npx ksor build`                                         | check the record, regenerate indexes, write the lock    |
+
+`docs/status.md` is authoritative on what the current release supports. If it
+and this tutorial ever disagree, it wins.

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -32,6 +32,18 @@ pasted as it appeared.
 Start here if you want to see what this is. Read the introduction below if you
 want to understand why it exists.
 
+### [Make it yours — your knowledge, your record, in about half an hour](./02-make-it-yours.md)
+
+Picks up where hello world leaves off. You run the intake interview, bring in
+one policy that already exists as a PDF — and watch a shipped check catch the
+one number the conversion got wrong — then write down one procedure that only
+ever lived in someone's head, with the thing they were not sure of recorded as
+an open question rather than smoothed into prose. Then the samples go, and
+nothing left in the record was approved by anything but a person.
+
+Two refusals do work for you on the way, and the tutorial says exactly which
+state each one fires on. Every output was run and pasted as it appeared.
+
 ### [Tutorial 1 — KSoR: One Governed Knowledge Record for Humans and AI Agents](./01-introduction-to-ksor.md)
 
 The introduction. No technical background required.
@@ -46,7 +58,7 @@ You will follow one hospital story the whole way through, and come out understan
 
 ## Coming next in this series
 
-2. **Build a Real Governed KSoR** — grow the Tutorial 1 exercise into a real corpus: scope, governance metadata, resolving a conflict between two concepts, publishing the human site.
+2. ~~Build a Real Governed KSoR~~ — shipped as [Make it yours](./02-make-it-yours.md).
 3. **KSoR Governance in Practice** — ownership, audiences, approvals, lifecycle states, effective dates, takedown, and fail-closed behavior.
 4. **Serve a KSoR to AI Agents with MCP** — provision Postgres + pgvector, publish a generation, connect an MCP client, retrieve citations, and test abstention.
 5. **Combine KSoR with Traditional Systems of Record** — an agent that applies governed policy to current operational facts from an ERP, CRM, or accounting system.

--- a/packages/ksor/src/docs-truth.integration.test.ts
+++ b/packages/ksor/src/docs-truth.integration.test.ts
@@ -763,6 +763,7 @@ describe("docs/status.md names the version that is actually published", () => {
 describe("documents that print a build_id say what moves one", () => {
   const DOCS = [
     "docs/tutorials/00-hello-world.md",
+    "docs/tutorials/02-make-it-yours.md",
     "packages/ksor/docs/building.md",
     "packages/ksor/README.md",
     "README.md",

--- a/packages/ksor/src/skill-triggers.integration.test.ts
+++ b/packages/ksor/src/skill-triggers.integration.test.ts
@@ -79,6 +79,19 @@ const TUTORIAL_PROMPTS: ReadonlyArray<readonly [string, string | null]> = [
   ["How long does a customer have to return something?", null],
 ];
 
+/**
+ * Tutorial 2's prompts. Two fire add-sources — one for a FILE, one for a PERSON
+ * — which is the decision on #50 made visible: same skill, two kinds of source.
+ */
+const TUTORIAL_2_PROMPTS: ReadonlyArray<readonly [string, string | null]> = [
+  ["Get me started — run the intake interview", "intake-interview"],
+  ["Here is our expense policy, `src/expense-policy.pdf`", "add-sources"],
+  ["Nobody ever wrote down how we handle a late expense claim", "add-sources"],
+  ["Show me both on the site", null],
+  ["Approved — record both as me", null],
+  ["Delete the five starter documents", null],
+];
+
 describe("every shipped skill's trigger says what it fires on", () => {
   it("the shipped set is exactly what this file accounts for", () => {
     // A new skill lands with its trigger recorded, or this goes red. That is
@@ -106,11 +119,18 @@ describe("every shipped skill's trigger says what it fires on", () => {
   });
 });
 
-describe("the hello world's prompts are accounted for", () => {
-  const tutorial = readFileSync(path.join(repoRoot, "docs/tutorials/00-hello-world.md"), "utf8");
+/** Every tutorial that hands the reader prompts, with the table that accounts for them. */
+const TUTORIALS: ReadonlyArray<readonly [string, ReadonlyArray<readonly [string, string | null]>]> =
+  [
+    ["docs/tutorials/00-hello-world.md", TUTORIAL_PROMPTS],
+    ["docs/tutorials/02-make-it-yours.md", TUTORIAL_2_PROMPTS],
+  ];
+
+describe.each(TUTORIALS)("%s's prompts are accounted for", (file, table) => {
+  const tutorial = readFileSync(path.join(repoRoot, file), "utf8");
 
   it("every prompt in this table is still in the tutorial", () => {
-    for (const [prompt] of TUTORIAL_PROMPTS) {
+    for (const [prompt] of table) {
       expect(
         tutorial.includes(prompt),
         `the tutorial no longer says ${JSON.stringify(prompt)}`,
@@ -125,9 +145,9 @@ describe("the hello world's prompts are accounted for", () => {
     const blocks = [...tutorial.matchAll(/^> \*\*Ask your agent:\*\*\n((?:^> .*\n)+)/gm)].map((m) =>
       (m[1] ?? "").replaceAll(/^> /gm, "").replaceAll("\n", " "),
     );
-    expect(blocks.length, "the tutorial's prompt blocks").toBe(TUTORIAL_PROMPTS.length);
+    expect(blocks.length, "the tutorial's prompt blocks").toBe(table.length);
     for (const block of blocks) {
-      const known = TUTORIAL_PROMPTS.some(([prompt]) => block.includes(prompt));
+      const known = table.some(([prompt]) => block.includes(prompt));
       expect(
         known,
         `the tutorial gives a prompt this table does not account for: ${JSON.stringify(block.slice(0, 70))}. ` +
@@ -137,7 +157,7 @@ describe("the hello world's prompts are accounted for", () => {
   });
 
   it("each prompt claiming a skill names one that ships", () => {
-    for (const [prompt, skill] of TUTORIAL_PROMPTS) {
+    for (const [prompt, skill] of table) {
       if (skill === null) continue;
       expect(shipped, `${JSON.stringify(prompt)} expects ${skill}`).toContain(skill);
     }


### PR DESCRIPTION
Stacked on #243 (add-sources 2.0.0) — the walk it describes needs `verify.mjs` and the person path. GitHub retargets to `main` when #243 merges.

## What it is

The journey walk in `adopter-journey.integration.test.ts` (#242), written for a person, plus the two things the test cannot do because it has no agent: bring a real PDF in, and interview someone.

Every output is from one walk on 2026-09-02, starting from exactly where hello world leaves the reader (five samples + a refund policy approved by `human:you`):

| step | what happens | build says |
|---|---|---|
| start | | `6 document(s), 6 admitted` |
| 1 | interview retires `human:you` — **without** re-attribution | `error: ksor-approver-unauthorised` on `refund-policy.md` |
| 1 | with re-attribution (intake-interview 1.6.0) | `6 document(s), 6 admitted` |
| 2 | a two-page PDF with page furniture, extracted with `pdftotext`, converted | `verify.mjs` prints `14`, exit 1 — the manual says 10 |
| 2 | fixed | exit 0 → `7 document(s), 6 admitted` |
| 3 | late claims, elicited, with one `Open question:` | `8 document(s), 6 admitted` |
| 4 | both approved as `human:priya`, committed | `8 document(s), 8 admitted` |
| 5 | five starters deleted, before committing | `3 document(s), 3 admitted` + `source: … (dirty)` |
| 6 | `ksor-starter/0.0.55` removed from inside the actors list | `3 document(s), 3 admitted`, clean |

The one convention, stated in the second paragraph: `build_id` is shown as `sha256:…` because it hashes the toolchain version. The docs-truth guard from #240 now holds this file too.

## Also

- Tutorial 0's three forward references ("tutorial 2", "not yet written") now link here.
- `docs/tutorials/README.md`: entry added under *Start here*; "Coming next" item 2 marked shipped.
- The prompt-accounting test in `skill-triggers` is generalised to a table of tutorials. Tutorial 2's six prompts are accounted for: two fire `add-sources` — one for a file, one for a person — which is the #50 decision made visible.

Unit 1607, integration 65 files / 678, corpus, guard, typecheck, fmt all green.