### PR TITLE
Re-date the stable body the bundle fixture edits, as R23 requires

### DIFF
--- a/packages/ksor/src/build.integration.test.ts
+++ b/packages/ksor/src/build.integration.test.ts
@@ -1005,9 +1005,19 @@ describe("ksor build — acceptance 6: --bundles, one OKF bundle per viewer", ()
   function bundleRepo(): string {
     const root = repo();
     const boardPay = path.join(root, "knowledge/policies/board-pay.md");
+    // The body of a STABLE concept is being edited after it was committed
+    // stable, so R23 (`ksor-generated-stale`, #256) requires the edit to
+    // advance `generated.at` — and `ksor.approval.at` may not precede it. This
+    // fixture is the rule's own subject, not an exception to it: the two
+    // instants move exactly as an author's would.
     writeFileSync(
       boardPay,
-      `${readFileSync(boardPay, "utf8")}\n![The board diagram](board-diagram.png)\n`,
+      `${readFileSync(boardPay, "utf8")
+        .replace("at: 2026-08-20T09:00:00Z", "at: 2026-08-23T09:00:00Z")
+        .replace(
+          "at: 2026-08-21T09:00:00Z",
+          "at: 2026-08-23T10:00:00Z",
+        )}\n![The board diagram](board-diagram.png)\n`,
     );
     writeFileSync(
       path.join(root, "knowledge/policies/board-pay.summary.md"),


### PR DESCRIPTION
## Problem

`main` was red on five `--bundles` tests. #255 (`ksor build --bundles`) and #256 (KSP R23) were each green on their own branch and broke each other once both landed — neither reviewer could have seen it, because they reviewed against different bases.

```
× the public bundle holds no byte of the internal concept …
× a denied concept is in no bundle, and a revoked denial restores it
× reads back as a conformant OKF bundle with no ksor in the loop
…
AssertionError: error: ksor-generated-stale: expected 1 to be +0
```

`bundleRepo()` builds its record with `repo()` (which commits), then appends an image reference to `knowledge/policies/board-pay.md` — a `status: stable` concept — and commits again. R23 refuses exactly that: a stable body edited without advancing `generated.at`.

## Solution

The fixture obeys the rule rather than being exempted from it. When it edits that body it now advances `generated.at` (2026-08-20 → 2026-08-23T09:00) and moves `ksor.approval.at` after it (→ 2026-08-23T10:00), which is what an author making the same edit would have to do. The reasoning sits at the edit.

This is R23's second real catch in this repo's own fixtures — the first was the browser walkthrough, fixed in #256 itself.

## Behaviour

```
build.integration.test.ts    43 passed
unit                       1702 passed
integration                 746 passed | 34 skipped
```

typecheck 0, guard ok, corpus ok, format clean.