### PR TITLE
The agent tier authenticates through claude's own login, never an API key

### DIFF
--- a/.changeset/plan-agent-tier-claude-login.md
+++ b/.changeset/plan-agent-tier-claude-login.md
@@ -1,0 +1,16 @@
+---
+"@panaversity/ksor": patch
+---
+
+The agent tier authenticates through `claude`'s own login, never an API key.
+
+Where the repository needs model inference — today, the skill evals — it uses
+`claude -p`: a developer's logged-in CLI locally, and in CI a long-lived token
+from `claude setup-token` in `CLAUDE_CODE_OAUTH_TOKEN`. The tier no longer reads
+`ANTHROPIC_API_KEY` and no longer passes `--bare`, because bare mode does not
+read the OAuth token (per the official headless docs) and would have quietly
+fallen back to needing the key it is not supposed to have. A guard holds both.
+
+The pending owner action changes with it: a `CLAUDE_CODE_OAUTH_TOKEN` repository
+secret, not an API key. Test infrastructure only; nothing an adopter installs
+behaves differently.

--- a/.github/workflows/skill-evals.yml
+++ b/.github/workflows/skill-evals.yml
@@ -3,8 +3,11 @@ name: Skill evals
 # The agent tier (AGENTS.md → Testing): a shipped skill run by a real coding
 # agent, with the skill and without it. It spends model tokens, so it runs on
 # push to main and by hand — never per pull request — and only when the paths
-# it measures changed. Without ANTHROPIC_API_KEY it still runs and prints that
-# every suite was skipped, so an unarmed tier is visible rather than absent.
+# it measures changed. It authenticates through claude's own login — a
+# long-lived token from `claude setup-token` in CLAUDE_CODE_OAUTH_TOKEN — never
+# an API key (owner decision, 2026-09-02). Without the token it still runs and
+# prints that every suite was skipped, so an unarmed tier is visible rather
+# than absent.
 on:
   push:
     branches: [main]
@@ -42,4 +45,4 @@ jobs:
       - run: pnpm test:agent
         env:
           CI: "true"
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1461,7 +1461,10 @@ gateway` package, serve-by-spawn) is superseded._
 
     **What it costs.** A one-word reply on the default model measured $0.25,
     so the tier pins a mid-tier model and runs on push to main, not per PR.
-    An `ANTHROPIC_API_KEY` repository secret is an owner action; until it
+    It authenticates through `claude`'s own login, never an API key (owner,
+    2026-09-02): a logged-in CLI locally, and in CI a `claude setup-token`
+    token in `CLAUDE_CODE_OAUTH_TOKEN` — which bare mode does not read, so the
+    tier never passes `--bare`. That secret is an owner action; until it
     exists the tier runs and prints that it skipped. Companion generation no
     longer has a skill to fire; an owner asks their agent in plain words and
     AGENTS.md carries the rule.
@@ -1657,7 +1660,7 @@ assertion.
 - `*.agent.test.ts` — a shipped skill run by a REAL coding agent (`claude -p`)
   in a fresh scaffold, with the skill and without it, graded on what it leaves
   behind (`pnpm test:agent`; `skill-evals.yml` runs it on push to main and by
-  hand, never per PR — it spends model tokens). Gated on `ANTHROPIC_API_KEY`
+  hand, never per PR — it spends model tokens). Gated on `CLAUDE_CODE_OAUTH_TOKEN`
   in CI or a logged-in `claude` locally, and it announces its own skip. The
   three-class split below applies: the deterministic graders GATE (files
   touched, the record builds, values verified), cost and the baseline arm are

--- a/docs/status.md
+++ b/docs/status.md
@@ -17,7 +17,9 @@ after 0.0.55 (they remain in the history below as what 0.0.38 added).
 `add-sources` 2.0.0 takes a file or a person as its source and ships
 `verify.mjs`. A fourth test tier, `pnpm test:agent`, runs a skill by a real
 coding agent with and without it (decision 31); **it needs an
-`ANTHROPIC_API_KEY` repository secret, which is a pending owner action** —
+`CLAUDE_CODE_OAUTH_TOKEN` repository secret (from `claude setup-token`; the
+tier uses `claude -p`'s own login, never an API key), which is a pending owner
+action** —
 until then `skill-evals.yml` runs and reports itself skipped. **`ksor dev` is the only verb still unimplemented**: it
 reports "designed but not implemented" and exits `2`. An unknown verb is
 refused with exit `1` and a stable `error: unknown-verb` stderr slug. The

--- a/packages/ksor/src/docs-truth.integration.test.ts
+++ b/packages/ksor/src/docs-truth.integration.test.ts
@@ -831,3 +831,33 @@ describe("every link into docs/tutorials resolves", () => {
     expect(targets.size, `${file} links into docs/tutorials at all`).toBeGreaterThan(0);
   });
 });
+
+/**
+ * The agent tier authenticates through `claude`'s own login, never an API key
+ * (owner decision, 2026-09-02). Two things would silently undo that: reading
+ * ANTHROPIC_API_KEY, or passing `--bare` — which the official docs say does
+ * not read CLAUDE_CODE_OAUTH_TOKEN, so a CI run would fall back to needing the
+ * key it is not supposed to have. Held on the source, since the predicate is
+ * module-level and the unarmed run only proves the skip.
+ */
+describe("the agent tier uses claude's own login, not an API key", () => {
+  const src = read("packages/ksor/src/evals/skill-add-sources.agent.test.ts")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^[ \t]*\/\/.*$/gm, "");
+  it("never reads ANTHROPIC_API_KEY", () => {
+    expect(src.includes("ANTHROPIC_API_KEY")).toBe(false);
+  });
+  it("never passes --bare (bare mode does not read the OAuth token)", () => {
+    expect(/"--bare"/.test(src)).toBe(false);
+  });
+  it("arms on CLAUDE_CODE_OAUTH_TOKEN in CI", () => {
+    expect(src.includes('process.env["CLAUDE_CODE_OAUTH_TOKEN"]')).toBe(true);
+  });
+  it("the CI workflow passes the token and not a key", () => {
+    const wf = read(".github/workflows/skill-evals.yml");
+    expect(wf.includes("CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}")).toBe(
+      true,
+    );
+    expect(wf.includes("ANTHROPIC_API_KEY")).toBe(false);
+  });
+});

--- a/packages/ksor/src/evals/skill-add-sources.agent.test.ts
+++ b/packages/ksor/src/evals/skill-add-sources.agent.test.ts
@@ -34,10 +34,14 @@
  * WHAT IT COSTS, and why it is gated. One arm on the default model ran to
  * $0.25 for a one-word reply (2026-09-02, claude-fable-5-1, `--bare`), so the
  * tier pins a mid-tier model unless `KSOR_EVAL_MODEL` says otherwise, and runs
- * on push to main and by hand, never per PR. It arms on `ANTHROPIC_API_KEY`
- * (CI: `--bare`, no OAuth) or, on a developer's machine, on a logged-in
- * `claude`; without either it prints that it was skipped, the way the
- * database and live-provider tiers do. Honest absence, never silent weakness.
+ * on push to main and by hand, never per PR. It authenticates the way the
+ * owner asked (2026-09-02): through `claude`'s OWN login, never an API key —
+ * a developer's logged-in CLI locally, and in CI a long-lived token from
+ * `claude setup-token` in `CLAUDE_CODE_OAUTH_TOKEN`. It never passes `--bare`,
+ * because bare mode does not read that token (code.claude.com/docs/en/headless:
+ * "Bare mode does not read CLAUDE_CODE_OAUTH_TOKEN"). Without a login it prints
+ * that it was skipped, the way the database and live-provider tiers do. Honest
+ * absence, never silent weakness.
  *
  * WHAT THREE ARMED RUNS SHOWED (2026-09-02, `SKILL_BASELINE`): on a clean
  * two-page PDF, both arms pass every deterministic gate. The skill's value was
@@ -97,10 +101,10 @@ const VERIFY = path.resolve(
   "verify.mjs",
 );
 
-const apiKey = process.env["ANTHROPIC_API_KEY"] ?? "";
+const oauthToken = process.env["CLAUDE_CODE_OAUTH_TOKEN"] ?? "";
 const claudeOnPath = spawnSync("claude", ["--version"], { encoding: "utf8" }).status === 0;
-/** CI arms only on the key; a developer's logged-in CLI is enough locally. */
-const armed = apiKey !== "" || (claudeOnPath && process.env["CI"] === undefined);
+/** CI arms only on a setup-token; a developer's logged-in CLI is enough locally. */
+const armed = claudeOnPath && (oauthToken !== "" || process.env["CI"] === undefined);
 const MODEL = process.env["KSOR_EVAL_MODEL"] ?? "claude-sonnet-5";
 const BUDGET_USD = process.env["KSOR_EVAL_BUDGET_USD"] ?? "4";
 
@@ -212,7 +216,6 @@ function agent(root: string): AgentResult {
     "Grep",
     "Skill",
   ];
-  if (apiKey !== "") args.push("--bare");
   // `CLAUDECODE` is set inside a Claude Code session and refuses nesting;
   // this is a subprocess with its own scaffold, which is the safe case.
   const env: NodeJS.ProcessEnv = { ...process.env };
@@ -404,7 +407,7 @@ describe.runIf(armed)(
 );
 
 describe.runIf(!armed)("add-sources, run by an agent (gated)", () => {
-  it("skipped — set ANTHROPIC_API_KEY (CI) or log in to `claude` (locally) to run the skill eval", () => {
+  it("skipped — run `claude setup-token` and set CLAUDE_CODE_OAUTH_TOKEN (CI), or log in to `claude` (locally), to run the skill eval", () => {
     expect(armed).toBe(false);
   });
 });


### PR DESCRIPTION
## What

Owner direction (2026-09-02): where the repository needs model inference, use `claude -p`, not an Anthropic API key.

The agent tier (#246) armed on `ANTHROPIC_API_KEY` and passed `--bare` when it had one. Both go. It now authenticates through `claude`'s own login: a developer's logged-in CLI locally, and in CI a long-lived token from `claude setup-token` in `CLAUDE_CODE_OAUTH_TOKEN`.

`--bare` is removed on the docs' word, not a hunch — [headless mode](https://code.claude.com/docs/en/headless): *"Bare mode does not read `CLAUDE_CODE_OAUTH_TOKEN`. If your script passes `--bare`, authenticate with `ANTHROPIC_API_KEY` or an `apiKeyHelper` instead."* Keeping it would have made the CI run silently fall back to needing the key it is not supposed to have.

## Changes

- `skill-add-sources.agent.test.ts`: arms on `claudeOnPath && (CLAUDE_CODE_OAUTH_TOKEN || not CI)`; no `--bare`; the skip message names the new instruction.
- `skill-evals.yml`: passes `CLAUDE_CODE_OAUTH_TOKEN`, never an API key.
- AGENTS.md decision 31 and the Testing tier line; `docs/status.md`'s pending owner action.
- A guard in `docs-truth`: the tier's source never reads `ANTHROPIC_API_KEY` and never passes `--bare`; the workflow passes the token. **Mutation-tested** — re-adding `args.push("--bare")` turns exactly that one case red.

```
↓ … the WITH arm passes every behavioural gate; both arms are reported
✓ … skipped — run `claude setup-token` and set CLAUDE_CODE_OAUTH_TOKEN (CI), or log in to `claude` (locally), to run the skill eval
```

## Pending owner action, restated

`claude setup-token` (requires a Pro/Max/Team/Enterprise subscription) → the token as a `CLAUDE_CODE_OAUTH_TOKEN` repository secret. Until then the tier runs green and skipped. The docs do not state whether a setup-token draws on the subscription's usage limits or is billed as API usage; that is worth knowing before arming it on push to main.

## Note

`plan/harness-fixture-2` (in flight) also edits the harness file; whichever lands second rebases. Unit and integration tiers green.