### PR TITLE
Keep the phones-home guard on the README, where the claim lives

### DIFF
--- a/packages/ksor/src/docs-truth.integration.test.ts
+++ b/packages/ksor/src/docs-truth.integration.test.ts
@@ -858,18 +858,24 @@ describe("every link into docs/tutorials resolves", () => {
  * ties the sentence to the bytes.
  */
 describe("the scaffold makes 'nothing phones home' true", () => {
-  it.each(["README.md", "docs/tutorials/00-introduction-to-ksor.md"])(
-    "%s makes the claim",
-    (file) => {
-      // Pinned so the assertion below cannot go vacuous: a document that stops
-      // making the claim fails here and asks whether the switch still matters.
-      expect(
-        flat(read(file)),
-        `${file} no longer says nothing phones home — if that was dropped on purpose, ` +
-          "retire this block with it rather than leaving a guard for a claim nobody makes",
-      ).toMatch(/nothing phones home/);
-    },
-  );
+  // README.md is the product pitch and its only home, so it is where the claim
+  // lives and what this block exists to keep true. It is pinned so the
+  // assertions below cannot go vacuous: a README that stops making the claim
+  // fails here and asks whether the switch still matters.
+  //
+  // The introduction tutorial was pinned here too until 2026-09-03, when its
+  // §10 mini-walkthrough — which carried the sentence — was replaced by a
+  // pointer to hello world. That is the guard working as its own message says:
+  // the document stopped making the claim, so the question was asked, and the
+  // answer is that the claim belongs to the README, not to a tutorial that no
+  // longer walks a build.
+  it("README.md makes the claim", () => {
+    expect(
+      flat(read("README.md")),
+      "README.md no longer says nothing phones home — if that was dropped on purpose, " +
+        "retire this block with it rather than leaving a guard for a claim nobody makes",
+    ).toMatch(/nothing phones home/);
+  });
 
   it("the wrapper hands next an environment with telemetry off", () => {
     expect(


### PR DESCRIPTION
## Problem

`main` is red. #252 added a guard pinning **two** documents as making the "nothing phones home" claim — `README.md` and the introduction tutorial. #258 then replaced the introduction's §10 mini-walkthrough with a pointer to hello world, and the sentence went with it. Both changes were right; together they broke the build.

```
× docs/tutorials/00-introduction-to-ksor.md makes the claim
  Tests  1 failed | 68 passed (69)
```

## Solution

The guard's own failure message says what to do: *"if that was dropped on purpose, retire this block with it rather than leaving a guard for a claim nobody makes."* The question it asked is now answered — the claim belongs to `README.md`, the product pitch and its only home, not to a tutorial that no longer walks a build. The introduction is unpinned; the README stays pinned, with the reasoning recorded at the pin.

Nothing about the telemetry switch changes: the wrapper, the script assertions and the emitted-tree half are untouched.

## Behaviour

Mutation-tested — and the first attempt was itself instructive: the phrase is line-wrapped in `README.md` (`…and nothing` / `phones home.`), so replacing the whole sentence changed nothing and the guard "passed". Mutating the real wrapped text:

```
× README.md makes the claim
  Tests  1 failed | 67 passed (68)
```

restored → 68 pass. typecheck 0, guard ok, corpus ok, format clean.