### PR TITLE
Fix twenty-six sentences that 0.0.44–0.0.57 made false

### DIFF
--- a/.changeset/staleness-after-0-0-57.md
+++ b/.changeset/staleness-after-0-0-57.md
@@ -1,0 +1,37 @@
+---
+"@panaversity/ksor": patch
+---
+
+Twenty-six sentences that 0.0.44 through 0.0.57 had made false, found by a
+sweep of every document against the tree and the published package, and fixed.
+
+The two that ship on npm and would have stopped a reader: the package README
+told `npx` users to run `pnpm install` — on the npm project `npx` emits, that
+installs nothing under `system/site` and `pnpm dev` fails with `next: command
+not found` (the tutorial had this exact fix; the README never got it) — and it
+still advertised the two companion skills 0.0.56 removed. It also claimed its
+abstention envelope was "pasted as it appeared" from a tutorial that never
+reaches one; it now says what that block is.
+
+The rest: `calibrate --check` was documented in three places (ingesting.md,
+the CLI help, and by implication the scaffold) as "always exits 0" — a verdict
+always does; an unreachable database exits 3 as for every verb, and the docs
+now say so before anyone puts it in CI. `tool-surface.md` carried two copies of
+one bullet, the stale one missing `audit`. `upgrading.md` gave `ksor init` a
+path, which it refuses. Three documents said "two" authorization recipes where
+`authorization.md` has four. The emitted `instance.md` still described "all
+four study attachments" on a starter trimmed to one companion in 0.0.44;
+`intake-interview` and `people.yaml` said add-sources writes display names (it
+does not); the scaffold README counted two negated `.ksor/` paths where there
+are three; two token figures in the emitted AGENTS.md predated their own
+re-measurement; and a sentence about "this record's own seven" embeds
+described a record that is not the one it is emitted into. Root AGENTS.md said
+"three tiers" above a list of four. `docs/status.md` described the seed quiz
+and deck as shipping (trimmed in 0.0.44), the kernel as "in progress" (released
+in 0.0.8–0.0.18), and carried yesterday's date. The introduction tutorial's
+"where to go next" now links the two tutorials that exist and numbers the rest
+as the index does; hello world said "five skills"; make-it-yours said `pnpm dev`
+in an npm project.
+
+Every fix is a document catching up to code, except the CLI help line, which
+is text.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1636,7 +1636,7 @@ cite the research they distill; guard rule 8 enforces the frontmatter
 
 ## Testing
 
-Three tiers by filename convention; pick the tightest tier that can express the
+Four tiers by filename convention; pick the tightest tier that can express the
 assertion.
 
 - `*.test.ts` — unit, colocated (packages `src/` and `scripts/`): pure, no

--- a/docs/status.md
+++ b/docs/status.md
@@ -2,7 +2,7 @@
 
 **This document is the only authority on what is implemented.** The README is
 the concept; the released package version and this page are the facts. Last
-updated: 2026-09-01.
+updated: 2026-09-02.
 
 ## Published package
 
@@ -749,8 +749,9 @@ date`. The same badge marks the row in the sidebar, in every listing and in
   choosing an author's answers. Verified live on a built scaffold — quiz text
   in **0** files outside its document's own page, parent's `/md/` and both
   llms files **byte-identical** with and without it, zero console errors, both
-  themes. The seed quiz `ksor init` ships was itself refused on first draft
-  for putting four of five answers at option B.
+  themes. The seed quiz `ksor init` shipped until 0.0.44 (when the starter was
+  trimmed to one companion, the summary) was itself refused on first draft for
+  putting four of five answers at option B.
 
 - **Study attachments — summaries and flashcard decks** (decision 24,
   `specs/ksor/study-attachments/spec.md`, released in 0.0.28). A
@@ -758,8 +759,9 @@ date`. The same badge marks the row in the sidebar, in every listing and in
   The summary joins the record's own words as a second TAB — the two readings
   of a document. The deck renders at the END of the page, in the region the quiz
   now shares, because a study aid is used after reading and a tab would hide
-  the document while you used it. `ksor init` ships one of each on the seed
-  document. Presence-driven: a document with neither gets no tab strip and no
+  the document while you used it. `ksor init` ships the summary on the seed
+  document; the seed deck, quiz and slides were trimmed from the starter in
+  0.0.44, so a flashcard deck is now something the owner adds. Presence-driven: a document with neither gets no tab strip and no
   region at all (verified live: a page without attachments renders zero
   `role="tab"` elements).
 
@@ -797,8 +799,8 @@ date`. The same badge marks the row in the sidebar, in every listing and in
   clock, and the ladder it produces is measured in the suite: 10 min, 2 d, 5 d,
   13 d, 33 d.
 
-- **The content kernel and the MCP gateway** (decision 11, in progress on
-  the kernel-conversion branch): four workspace packages — postgres (Postgres access
+- **The content kernel and the MCP gateway** (decision 11; converted on the
+  kernel-conversion branch and released in 0.0.8–0.0.18): four workspace packages — postgres (Postgres access
   discipline: pooling, scoped transactions, retry classification), content (schema + ingest + hybrid retrieval
   - calibrated abstention + read plane), gateway-kit (fail-closed serving
     postures), content-gateway (the content MCP door: search/outline/read over stateless

--- a/docs/tutorials/00-introduction-to-ksor.md
+++ b/docs/tutorials/00-introduction-to-ksor.md
@@ -1740,17 +1740,21 @@ And the operating principle is:
 
 # 13. Where to go next
 
-After completing this tutorial, useful next tutorials would be:
+Two of these exist now, and they are the ones to do next, in this order:
 
-1. **Build a Real Governed KSoR** — take the small exercise from section 11 further: grow it into a real corpus, apply governance metadata properly, resolve a conflict between two concepts, and publish the human site for others to use.
+1. **[Hello world](./01-hello-world.md)** — a governed record in about fifteen minutes: one document, refused until a human approves it, then your own coding agent answering from it with a citation.
 
-2. **KSoR Governance in Practice** — ownership, audiences, approvals, lifecycle states, effective dates, takedown, and fail-closed behavior.
+2. **[Make it yours](./02-make-it-yours.md)** — your knowledge, your record: bring in a file without losing a number, write down what only lived in someone's head, retire the samples.
 
-3. **Serve a KSoR to AI Agents with MCP** — provision Postgres + pgvector, publish a generation, connect an MCP client, retrieve citations, and test abstention.
+Still to be written, numbered as the [tutorials index](./README.md) numbers them:
 
-4. **Combine KSoR with Traditional Systems of Record** — build an agent that combines governed policy with current operational facts from an ERP, CRM, or accounting system.
+3. **KSoR Governance in Practice** — ownership, audiences, approvals, lifecycle states, effective dates, takedown, and fail-closed behavior.
 
-5. **Exchange Governed Knowledge with OKF** — package and move governed knowledge between knowledge systems without creating a second source of truth.
+4. **Serve a KSoR to AI Agents with MCP** — beyond hello world's first door: calibrate the abstention floor, connect more than one client, and test that the record declines what it does not cover.
+
+5. **Combine KSoR with Traditional Systems of Record** — build an agent that combines governed policy with current operational facts from an ERP, CRM, or accounting system.
+
+6. **Exchange Governed Knowledge with OKF** — package and move governed knowledge between knowledge systems without creating a second source of truth.
 
 ---
 

--- a/docs/tutorials/01-hello-world.md
+++ b/docs/tutorials/01-hello-world.md
@@ -35,7 +35,7 @@ yours, not whatever your agent's shell reached for.
 The commands below are npm's, to match the `npx` above. On a `pnpm dlx` or
 `bunx` project, substitute your own manager throughout.
 
-It is also the moment your agent gets its instructions: `AGENTS.md`, five
+It is also the moment your agent gets its instructions: `AGENTS.md`, three
 skills, and `.mcp.json` all arrive here. Before this command there is nothing
 for an agent to read.
 
@@ -257,10 +257,21 @@ npm run refresh     # build, embed, publish a generation
 
 ```
 run 1: building generation 1 (embed gemini:gemini-embedding-001/d1536/RETRIEVAL_DOCUMENT)
+structure: 7 nodes, 6 sources, 23 chunks; carried 0, pending 23
+embedding 23 pending chunks (batch 32) ...
 embedded 23, failed 0
+source: 5bfbaafd809e199e44453ad94837300cf6e4e0ad-dirty
 ingest: generation 1 — 7 nodes, 23 chunks; embedded 23, carried 0, failed 0
+pre-flip delta vs gen 0: 0 -> 7 nodes (+7 / -0)
+  added:   ["knowledge/governance-ladder","knowledge/refund-policy","knowledge/surfaces#section","knowledge/surfaces/for-agents","knowledge/surfaces/for-people","knowledge/surfaces/overview","knowledge/what-is-a-ksor"]
 FLIPPED active generation -> 1
+gc: nothing collectable (active/rollback/grace all hold)
 ```
+
+Seven nodes: your six documents and the `surfaces` folder, which is a node of
+its own. The `source:` sha is your commit, and `-dirty` because `refresh` ran
+`ksor build` first and the lock it rewrote is not committed yet — provenance
+being precise about that, as in Part 1.
 
 Seven seconds, and your record is published as **generation 1** — the number
 every answer will cite.

--- a/docs/tutorials/02-make-it-yours.md
+++ b/docs/tutorials/02-make-it-yours.md
@@ -243,7 +243,7 @@ name on it, not an edit.
 > **Ask your agent:**
 > Show me both on the site.
 
-`pnpm dev`, and open the two pages. They are marked as drafts. This is the
+`npm run dev`, and open the two pages. They are marked as drafts. This is the
 review surface — the actual page, not a message in a terminal — and it is
 where you decide whether the record says what you meant.
 

--- a/packages/content/src/commands.ts
+++ b/packages/content/src/commands.ts
@@ -113,7 +113,8 @@ Usage:
       --check reads the record's OWN logged searches instead and reports how
       the declared floor is holding against them — no provider key, no
       embedding call, no LLM. A monitor, never a gate: it says what to
-      re-measure and always exits 0.
+      re-measure, and a verdict always exits 0 — the environment exits 3, as
+      for every verb.
   ksor grant --instance PATH [--revoke]
       Authorize ingest for the instance's tenant (the row row-level security
       requires), or withdraw it. Idempotent; reports the state it established.

--- a/packages/ksor/README.md
+++ b/packages/ksor/README.md
@@ -12,16 +12,19 @@ when the corpus does not cover the question.
 ```bash
 npx @panaversity/ksor@latest init my-sor
 cd my-sor
-pnpm install
-pnpm dev        # the site, live at http://localhost:3000
+npm install
+npm run dev     # the site, live at http://localhost:3000
 ```
 
 Then write a document and publish it:
 
 ```console
-$ pnpm exec ksor build
+$ npx ksor build
 ksor build: 6 document(s), 5 admitted to a machine surface
 ```
+
+(`npx` emits an npm project; `pnpm dlx` or `bunx` emit that manager's, and
+the README it writes speaks that manager throughout.)
 
 **Six documents, five admitted.** The one you just wrote is a `draft`, so it
 reaches nothing an AI agent reads — not `llms.txt`, not the markdown twins —
@@ -44,7 +47,9 @@ where it came from:
 
 **[Hello world](https://github.com/panaversity/ksor/blob/main/docs/tutorials/01-hello-world.md)**
 walks all of that in about fifteen minutes. Every command and output in it was
-run and pasted as it appeared — including the ones above.
+run and pasted as it appeared. The envelopes above show the SHAPE of an answer
+and a refusal; the refusal needs a calibrated floor, which hello world defers
+to its own tutorial.
 
 The three so far, in reading order — pick by what you want from it:
 
@@ -100,13 +105,9 @@ that document's page and nowhere else:
 | `<doc>.flashcards.yaml` | a recall deck, at the end                               |
 | `<doc>.quiz.yaml`       | a multiple-choice check, at the end                     |
 
-Ask your coding agent — `make slides for knowledge/expenses/approvals.md`, or
-`summarise knowledge/expenses/approvals.md` — and the `make-slides` and
-`make-summary` skills write the attachment from the document, check every claim
-and number back against it, and report what they left out because the document
-did not support it. A summary is checked section by section, because one that
-covers the opening and trails off leaves a reader believing they have the whole
-document.
+Companions are ordinary files beside the document. Write them yourself or ask
+your coding agent for one, and hold it to the rule the emitted AGENTS.md
+states: a companion may only say what its document says.
 
 An attachment is **part of its document**: no URL, no sidebar row, no
 `llms.txt` line, and no id an agent can cite. It takes its audience and any

--- a/packages/ksor/docs/deploying.md
+++ b/packages/ksor/docs/deploying.md
@@ -314,8 +314,8 @@ correct for a genuinely public record or one behind your own gateway; it is not 
 way to make a deploy go green.
 
 The alternative is a real authorization server — `KSOR_SSO_URL`,
-`KSOR_MCP_RESOURCE_URL`, `KSOR_JWT_ALLOWED_AUDIENCES`, with worked recipes for two
-of them in [authorization.md](./authorization.md).
+`KSOR_MCP_RESOURCE_URL`, `KSOR_JWT_ALLOWED_AUDIENCES`, with worked recipes for
+four of them in [authorization.md](./authorization.md).
 
 ### Set this on any container host
 
@@ -573,7 +573,7 @@ auth-off default, and that refusal is the last real step of a deployment. Two
 ways past it:
 
 - **Configure the SSO door** — `KSOR_SSO_URL`, `KSOR_MCP_RESOURCE_URL`,
-  `KSOR_JWT_ALLOWED_AUDIENCES`. Worked recipes for two different authorization
+  `KSOR_JWT_ALLOWED_AUDIENCES`. Worked recipes for four different authorization
   servers: [authorization.md](./authorization.md).
 - **Set `KSOR_AUTH=disabled-public`** — a deliberate decision that
   serves your whole record to anyone who can reach the port. Correct for a

--- a/packages/ksor/docs/index.md
+++ b/packages/ksor/docs/index.md
@@ -57,8 +57,8 @@ instead of their training memory. The corpus grows with each implemented verb.
     which a dependency bump reaches a project already scaffolded. Includes the
     list of files migrate does NOT carry, so you know what to diff by hand.
   - **[authorization.md](./authorization.md)** — putting the record behind an
-    authorization server, with worked recipes for two of them, executed rather
-    than written. `ksor serve` refuses to boot unauthenticated on a public bind,
+    authorization server, with worked recipes for four of them — two self-hosted,
+    one hosted, one an organisation's own — executed rather than written. `ksor serve` refuses to boot unauthenticated on a public bind,
     so this is the last step of a deployment, not an optional hardening pass.
 - Exit codes are a contract: `1` refused (first stderr line is a stable
   slug such as `error: bad-name`, followed by a remedy), `2` designed but

--- a/packages/ksor/docs/ingesting.md
+++ b/packages/ksor/docs/ingesting.md
@@ -50,7 +50,7 @@ root**, where `instance.md` and `package.json` live.
 
 ```sh
 pnpm provision   # ksor schema --apply, then ksor grant
-pnpm refresh     # ksor ingest --flip, then ksor gc
+pnpm refresh     # ksor build, then ksor ingest --flip, then ksor gc
 ```
 
 `provision` is separate because applying DDL and granting ingest are acts an
@@ -289,9 +289,12 @@ decision in this project's own gold rather than a threshold somebody picked.
 Run it on a schedule, or in your own CI beside `ksor build`. Three things to
 know about what it is:
 
-- **It never fails a run.** It always exits 0. A stale floor wants
-  re-measuring, and failing a build for one would make the shortest way out
-  deleting `vector_floor` — turning the gate off entirely to clear the error.
+- **A verdict never fails a run.** STEADY, WATCH and no-data all exit 0: a
+  stale floor wants re-measuring, and failing a build for one would make the
+  shortest way out deleting `vector_floor` — turning the gate off entirely to
+  clear the error. What does exit non-zero is the environment, the same way it
+  does for every verb: 3 when `KSOR_DB_URL` is unset or the database is
+  unreachable, 1 on a bad flag. Put it in CI knowing that.
 - **It reads traffic, so it needs traffic**, and it says so rather than
   reporting a healthy-looking nothing. It also cannot see questions nobody
   asked: it can tell you the floor has gone permissive, never that it is too

--- a/packages/ksor/docs/tool-surface.md
+++ b/packages/ksor/docs/tool-surface.md
@@ -145,9 +145,6 @@ made it answer from.
   hand-written one returning fabricated hits with plausible `stable_id`s would
   pass every shape check there is.
 - **The output schemas.** `SEARCH_OUTPUT`, `OUTLINE_OUTPUT`, `READ_OUTPUT` carry
-  `provenance`, each hit's `governance`, the `snapshot` token and `gate`. A
-  record that reshaped them would still look like a KSoR and no longer be one.
-- **The output schemas.** `SEARCH_OUTPUT`, `OUTLINE_OUTPUT`, `READ_OUTPUT` carry
   `provenance`, each hit's `governance`, the `snapshot` token, `gate`, and
   `audit`. A record that reshaped them would still look like a KSoR and no
   longer be one.

--- a/packages/ksor/docs/upgrading.md
+++ b/packages/ksor/docs/upgrading.md
@@ -76,7 +76,7 @@ These are yours, and no release touches them. Diff them against a fresh
 - `pnpm-workspace.yaml` / `.npmrc` and any lockfile
 
 ```sh
-npx @panaversity/ksor@latest init /tmp/fresh
+(cd /tmp && npx @panaversity/ksor@latest init fresh)   # init takes a NAME, not a path
 diff -ru /tmp/fresh/vercel.json ./vercel.json
 ```
 

--- a/packages/ksor/templates/scaffold/.agents/skills/intake-interview/SKILL.md
+++ b/packages/ksor/templates/scaffold/.agents/skills/intake-interview/SKILL.md
@@ -146,11 +146,12 @@ never an email address.
   MAP from each actor to its natural name — `"human:bashiraziz": Bashir Aziz`.
   Keyed by the actor exactly as the record stores it, quoted because it
   contains a colon. Nothing else — the site looks the actor up at render time,
-  so pages read "Owner · Bashir Aziz" instead of "Owner · human:bashiraziz". Every skill that records a governance
-  act (this one, add-sources when it names a `ksor.owner`, `ksor takedown` for
-  withdrawals) asks the owner for a natural name whenever it is about to write
-  an actor that isn't in `people.yaml` yet — the owner is the only source of a
-  display name, never a convention-based guess.
+  so pages read "Owner · Bashir Aziz" instead of "Owner · human:bashiraziz". This
+  is the skill that writes actors into the policy, so it is the one that asks
+  the owner for a natural name for each — the owner is the only source of a
+  display name, never a convention-based guess. An actor that arrives later
+  (an owner named in a document, an approver added by hand) gets its entry
+  when the owner adds one; the site prints the identifier until then.
 - **Offer to start replacing the starter documents — they are already
   published.** All five ship `status: stable`, approved by
   `ksor-starter/KSOR-STAMP-VERSION`, so the site and `llms.txt` carry them from

--- a/packages/ksor/templates/scaffold/.claude/skills/intake-interview/SKILL.md
+++ b/packages/ksor/templates/scaffold/.claude/skills/intake-interview/SKILL.md
@@ -146,11 +146,12 @@ never an email address.
   MAP from each actor to its natural name — `"human:bashiraziz": Bashir Aziz`.
   Keyed by the actor exactly as the record stores it, quoted because it
   contains a colon. Nothing else — the site looks the actor up at render time,
-  so pages read "Owner · Bashir Aziz" instead of "Owner · human:bashiraziz". Every skill that records a governance
-  act (this one, add-sources when it names a `ksor.owner`, `ksor takedown` for
-  withdrawals) asks the owner for a natural name whenever it is about to write
-  an actor that isn't in `people.yaml` yet — the owner is the only source of a
-  display name, never a convention-based guess.
+  so pages read "Owner · Bashir Aziz" instead of "Owner · human:bashiraziz". This
+  is the skill that writes actors into the policy, so it is the one that asks
+  the owner for a natural name for each — the owner is the only source of a
+  display name, never a convention-based guess. An actor that arrives later
+  (an owner named in a document, an approver added by hand) gets its entry
+  when the owner adds one; the site prints the identifier until then.
 - **Offer to start replacing the starter documents — they are already
   published.** All five ship `status: stable`, approved by
   `ksor-starter/KSOR-STAMP-VERSION`, so the site and `llms.txt` carry them from

--- a/packages/ksor/templates/scaffold/.ksor/people.yaml
+++ b/packages/ksor/templates/scaffold/.ksor/people.yaml
@@ -26,7 +26,7 @@
 # name has to keep rendering on those acts.
 #
 # Optional. An actor with no entry renders exactly as stored, as it did before
-# this file existed. The intake and add-sources skills offer to add one; the
-# owner can also edit this file by hand — it is theirs.
+# this file existed. The intake interview offers to add one; the owner can
+# also edit this file by hand — it is theirs.
 version: "0.1"
 people: {}

--- a/packages/ksor/templates/scaffold/AGENTS.md
+++ b/packages/ksor/templates/scaffold/AGENTS.md
@@ -423,7 +423,7 @@ governance block every hit now carries:
 Three edits pay for themselves:
 
 - **Delete a tool nothing calls.** Removing `outline` and `read` gives back
-  ~2,152 tokens for the whole session.
+  ~2,310 tokens for the whole session.
 - **Say what this record covers**, above `FLOOR.search`. It is how an agent with
   several records attached picks yours; name the subject AND the boundary.
 - **Set `k`** in the input schema — it is the lever on reply size.
@@ -899,8 +899,7 @@ CI — and a first deploy without it serves an empty record. Full walkthrough:
   click is informed.
 
   **You do not state a height.** A page carried in the record is measured, so
-  the frame is exactly as tall as what it holds — on this record's own seven,
-  to the pixel. A number written into a document would be a number some other
+  the frame is exactly as tall as what it holds, to the pixel. A number written into a document would be a number some other
   measure makes wrong.
 
   **Carry the page in where you can.** A file named `<name>.sim.html`, sitting

--- a/packages/ksor/templates/scaffold/README.md
+++ b/packages/ksor/templates/scaffold/README.md
@@ -698,7 +698,7 @@ different coding agent's way of finding the same working contract.
 | `.gemini/settings.json`          | points Gemini CLI at `AGENTS.md`; Gemini does not read that filename on its own.                                                                                                                        |
 | `.github/workflows/validate.yml` | your CI: runs the same checker on every pull request and push to main.                                                                                                                                  |
 | `.gitattributes`                 | markdown is checked out byte-stable on every platform, so the same commit hashes the same everywhere.                                                                                                   |
-| `.gitignore`                     | keeps build output, `node_modules/`, and `.env` out of the record's history — and negates two paths inside `.ksor/`, because the policy and the ledger ARE the record.                                   |
+| `.gitignore`                     | keeps build output, `node_modules/`, and `.env` out of the record's history — and negates three paths inside `.ksor/`, because the policy, the ledger and the phone book ARE the record.                  |
 
 `format-checker` deliberately contains a program, `check.mjs`, and not only
 prose: rules that are only written down cannot refuse anything.

--- a/packages/ksor/templates/scaffold/instance.md
+++ b/packages/ksor/templates/scaffold/instance.md
@@ -41,9 +41,8 @@ record wins.
 
 Everything above describes KSoR itself. It ships filled in so that a fresh
 project has a real governed corpus on the first `pnpm dev` — five approved
-documents, three of them inside a folder, and one carrying all four study
-attachments (a summary, slides, flashcards and a quiz) — instead of an empty
-shelf and a placeholder.
+documents, three of them inside a folder, and one carrying a summary
+companion — instead of an empty shelf and a placeholder.
 The documents live in `knowledge/`; delete them as your own knowledge arrives.
 
 Be deliberate about replacing it, because a starter that describes the wrong


### PR DESCRIPTION
## What

A sweep of every document against the tree and the published 0.0.57 — five independent finders, two refuters per finding — confirmed 26 stale sentences (20 candidates were refuted and left alone). All 26 are fixed here. Every one is a document catching up to code; no behaviour changes except one line of CLI help text.

## The two that would have stopped a reader — both ship on npm

- **`packages/ksor/README.md` told `npx` users to run `pnpm install`.** `npx … init` emits an npm project (decision 25): no `pnpm-workspace.yaml`, `workspaces` in the manifest, which pnpm ignores — so `pnpm install` installs nothing under `system/site` and `pnpm dev` fails with `sh: next: command not found`. Reproduced live. The hello-world tutorial fixed this exact bug in #236; the README never got it. Now npm throughout, with one line saying which manager `npx`/`pnpm dlx`/`bunx` each emit.
- **It still advertised `make-slides` and `make-summary`**, removed in #242. Replaced with the one rule that survives them.
- It also claimed its abstention envelope was "pasted as it appeared" from the tutorial. The tutorial never reaches an abstention (`abstain OFF`, calibration deferred). It now says what that block is.

## The rest, by surface

**Shipped docs.** `calibrate --check` was documented as "always exits 0 / never fails a run" in `ingesting.md` and in the CLI's own `--help` — a *verdict* always does; an unreachable database or unset `KSOR_DB_URL` exits 3 as for every verb, which matters exactly where the docs recommend putting it: CI. `tool-surface.md` carried two copies of one bullet, the stale one missing `audit`. `upgrading.md` gave `ksor init` a path; it takes a name and refuses a path. `index.md` and `deploying.md` (twice) said "two" authorization recipes; `authorization.md` has four. `ingesting.md`'s `refresh` comment omitted the `ksor build` step the script runs first.

**The emitted scaffold.** `instance.md` described "all four study attachments" on a starter trimmed to one companion in 0.0.44. `intake-interview` (both trees) and `people.yaml` said add-sources writes display names — it never has. The README counted two negated `.ksor/` paths where there are three (people.yaml joined in 0.0.53, and is in `build_id` since #237). Two token figures in AGENTS.md predated their own re-measurement (2,152 → 2,310). A sentence about "this record's own seven" carried pages described a record the scaffold is not.

**Authority docs.** Root AGENTS.md said "Three tiers" above a list of four. `docs/status.md` described the seed quiz and deck as shipping (trimmed in 0.0.44), the kernel as "in progress on the kernel-conversion branch" (released in 0.0.8–0.0.18, no such branch on the remote), and carried yesterday's date.

**Tutorials.** Hello world said "five skills" arrive at init (three do). Its ingest block was four lines where 0.0.57 prints ten — **re-captured live** against a real Postgres and a real embed, and the two lines a reader would wonder about (`structure:`, `source: …-dirty`) now have a sentence each. *Make it yours* said `pnpm dev` in the npm project it continues. The introduction's "where to go next" listed a tutorial that shipped as `02` and numbered the MCP one `3` where the index says `4`; it now links the two that exist and numbers the rest as the index does.

## Verified

Every fix's anchor was matched exactly or the script refused. `check:corpus`, guard, typecheck, fmt green; the three doc guards (docs-truth incl. the tutorial-link and build-id rules, skill-consistency, skill-triggers) 90/90; unit and integration tiers green on the full tree.